### PR TITLE
Jmprieur/produce templates Nuget package

### DIFF
--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -21,6 +21,13 @@ steps:
     ProjectRootPath: '$(Build.SourcesDirectory)\src\Microsoft.Identity.Web.UI'
     AssemblyName: 'Microsoft.Identity.Web.UI*'
 
+# Pack and sign Microsoft.Identity.Web.ProjectTemplates
+- template: template-pack-and-sign-nuget.yaml
+  parameters:
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
+    ProjectRootPath: '$(Build.SourcesDirectory)\ProjectTemplates'
+    AssemblyName: 'Microsoft.Identity.Web.ProjectTemplates*'
+
 # Copy all packages out to staging
 - task: CopyFiles@2
   displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\packages'

--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -26,7 +26,7 @@ steps:
   parameters:
     BuildConfiguration: ${{ parameters.BuildConfiguration }}
     ProjectRootPath: '$(Build.SourcesDirectory)\ProjectTemplates'
-    AssemblyName: 'Microsoft.Identity.Web.ProjectTemplates*'
+    AssemblyName: 'AspNetCoreMicrosoftIdentityWebProjectTemplates'
 
 # Copy all packages out to staging
 - task: CopyFiles@2


### PR DESCRIPTION
This changes the build scripts to create a NuGet package containing the 3 templates:

Validated by build. See build artifacts.
https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=514654&view=artifacts&type=publishedArtifacts