### PR TITLE
Adding an environment variable

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      FROM_GITHUB_ACTION: true
+    
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core


### PR DESCRIPTION
Adding the `FROM_GITHUB_ACTION` environment variable so that some tests don't run from GitHub actions (test requiring specific environments)