### PR TITLE
validate v2.0 authority with web app, like we do w/web api.

### DIFF
--- a/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Web
                 if (string.IsNullOrWhiteSpace(options.Authority))
                     options.Authority = AuthorityHelpers.BuildAuthority(microsoftIdentityOptions);
 
-                // This is an Microsoft identity platform Web API
+                // This is a Microsoft identity platform Web API
                 EnsureAuthorityIsV2_0(options);
 
                 // The valid audience could be given as Client Id or as Uri. 
@@ -142,7 +142,7 @@ namespace Microsoft.Identity.Web
         /// Ensures that the authority is a v2.0 authority
         /// </summary>
         /// <param name="options">Jwt bearer options read from the config file
-        /// or set by the developper, for which we want to ensure the authority
+        /// or set by the developer, for which we want to ensure the authority
         /// is a v2.0 authority</param>
         internal static void EnsureAuthorityIsV2_0(JwtBearerOptions options)
         {

--- a/src/Microsoft.Identity.Web/WebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppAuthenticationBuilderExtensions.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Identity.Web
                 if (string.IsNullOrWhiteSpace(options.Authority))
                     options.Authority = AuthorityHelpers.BuildAuthority(microsoftIdentityOptions);
 
-                if (!AuthorityHelpers.IsV2Authority(options.Authority))
-                    options.Authority += "/v2.0";
+                // This is a Microsoft identity platform Web APP
+                EnsureAuthorityIsV2_0(options);
 
                 // B2C doesn't have preferred_username claims
                 if (microsoftIdentityOptions.IsB2C)
@@ -162,5 +162,18 @@ namespace Microsoft.Identity.Web
             return builder;
         }
 
+        /// <summary>
+        /// Ensures that the authority is a v2.0 authority
+        /// </summary>
+        /// <param name="options">OpenIdConnect options read from the config file
+        /// or set by the developer, for which we want to ensure the authority
+        /// is a v2.0 authority</param>
+        internal static void EnsureAuthorityIsV2_0(OpenIdConnectOptions options)
+        {
+            var authority = options.Authority.Trim().TrimEnd('/');
+            if (!authority.EndsWith("v2.0"))
+                authority += "/v2.0";
+            options.Authority = authority;
+        }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtentionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtentionsTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Identity.Web.Test.Common;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    public class WebAppExtentionsTests
+    {
+        [Theory]
+        [InlineData(TestConstants.AuthorityCommonTenant, TestConstants.AuthorityCommonTenantWithV2)]
+        [InlineData(TestConstants.AuthorityOrganizationsUSTenant, TestConstants.AuthorityOrganizationsUSWithV2)]
+        [InlineData(TestConstants.AuthorityCommonTenantWithV2, TestConstants.AuthorityCommonTenantWithV2)]
+        [InlineData(TestConstants.AuthorityCommonTenantWithV2 + "/", TestConstants.AuthorityCommonTenantWithV2)]
+        [InlineData(TestConstants.B2CAuthorityWithV2, TestConstants.B2CAuthorityWithV2)]
+        [InlineData(TestConstants.B2CCustomDomainAuthorityWithV2, TestConstants.B2CCustomDomainAuthorityWithV2)]
+        [InlineData(TestConstants.B2CAuthority, TestConstants.B2CAuthorityWithV2)]
+        [InlineData(TestConstants.B2CCustomDomainAuthority, TestConstants.B2CCustomDomainAuthorityWithV2)]
+        public void EnsureAuthorityIsV2_0(string initialAuthority, string expectedAuthority)
+        {
+            OpenIdConnectOptions options = new OpenIdConnectOptions
+            {
+                Authority = initialAuthority
+            };
+
+            WebAppAuthenticationBuilderExtensions.EnsureAuthorityIsV2_0(options);
+            Assert.Equal(expectedAuthority, options.Authority);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #19 