### PR TITLE
Prepare unit tests for more commits

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/AadIssuerValidatorTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AadIssuerValidatorTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Identity.Web.Test
             // Act and Assert
             Assert.Throws<ArgumentNullException>(() => validator.Validate(null, jwtSecurityToken, validationParams));
             Assert.Throws<ArgumentNullException>(() => validator.Validate(string.Empty, jwtSecurityToken, validationParams));
-            Assert.Throws<ArgumentNullException>(() => validator.Validate(TestConstants.Iss, null, validationParams));
-            Assert.Throws<ArgumentNullException>(() => validator.Validate(TestConstants.Iss, jwtSecurityToken, null));
+            Assert.Throws<ArgumentNullException>(() => validator.Validate(TestConstants.ClaimNameIss, null, validationParams));
+            Assert.Throws<ArgumentNullException>(() => validator.Validate(TestConstants.ClaimNameIss, jwtSecurityToken, null));
         }
 
         [Fact]
@@ -32,8 +32,8 @@ namespace Microsoft.Identity.Web.Test
         {
             // Arrange
             AadIssuerValidator validator = new AadIssuerValidator(TestConstants.s_aliases);
-            Claim issClaim = new Claim(TestConstants.Tid, TestConstants.TenantIdAsGuid);
-            Claim tidClaim = new Claim(TestConstants.Iss, TestConstants.AadIssuer);
+            Claim issClaim = new Claim(TestConstants.ClaimNameTid, TestConstants.TenantIdAsGuid);
+            Claim tidClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.AadIssuer);
             JwtSecurityToken jwtSecurityToken = new JwtSecurityToken(issuer: TestConstants.AadIssuer, claims: new[] { issClaim, tidClaim });
 
             // Act & Assert
@@ -47,8 +47,8 @@ namespace Microsoft.Identity.Web.Test
         {
             // Arrange
             AadIssuerValidator validator = new AadIssuerValidator(TestConstants.s_aliases);
-            Claim issClaim = new Claim(TestConstants.Tid, TestConstants.TenantIdAsGuid);
-            Claim tidClaim = new Claim(TestConstants.Iss, TestConstants.AadIssuer);
+            Claim issClaim = new Claim(TestConstants.ClaimNameTid, TestConstants.TenantIdAsGuid);
+            Claim tidClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.AadIssuer);
             JwtSecurityToken jwtSecurityToken = new JwtSecurityToken(issuer: TestConstants.AadIssuer, claims: new[] { issClaim, tidClaim });
 
             // Act & Assert
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Web.Test
         {
             // Arrange
             AadIssuerValidator validator = new AadIssuerValidator(TestConstants.s_aliases);
-            Claim issClaim = new Claim(TestConstants.Iss, TestConstants.AadIssuer);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.AadIssuer);
 
             JwtSecurityToken noTidJwt = new JwtSecurityToken(issuer: TestConstants.AadIssuer, claims: new[] { issClaim });
 
@@ -75,8 +75,8 @@ namespace Microsoft.Identity.Web.Test
         {
             // Arrange
             AadIssuerValidator validator = new AadIssuerValidator(TestConstants.s_aliases);
-            Claim issClaim = new Claim(TestConstants.Iss, TestConstants.AadIssuer);
-            Claim tidClaim = new Claim(TestConstants.Tid, TestConstants.B2CTenantAsGuid);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.AadIssuer);
+            Claim tidClaim = new Claim(TestConstants.ClaimNameTid, TestConstants.B2CTenantAsGuid);
 
             JwtSecurityToken noTidJwt = new JwtSecurityToken(issuer: TestConstants.AadIssuer, claims: new[] { issClaim, tidClaim });
 
@@ -93,8 +93,8 @@ namespace Microsoft.Identity.Web.Test
         {
             // Arrange
             AadIssuerValidator validator = new AadIssuerValidator(TestConstants.s_aliases);
-            Claim issClaim = new Claim(TestConstants.Iss, TestConstants.AadIssuer);
-            Claim tidClaim = new Claim(TestConstants.Tid, TestConstants.TenantIdAsGuid);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.AadIssuer);
+            Claim tidClaim = new Claim(TestConstants.ClaimNameTid, TestConstants.TenantIdAsGuid);
 
             JwtSecurityToken noTidJwt = new JwtSecurityToken(issuer: TestConstants.AadIssuer, claims: new[] { issClaim, tidClaim });
 
@@ -119,8 +119,8 @@ namespace Microsoft.Identity.Web.Test
             // Arrange
             string iss = $"https://badissuer/{TestConstants.TenantIdAsGuid}/v2.0";
             AadIssuerValidator validator = new AadIssuerValidator(TestConstants.s_aliases);
-            Claim issClaim = new Claim(TestConstants.Iss, TestConstants.AadIssuer);
-            Claim tidClaim = new Claim(TestConstants.Tid, TestConstants.TenantIdAsGuid);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.AadIssuer);
+            Claim tidClaim = new Claim(TestConstants.ClaimNameTid, TestConstants.TenantIdAsGuid);
 
             JwtSecurityToken noTidJwt = new JwtSecurityToken(issuer: TestConstants.AadIssuer, claims: new[] { issClaim, tidClaim });
 
@@ -136,8 +136,8 @@ namespace Microsoft.Identity.Web.Test
         public void Validate_FromB2CAuthority_WithNoTidClaim_ValidateSuccessfully()
         {
             //Arrange
-            Claim issClaim = new Claim(TestConstants.Iss, TestConstants.B2CIssuer);
-            Claim tfpClaim = new Claim(TestConstants.Tfp, TestConstants.B2CSuSiUserFlow);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.B2CIssuer);
+            Claim tfpClaim = new Claim(TestConstants.ClaimNameTfp, TestConstants.B2CSuSiUserFlow);
             JwtSecurityToken jwtSecurityToken = new JwtSecurityToken(issuer: TestConstants.B2CIssuer, claims: new[] { issClaim, tfpClaim });
 
             //Act
@@ -157,9 +157,9 @@ namespace Microsoft.Identity.Web.Test
         public void Validate_FromB2CAuthority_WithTidClaim_ValidateSuccessfully()
         {
             //Arrange
-            Claim issClaim = new Claim(TestConstants.Iss, TestConstants.B2CIssuer);
-            Claim tfpClaim = new Claim(TestConstants.Tfp, TestConstants.B2CSuSiUserFlow);
-            Claim tidClaim = new Claim(TestConstants.Tid, TestConstants.B2CTenantAsGuid);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.B2CIssuer);
+            Claim tfpClaim = new Claim(TestConstants.ClaimNameTfp, TestConstants.B2CSuSiUserFlow);
+            Claim tidClaim = new Claim(TestConstants.ClaimNameTid, TestConstants.B2CTenantAsGuid);
             JwtSecurityToken jwtSecurityToken = new JwtSecurityToken(issuer: TestConstants.B2CIssuer, claims: new[] { issClaim, tfpClaim, tidClaim });
 
             //Act
@@ -179,8 +179,8 @@ namespace Microsoft.Identity.Web.Test
         public void Validate_FromB2CAuthority_InvalidIssuer_Fails()
         {
             //Arrange
-            Claim issClaim = new Claim(TestConstants.Iss, TestConstants.B2CIssuer2);
-            Claim tfpClaim = new Claim(TestConstants.Tfp, TestConstants.B2CSuSiUserFlow);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.B2CIssuer2);
+            Claim tfpClaim = new Claim(TestConstants.ClaimNameTfp, TestConstants.B2CSuSiUserFlow);
             JwtSecurityToken jwtSecurityToken = new JwtSecurityToken(issuer: TestConstants.B2CIssuer2, claims: new[] { issClaim, tfpClaim });
 
             //Act
@@ -203,8 +203,8 @@ namespace Microsoft.Identity.Web.Test
         {
             //Arrange
             string issuerWithInvalidTid = TestConstants.B2CInstance + "/" + TestConstants.TenantIdAsGuid + "/v2.0";
-            Claim issClaim = new Claim(TestConstants.Iss, issuerWithInvalidTid);
-            Claim tfpClaim = new Claim(TestConstants.Tfp, TestConstants.B2CSuSiUserFlow);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, issuerWithInvalidTid);
+            Claim tfpClaim = new Claim(TestConstants.ClaimNameTfp, TestConstants.B2CSuSiUserFlow);
             JwtSecurityToken jwtSecurityToken = new JwtSecurityToken(issuer: issuerWithInvalidTid, claims: new[] { issClaim, tfpClaim });
 
             //Act
@@ -226,8 +226,8 @@ namespace Microsoft.Identity.Web.Test
         public void Validate_FromCustomB2CAuthority_ValidateSuccessfully()
         {
             //Arrange
-            Claim issClaim = new Claim(TestConstants.Iss, TestConstants.B2CCustomDomainIssuer);
-            Claim tfpClaim = new Claim(TestConstants.Tfp, TestConstants.B2CSuSiUserFlow);
+            Claim issClaim = new Claim(TestConstants.ClaimNameIss, TestConstants.B2CCustomDomainIssuer);
+            Claim tfpClaim = new Claim(TestConstants.ClaimNameTfp, TestConstants.B2CSuSiUserFlow);
             JwtSecurityToken jwtSecurityToken = new JwtSecurityToken(issuer: TestConstants.B2CCustomDomainIssuer, claims: new[] { issClaim, tfpClaim });
 
             //Act

--- a/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Xunit;
 
 namespace Microsoft.Identity.Web.Test
@@ -12,10 +12,9 @@ namespace Microsoft.Identity.Web.Test
         {
             //Arrange
             string authority = string.Empty;
-            bool? result = null;
 
             //Act
-            result = AuthorityHelpers.IsV2Authority(authority);
+            bool? result = AuthorityHelpers.IsV2Authority(authority);
 
             //Assert
             Assert.False(result);
@@ -26,10 +25,9 @@ namespace Microsoft.Identity.Web.Test
         {
             //Arrange
             string authority = null;
-            bool? result = null;
 
             //Act
-            result = AuthorityHelpers.IsV2Authority(authority);
+            bool? result = AuthorityHelpers.IsV2Authority(authority);
 
             //Assert
             Assert.False(result);
@@ -39,11 +37,10 @@ namespace Microsoft.Identity.Web.Test
         public void IsV2Authority_EndsWithV2_ReturnsTrue()
         {
             //Arrange
-            string authority = "https://login.microsoftonline.com/tenantId/v2.0";
-            bool? result = null;
+            string authority = TestConstants.AuthorityWithTenantSpecifiedWithV2;
 
             //Act
-            result = AuthorityHelpers.IsV2Authority(authority);
+            bool? result = AuthorityHelpers.IsV2Authority(authority);
 
             //Assert
             Assert.True(result);
@@ -53,11 +50,10 @@ namespace Microsoft.Identity.Web.Test
         public void IsV2Authority_DoesntEndWithV2_ReturnsFalse()
         {
             //Arrange
-            string authority = "https://login.microsoftonline.com/tenantId";
-            bool? result = null;
+            string authority = TestConstants.AuthorityWithTenantSpecified;
 
             //Act
-            result = AuthorityHelpers.IsV2Authority(authority);
+            bool? result = AuthorityHelpers.IsV2Authority(authority);
 
             //Assert
             Assert.False(result);
@@ -68,27 +64,26 @@ namespace Microsoft.Identity.Web.Test
         {
             //Arrange
             MicrosoftIdentityOptions options = null;
-            string result = null;
 
             //Act
-            result = AuthorityHelpers.BuildAuthority(options);
+            string result = AuthorityHelpers.BuildAuthority(options);
 
             //Assert
             Assert.Null(result);
-
         }
 
         [Fact]
         public void BuildAuthority_EmptyInstance_ReturnsNull()
         {
             //Arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions();
-            options.Domain = "contoso.onmicrosoft.com";
-            options.Instance = "";
-            string result = null;
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                Domain = TestConstants.Domain,
+                Instance = string.Empty
+            };
 
             //Act
-            result = AuthorityHelpers.BuildAuthority(options);
+            string result = AuthorityHelpers.BuildAuthority(options);
 
             //Assert
             Assert.Null(result);
@@ -98,14 +93,15 @@ namespace Microsoft.Identity.Web.Test
         public void BuildAuthority_B2CEmptyDomain_ReturnsNull()
         {
             //Arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions();
-            options.Domain = "";
-            options.Instance = "https://login.microsoftonline.com/";
-            options.SignUpSignInPolicyId = "b2c_1_susi";
-            string result = null;
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                Domain = string.Empty,
+                Instance = TestConstants.B2CInstance,
+                SignUpSignInPolicyId = TestConstants.B2CSuSiUserFlow
+            };
 
             //Act
-            result = AuthorityHelpers.BuildAuthority(options);
+            string result = AuthorityHelpers.BuildAuthority(options);
 
             //Assert
             Assert.Null(result);
@@ -115,13 +111,14 @@ namespace Microsoft.Identity.Web.Test
         public void BuildAuthority_AADEmptyTenantId_ReturnsNull()
         {
             //Arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions();
-            options.TenantId = "";
-            options.Instance = "https://login.microsoftonline.com/";
-            string result = null;
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                TenantId = string.Empty,
+                Instance = TestConstants.AadInstance
+            };
 
             //Act
-            result = AuthorityHelpers.BuildAuthority(options);
+            string result = AuthorityHelpers.BuildAuthority(options);
 
             //Assert
             Assert.Null(result);
@@ -131,14 +128,15 @@ namespace Microsoft.Identity.Web.Test
         public void BuildAuthority_AadInstanceAndTenantId_BuildAadAuthority()
         {
             //Arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions();
-            options.TenantId = "da41245a5-11b3-996c-00a8-4d99re19f292";
-            options.Instance = "https://login.microsoftonline.com";
-            string result = null;
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                TenantId = TestConstants.TenantIdAsGuid,
+                Instance = TestConstants.AadInstance
+            };
             string expectedResult = $"{options.Instance}/{options.TenantId}/v2.0";
 
             //Act
-            result = AuthorityHelpers.BuildAuthority(options);
+            string result = AuthorityHelpers.BuildAuthority(options);
 
             //Assert
             Assert.NotNull(result);
@@ -146,17 +144,18 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
-        public void BuildAuthority_OptionsInstaceWithTrailing_BuildAadAuthorityWithoutExtraTrailing()
+        public void BuildAuthority_OptionsInstanceWithTrailing_BuildAadAuthorityWithoutExtraTrailing()
         {
             //Arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions();
-            options.TenantId = "da41245a5-11b3-996c-00a8-4d99re19f292";
-            options.Instance = "https://login.microsoftonline.com/";
-            string result = null;
-            string expectedResult = $"https://login.microsoftonline.com/{options.TenantId}/v2.0";
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                TenantId = TestConstants.TenantIdAsGuid,
+                Instance = TestConstants.AadInstance + "/"
+            };
+            string expectedResult = $"{TestConstants.AadInstance}/{options.TenantId}/v2.0";
 
             //Act
-            result = AuthorityHelpers.BuildAuthority(options);
+            string result = AuthorityHelpers.BuildAuthority(options);
 
             //Assert
             Assert.NotNull(result);
@@ -167,16 +166,16 @@ namespace Microsoft.Identity.Web.Test
         public void BuildAuthority_B2CInstanceDomainAndPolicy_BuildB2CAuthority()
         {
             //Arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions();
-            options.Domain = "fabrikamb2c.onmicrosoft.com";
-            options.Instance = "https://fabrikamb2c.b2clogin.com";
-            options.SignUpSignInPolicyId = "b2c_1_susi";
-
-            string result = null;
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                Domain = TestConstants.B2CTenant,
+                Instance = TestConstants.B2CInstance,
+                SignUpSignInPolicyId = TestConstants.B2CSuSiUserFlow
+            };
             string expectedResult = $"{options.Instance}/{options.Domain}/{options.DefaultUserFlow}/v2.0";
 
             //Act
-            result = AuthorityHelpers.BuildAuthority(options);
+            string result = AuthorityHelpers.BuildAuthority(options);
 
             //Assert
             Assert.NotNull(result);

--- a/tests/Microsoft.Identity.Web.Test/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestConstants.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Identity.Web.Test
+{
+    internal static class TestConstants
+    {
+        public const string ProductionPrefNetworkEnvironment = "login.microsoftonline.com";
+        public const string ProductionPrefNetworkUSEnvironment = "login.microsoftonline.us";
+        public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
+
+        public const string LocalHost = "https://localhost";
+        
+        public const string ApiAudience = "api://1EE5A092-0DFD-42B6-88E5-C517C0141321";
+        public const string ApiClientId = "1EE5A092-0DFD-42B6-88E5-C517C0141321";
+
+        public const string TenantId = "some-tenant-id";
+        public const string TenantIdAsGuid = "da41245a5-11b3-996c-00a8-4d99re19f292";
+        public const string Domain = "contoso.onmicrosoft.com";
+
+        public const string AadInstance = "https://login.microsoftonline.com";
+        public const string AuthorityCommonTenant = AadInstance + "/common/";
+        public const string AuthorityOrganizationsTenant = AadInstance + "/organizations/";
+        public const string AuthorityOrganizationsUSTenant = "https://" + ProductionPrefNetworkUSEnvironment + "/organizations";
+
+        public const string AuthorityWithTenantSpecified = AadInstance + "/" + TenantId;
+        public const string AuthorityCommonTenantWithV2 = AadInstance + "/common/v2.0";
+        public const string AuthorityOrganizationsWithV2 = AadInstance + "/organizations/v2.0";
+        public const string AuthorityOrganizationsUSWithV2 = AuthorityOrganizationsUSTenant + "/v2.0";
+        public const string AuthorityWithTenantSpecifiedWithV2 = AadInstance + "/" + TenantId + "/v2.0";
+        public const string AadIssuer = AadInstance + "/" + TenantIdAsGuid + "/v2.0";
+        
+        // B2C
+        public const string B2CSuSiUserFlow = "b2c_1_susi";
+        public const string B2CTenant = "fabrikamb2c.onmicrosoft.com";
+        public const string B2CTenantAsGuid = "775527ff-9a37-4307-8b3d-cc311f58d925";
+        public const string B2CHost = "fabrikamb2c.b2clogin.com";
+        public const string B2CInstance = "https://fabrikamb2c.b2clogin.com";
+        public const string B2CInstance2 = "https://catb2c.b2clogin.com";
+        public const string B2CCustomDomainInstance = "https://catsAreAmazing.com";
+
+        public const string B2CAuthority = B2CInstance + "/" + B2CTenant + "/" + B2CSuSiUserFlow;
+        public const string B2CAuthorityWithV2 = B2CAuthority + "/v2.0";
+        public const string B2CCustomDomainAuthority = B2CCustomDomainInstance + "/" + B2CTenant + "/" + B2CSuSiUserFlow;
+        public const string B2CCustomDomainAuthorityWithV2 = B2CCustomDomainAuthority + "/v2.0";
+
+        public const string B2CIssuer = B2CInstance + "/" + B2CTenantAsGuid + "/v2.0";       
+        public const string B2CIssuer2 = B2CInstance2 + "/" + B2CTenantAsGuid + "/v2.0";       
+        public const string B2CCustomDomainIssuer = B2CCustomDomainInstance + "/" + B2CTenantAsGuid + "/v2.0";        
+
+        //Claims
+        public const string Tid = "tid";
+        public const string Iss = "iss";
+        public const string Tfp = "tfp"; //Trust Framework Policy for B2C (aka userflow/policy)
+
+        public static readonly IEnumerable<string> s_aliases = new[]
+        {
+            ProductionPrefNetworkEnvironment,
+            ProductionNotPrefEnvironmentAlias
+        };
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestConstants.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Identity.Web.Test
         public const string ProductionPrefNetworkUSEnvironment = "login.microsoftonline.us";
         public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
 
-        public const string LocalHost = "https://localhost";
+        public const string HttpLocalHost = "https://localhost";
         
-        public const string ApiAudience = "api://1EE5A092-0DFD-42B6-88E5-C517C0141321";
+        public const string ApiAudience = "api://" + ApiClientId;
         public const string ApiClientId = "1EE5A092-0DFD-42B6-88E5-C517C0141321";
 
         public const string TenantId = "some-tenant-id";
@@ -50,10 +50,10 @@ namespace Microsoft.Identity.Web.Test
         public const string B2CIssuer2 = B2CInstance2 + "/" + B2CTenantAsGuid + "/v2.0";       
         public const string B2CCustomDomainIssuer = B2CCustomDomainInstance + "/" + B2CTenantAsGuid + "/v2.0";        
 
-        //Claims
-        public const string Tid = "tid";
-        public const string Iss = "iss";
-        public const string Tfp = "tfp"; //Trust Framework Policy for B2C (aka userflow/policy)
+        // Claims
+        public const string ClaimNameTid = "tid";
+        public const string ClaimNameIss = "iss";
+        public const string ClaimNameTfp = "tfp"; //Trust Framework Policy for B2C (aka userflow/policy)
 
         public static readonly IEnumerable<string> s_aliases = new[]
         {

--- a/tests/Microsoft.Identity.Web.Test/WebApiServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebApiServiceCollectionExtensionsTests.cs
@@ -73,10 +73,10 @@ namespace Microsoft.Identity.Web.Test
             MicrosoftIdentityOptions microsoftIdentityOptions = new MicrosoftIdentityOptions() { ClientId = Guid.NewGuid().ToString() };
 
             // Act and Assert
-            options.Audience = TestConstants.LocalHost;
+            options.Audience = TestConstants.HttpLocalHost;
             WebApiServiceCollectionExtensions.EnsureValidAudiencesContainsApiGuidIfGuidProvided(options, microsoftIdentityOptions);
             Assert.True(options.TokenValidationParameters.ValidAudiences.Count() == 1);
-            Assert.True(options.TokenValidationParameters.ValidAudiences.First() == TestConstants.LocalHost);
+            Assert.True(options.TokenValidationParameters.ValidAudiences.First() == TestConstants.HttpLocalHost);
 
             options.Audience = TestConstants.ApiAudience;
             WebApiServiceCollectionExtensions.EnsureValidAudiencesContainsApiGuidIfGuidProvided(options, microsoftIdentityOptions);


### PR DESCRIPTION
- Add a test constants class
- Fix failing unit test which is fixed now that we get client_info, so we no longer fail if there is no tid in the jwt, we pull it from the claim
- I've only added on b2c authority test, but otherwise have not changed them