### PR TITLE
Updated EnsureValidAudiencesContainsApiGuidIfGuidProvided

### DIFF
--- a/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
@@ -143,11 +143,12 @@ namespace Microsoft.Identity.Web
         /// as a valid audience (this is the default App ID URL in the app registration
         /// portal)
         /// </summary>
-        /// <param name="options">Jwt bearer options for which to ensure that
+        /// <param name="options"><see cref="JwtBearerOptions"/> for which to ensure that
         /// api://GUID is a valid audience</param>
         internal static void EnsureValidAudiencesContainsApiGuidIfGuidProvided(JwtBearerOptions options, MicrosoftIdentityOptions msIdentityOptions)
         {
-            var validAudiences = new List<string>();
+            options.TokenValidationParameters.ValidAudiences ??= new List<string>();
+            var validAudiences = new List<string>(options.TokenValidationParameters.ValidAudiences);
             if (!string.IsNullOrWhiteSpace(options.Audience))
             {
                 validAudiences.Add(options.Audience);

--- a/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string ConfidentialClientLabTenant = "72f988bf-86f1-41af-91ab-2d7cd011db47";
 
         //This value is only for testing purposes. It is for a certificate that is not used for anything other than running tests
-        public const string certificateX5c = @"MIIDHzCCAgegAwIBAgIQM6NFYNBJ9rdOiK+C91ZzFDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwHhcNMTIwNTIyMj
+        public const string CertificateX5c = @"MIIDHzCCAgegAwIBAgIQM6NFYNBJ9rdOiK+C91ZzFDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwHhcNMTIwNTIyMj
             IxMTIyWhcNMzAwNTIyMDcwMDAwWjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCh7HjK
             YyVMDZDT64OgtcGKWxHmK2wqzi2LJb65KxGdNfObWGxh5HQtjzrgHDkACPsgyYseqxhGxHh8I/TR6wBKx/AAKuPHE8jB4hJ1W6FczPfb7FaMV9xP0qNQrbNGZU
             YbCdy7U5zIw4XrGq22l6yTqpCAh59DLufd4d7x8fCgUDV3l1ZwrncF0QrBRzns/O9Ex9pXsi2DzMa1S1PKR81D9q5QSW7LZkCgSSqI6W0b5iodx/a3RBvW3l7d


### PR DESCRIPTION
- Updated EnsureValidAudiencesContainsApiGuidIfGuidProvided method to add on to the existing TokenValidationParameters.ValidAudiences collection instead of replacing it.
- Minor renamings.

Resolves #52 