### PR TITLE
Fix typo in Web app project templates

### DIFF
--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/Startup.cs
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/Startup.cs
@@ -69,7 +69,7 @@ namespace Company.WebApplication1
                 .AddEntityFrameworkStores<ApplicationDbContext>();
 #elif (OrganizationalAuth)
             services.AddSignIn(Configuration, "AzureAd");
-            // Uncomment the following lines if you want your Web API to call a downstream API
+            // Uncomment the following lines if you want your Web app to call a downstream API
             // services.AddWebAppCallsProtectedWebApi(Configuration, 
             //                                        new string[] { "user.read" }, 
             //                                        "AzureAd")

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Startup.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Startup.cs
@@ -69,7 +69,7 @@ namespace Company.WebApplication1
                 .AddEntityFrameworkStores<ApplicationDbContext>();
 #elif (OrganizationalAuth)
             services.AddSignIn(Configuration, "AzureAd");
-            // Uncomment the following lines if you want your Web API to call a downstream API
+            // Uncomment the following lines if you want your Web app to call a downstream API
             // services.AddWebAppCallsProtectedWebApi(Configuration, 
             //                                        new string[] { "user.read" }, 
             //                                        "AzureAd")


### PR DESCRIPTION
Why?
The startup.cs file for web apps in the templates had a comment ' Uncomment the following lines if you want your Web API ' (copy/paste issue from Web api template probably)

What?
fix this typo.

Thanks @mahoekst for reporting!