### PR TITLE
Simplification of the token cache serialization providers

### DIFF
--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Identity.Web
                     await app.RemoveAsync(b2cAccount).ConfigureAwait(false);
                 }
 
-                _tokenCacheProvider?.ClearAsync().ConfigureAwait(false);
+                _tokenCacheProvider?.ClearAsync(_microsoftIdentityOptions.ClientId).ConfigureAwait(false);
             }
 
             else
@@ -304,7 +304,7 @@ namespace Microsoft.Identity.Web
                 if (account != null)
                 {
                     await app.RemoveAsync(account).ConfigureAwait(false);
-                    _tokenCacheProvider?.ClearAsync().ConfigureAwait(false);
+                    _tokenCacheProvider?.ClearAsync(_microsoftIdentityOptions.ClientId).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 {
@@ -32,11 +31,10 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// <param name="httpContextAccessor"></param>
         /// <param name="memoryCache"></param>
         /// <param name="cacheOptions"></param>
-        public MsalDistributedTokenCacheAdapter(IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
-                                            IHttpContextAccessor httpContextAccessor,
+        public MsalDistributedTokenCacheAdapter(IHttpContextAccessor httpContextAccessor,
                                             IDistributedCache memoryCache,
                                             IOptions<DistributedCacheEntryOptions> cacheOptions) :
-            base(microsoftIdentityOptions, httpContextAccessor)
+            base(httpContextAccessor)
         {
             _distributedCache = memoryCache;
             _cacheOptions = cacheOptions.Value;

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider .cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider .cs
@@ -22,6 +22,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// Clear the cache
         /// </summary>
         /// <returns></returns>
-        Task ClearAsync();
+        Task ClearAsync(string clientId);
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheProvider.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
 {
@@ -32,11 +31,10 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         /// <param name="httpContextAccessor"></param>
         /// <param name="memoryCache"></param>
         /// <param name="cacheOptions"></param>
-        public MsalMemoryTokenCacheProvider(IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
-                                            IHttpContextAccessor httpContextAccessor,
+        public MsalMemoryTokenCacheProvider(IHttpContextAccessor httpContextAccessor,
                                             IMemoryCache memoryCache,
                                             IOptions<MsalMemoryTokenCacheOptions> cacheOptions) :
-            base(microsoftIdentityOptions, httpContextAccessor)
+            base(httpContextAccessor)
         {
             _memoryCache = memoryCache;
             _cacheOptions = cacheOptions.Value;

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.Session
 {
@@ -32,10 +31,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         private ILogger _logger;
 
         public MsalSessionTokenCacheProvider(
-            IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
             IHttpContextAccessor httpContextAccessor,
             ILogger<MsalSessionTokenCacheProvider> logger) : 
-            base(microsoftIdentityOptions, httpContextAccessor)
+            base(httpContextAccessor)
         {
             _logger = logger;
         }

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/MsalTestTokenCacheProvider.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/MsalTestTokenCacheProvider.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
         public int Count { get; internal set; }
 
         public MsalTestTokenCacheProvider(
-            IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
             IHttpContextAccessor httpContextAccessor,
             IMemoryCache memoryCache,
             IOptions<MsalMemoryTokenCacheOptions> cacheOptions) :
-            base(microsoftIdentityOptions, httpContextAccessor)
+            base(httpContextAccessor)
         {
             MemoryCache = memoryCache;
             _cacheOptions = cacheOptions.Value;

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -96,7 +96,6 @@ namespace Microsoft.Identity.Web.Test.Integration
             IHttpContextAccessor httpContextAccessor = CreateMockHttpContextAccessor();
 
             _msalTestTokenCacheProvider = new MsalTestTokenCacheProvider(
-                microsoftIdentityOptions,
                  httpContextAccessor,
                 _provider.GetService<IMemoryCache>(),
                 tokenOptions);


### PR DESCRIPTION
Simplification of the token cache serialization providers, which don't need a reference to the options (the ClientId, which was extracted from these options, can be provided by the TokenCacheArguments, or in the call ClearAsync