### PR TITLE
Enables developers to use the domain instead of the TenantId

### DIFF
--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Web
 
             var baseUri = new Uri(options.Instance);
             var pathBase = baseUri.PathAndQuery.TrimEnd('/');
-            var domain = options.Domain;
+            var domain = options.Domain ?? options.TenantId;
             var tenantId = options.TenantId;
 
             // If there are user flows, then it must build a B2C authority 
@@ -44,10 +44,10 @@ namespace Microsoft.Identity.Web
             else
             {
                 // Cannot build AAD authority without tenant id
-                if (string.IsNullOrWhiteSpace(tenantId))
+                if (string.IsNullOrWhiteSpace(domain))
                     return null;
 
-                return new Uri(baseUri, new PathString($"{pathBase}/{tenantId}/v2.0")).ToString();
+                return new Uri(baseUri, new PathString($"{pathBase}/{domain}/v2.0")).ToString();
             }
         }
     }

--- a/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
@@ -125,6 +125,22 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
+        public void BuildAuthority_AadValidOptionsWithDomain_ReturnsValidAadAuthority()
+        {
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                Domain = TestConstants.Domain,
+                Instance = TestConstants.AadInstance
+            };
+            string expectedResult = $"{options.Instance}/{options.Domain}/v2.0";
+
+            string result = AuthorityHelpers.BuildAuthority(options);
+
+            Assert.NotNull(result);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
         public void BuildAuthority_AadInstanceWithTrailingSlash_ReturnsValidAadAuthority()
         {
             //Arrange


### PR DESCRIPTION
Enables developers to use the domain instead of the TenantId for the authority (in the case of AAD)