### PR TITLE
Imported analyzer rules from MSAL and included some warning fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,479 @@
-# NOTE: Requires **VS2019 16.3** or later
+# Note: MSAL rules used as a starting point
 
-# Code files
-[*.{cs,vb}]
+# editorconfig.org
+# Copied from the .NET Core repo https://github.com/dotnet/corefx/blob/master/.editorconfig
 
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[project.json]
+indent_size = 2
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# only use var when it's obvious what the variable type is
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+
+# use language keywords instead of BCL types
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case 
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+
+# Code style defaults
+dotnet_sort_system_directives_first = true
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# MSAL Rules
+
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity = error
+
+# CA1008: Enums should have zero value
+dotnet_diagnostic.CA1008.severity = error
+
+# CA1010: Collections should implement generic interface
+dotnet_diagnostic.CA1010.severity = error
+
+# CA1012: Abstract types should not have constructors
+dotnet_diagnostic.CA1012.severity = error
+
+# CA1016: Mark assemblies with assembly version
+dotnet_diagnostic.CA1016.severity = none
+
+# CA1017: Mark assemblies with ComVisible
+dotnet_diagnostic.CA1017.severity = error
+
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = error
+
+# CA1027: Mark enums with FlagsAttribute
+dotnet_diagnostic.CA1027.severity = error
+
+# CA1028: Enum Storage should be Int32
+dotnet_diagnostic.CA1028.severity = error
+
+# CA1030: Use events where appropriate
+dotnet_diagnostic.CA1030.severity = error
+
+# CA1033: Interface methods should be callable by child types
+dotnet_diagnostic.CA1033.severity = error
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.CA1034.severity = error
+
+# CA1036: Override methods on comparable types
+dotnet_diagnostic.CA1036.severity = error
+
+# CA1040: Avoid empty interfaces
+dotnet_diagnostic.CA1040.severity = none
+
+# CA1041: Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = error
+
+# CA1043: Use Integral Or String Argument For Indexers
+dotnet_diagnostic.CA1043.severity = error
+
+# CA1044: Properties should not be write only
+dotnet_diagnostic.CA1044.severity = none
+
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = error
+
+# CA1051: Do not declare visible instance fields
+dotnet_diagnostic.CA1051.severity = none
+
+# CA1052: Static holder types should be Static or NotInheritable
+dotnet_diagnostic.CA1052.severity = none
+
+# CA1054: Uri parameters should not be strings
+dotnet_diagnostic.CA1054.severity = none
+
+# CA1055: Uri return values should not be strings
+dotnet_diagnostic.CA1055.severity = error
+
+# CA1056: Uri properties should not be strings
+dotnet_diagnostic.CA1056.severity = none
+
+# CA1061: Do not hide base class methods
+dotnet_diagnostic.CA1061.severity = error
+
+# CA1063: Implement IDisposable Correctly
+dotnet_diagnostic.CA1063.severity = none
+
+# CA1064: Exceptions should be public
+dotnet_diagnostic.CA1064.severity = none
+
+# CA1066: Type {0} should implement IEquatable<T> because it overrides Equals
+dotnet_diagnostic.CA1066.severity = none
+
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
+dotnet_diagnostic.CA1067.severity = error
+
+# CA1068: CancellationToken parameters must come last
+dotnet_diagnostic.CA1068.severity = error
+
+# CA1505: Avoid unmaintainable code
+dotnet_diagnostic.CA1505.severity = error
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none
+
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = none
+
+# CA1714: Flags enums should have plural names
+dotnet_diagnostic.CA1714.severity = none
+
+# CA1715: Identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = none
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = none
+
+# CA1717: Only FlagsAttribute enums should have plural names
+dotnet_diagnostic.CA1717.severity = none
+
+# CA1720: Identifier contains type name
+dotnet_diagnostic.CA1720.severity = none
+
+# CA1721: Property names should not match get methods
+dotnet_diagnostic.CA1721.severity = none
+
+# CA1724: Type names should not match namespaces
+dotnet_diagnostic.CA1724.severity = none
+
+# CA1801: Review unused parameters
+dotnet_diagnostic.CA1801.severity = none
+
+# CA1802: Use literals where appropriate
+dotnet_diagnostic.CA1802.severity = none
+
+# CA1806: Do not ignore method results
+dotnet_diagnostic.CA1806.severity = none
+
+# CA1812: Avoid uninstantiated internal classes
+dotnet_diagnostic.CA1812.severity = none
+
+# CA1814: Prefer jagged arrays over multidimensional
+dotnet_diagnostic.CA1814.severity = none
+
+# CA1815: Override equals and operator equals on value types
+dotnet_diagnostic.CA1815.severity = none
+
+# CA1819: Properties should not return arrays
+dotnet_diagnostic.CA1819.severity = none
+
+# CA1822: Mark members as static
+dotnet_diagnostic.CA1822.severity = none
+
+# CA1823: Avoid unused private fields
+dotnet_diagnostic.CA1823.severity = none
+
+# CA2119: Seal methods that satisfy private interfaces
+dotnet_diagnostic.CA2119.severity = none
+
+# CA2211: Non-constant fields should not be visible
+dotnet_diagnostic.CA2211.severity = none
+
+# CA2214: Do not call overridable methods in constructors
+dotnet_diagnostic.CA2214.severity = none
+
+# CA2219: Do not raise exceptions in finally clauses
+dotnet_diagnostic.CA2219.severity = none
+
+# CA2226: Operators should have symmetrical overloads
+dotnet_diagnostic.CA2226.severity = none
+
+# CA2225: Operator overloads have named alternates
+dotnet_diagnostic.CA2225.severity = none
+
+# CA2227: Collection properties should be read only
+dotnet_diagnostic.CA2227.severity = none
+
+# CA2231: Overload operator equals on overriding value type Equals
+dotnet_diagnostic.CA2231.severity = none
+
+# CA2244: Do not duplicate indexed element initializations
+dotnet_diagnostic.CA2244.severity = none
+
+# CA9999: Analyzer version mismatch
+dotnet_diagnostic.CA9999.severity = none
+
+# CA1001: Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1001.severity = none
+
+# CA1032: Implement standard exception constructors
+dotnet_diagnostic.CA1032.severity = none
+
+# CA1065: Do not raise exceptions in unexpected locations
+dotnet_diagnostic.CA1065.severity = none
+
+# CA1200: Avoid using cref tags with a prefix
+dotnet_diagnostic.CA1200.severity = none
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = none
+
+# CA1821: Remove empty Finalizers
+dotnet_diagnostic.CA1821.severity = none
+
+# CA2200: Rethrow to preserve stack details.
+dotnet_diagnostic.CA2200.severity = none
+
+# CA2234: Pass system uri objects instead of strings
+dotnet_diagnostic.CA2234.severity = none
+
+# CA1304: Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = error
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = error
+
+# CA1307: Specify StringComparison
+dotnet_diagnostic.CA1307.severity = none
+
+# CA1308: Normalize strings to uppercase
+dotnet_diagnostic.CA1308.severity = none
+
+# CA1401: P/Invokes should not be visible
+dotnet_diagnostic.CA1401.severity = none
+
+# CA1816: Dispose methods should call SuppressFinalize
+dotnet_diagnostic.CA1816.severity = none
+
+# CA1820: Test for empty strings using string length
+dotnet_diagnostic.CA1820.severity = none
+
+# CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
+dotnet_diagnostic.CA1826.severity = none
+
+# CA2002: Do not lock on objects with weak identity
+dotnet_diagnostic.CA2002.severity = none
+
+# CA2008: Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.CA2008.severity = none
+
+# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+dotnet_diagnostic.CA2009.severity = none
+
+# CA2101: Specify marshaling for P/Invoke string arguments
+dotnet_diagnostic.CA2101.severity = none
+
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = none
+
+# CA2216: Disposable types should declare finalizer
+dotnet_diagnostic.CA2216.severity = none
+
+# CA2241: Provide correct arguments to formatting methods
+dotnet_diagnostic.CA2241.severity = none
+
+# CA2242: Test for NaN correctly
+dotnet_diagnostic.CA2242.severity = none
+
+# CA2243: Attribute string literals should parse correctly
+dotnet_diagnostic.CA2243.severity = none
+
+# CA1810: Initialize reference type static fields inline
+dotnet_diagnostic.CA1810.severity = none
+
+# CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
+dotnet_diagnostic.CA1824.severity = none
+
+# CA1825: Avoid zero-length array allocations.
+dotnet_diagnostic.CA1825.severity = none
+
+# CA2010: Always consume the value returned by methods marked with PreserveSigAttribute
+dotnet_diagnostic.CA2010.severity = none
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = error
+
+# CA2207: Initialize value type static fields inline
+dotnet_diagnostic.CA2207.severity = none
+
+# CA1058: Types should not extend certain base types
+dotnet_diagnostic.CA1058.severity = none
+
+# CA2153: Do Not Catch Corrupted State Exceptions
+dotnet_diagnostic.CA2153.severity = error
+
+# CA2229: Implement serialization constructors
+dotnet_diagnostic.CA2229.severity = none
+
+# CA2235: Mark all non-serializable fields
+dotnet_diagnostic.CA2235.severity = none
+
+# CA2237: Mark ISerializable types with serializable
+dotnet_diagnostic.CA2237.severity = none
+
+# SDL Required
+# CA3075: Insecure DTD processing in XML
+dotnet_diagnostic.CA3075.severity = error
+
+# SDL Required
+# CA3147: Mark Verb Handlers With Validate Antiforgery Token
+dotnet_diagnostic.CA3147.severity = error
+
+# SDL Required
+# CA3076: Insecure XSLT script processing.
+dotnet_diagnostic.CA3076.severity = error
+
+# SDL Required
+# CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
+dotnet_diagnostic.CA3077.severity = error
+
+# SDL Required
+# CA5350: Do Not Use Weak Cryptographic Algorithms
+dotnet_diagnostic.CA5350.severity = error
+
+# SDL Required
+# CA5351: Do Not Use Broken Cryptographic Algorithms
+dotnet_diagnostic.CA5351.severity = error
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# SX1101: Do not prefix local calls with 'this.'
+dotnet_diagnostic.SX1101.severity = error
+
+# SA1309: Field names should not begin with underscore
+dotnet_diagnostic.SA1309.severity = none
+
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/Microsoft.Identity.Web.sln
+++ b/Microsoft.Identity.Web.sln
@@ -37,6 +37,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2B919DEC-2539-4357-8E89-8C0CC9889FB4}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		stylecop.json = stylecop.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreMicrosoftIdentityWebProjectTemplates", "ProjectTemplates\AspNetCoreMicrosoftIdentityWebProjectTemplates.csproj", "{893905EA-94D6-4F71-957A-43B194751DC7}"

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
 {
     /// <summary>
-    /// Controller used in web apps to manage accounts
+    /// Controller used in web apps to manage accounts.
     /// </summary>
     [NonController]
     [AllowAnonymous]
@@ -24,19 +24,19 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
 
         /// <summary>
         /// Constructor of <see cref="AccountController"/> from <see cref="MicrosoftIdentityOptions"/>
-        /// This constructor is used by dependency injection
+        /// This constructor is used by dependency injection.
         /// </summary>
-        /// <param name="microsoftIdentityOptions">Configuration options</param>
+        /// <param name="microsoftIdentityOptions">Configuration options.</param>
         public AccountController(IOptionsMonitor<MicrosoftIdentityOptions> microsoftIdentityOptions)
         {
             _options = microsoftIdentityOptions;
         }
 
         /// <summary>
-        /// Handles user sign in
+        /// Handles user sign in.
         /// </summary>
-        /// <param name="scheme">Authentication scheme</param>
-        /// <returns>Challenge generating a redirect to Azure AD to sign in the user</returns>
+        /// <param name="scheme">Authentication scheme.</param>
+        /// <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
         [HttpGet("{scheme?}")]
         public IActionResult SignIn([FromRoute] string scheme)
         {
@@ -48,10 +48,10 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         }
 
         /// <summary>
-        /// Handles the user sign-out
+        /// Handles the user sign-out.
         /// </summary>
-        /// <param name="scheme">Authentication scheme</param>
-        /// <returns>Sign out result</returns>
+        /// <param name="scheme">Authentication scheme.</param>
+        /// <returns>Sign out result.</returns>
         [HttpGet("{scheme?}")]
         public IActionResult SignOut([FromRoute] string scheme)
         {
@@ -60,17 +60,17 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
             return SignOut(
                  new AuthenticationProperties
                  {
-                     RedirectUri = callbackUrl
+                     RedirectUri = callbackUrl,
                  },
                 CookieAuthenticationDefaults.AuthenticationScheme,
                 scheme);
         }
 
         /// <summary>
-        /// In B2C applications handles the Reset password policy
+        /// In B2C applications handles the Reset password policy.
         /// </summary>
-        /// <param name="scheme">Authentication scheme</param>
-        /// <returns>Challenge generating a redirect to Azure AD B2C</returns>
+        /// <param name="scheme">Authentication scheme.</param>
+        /// <returns>Challenge generating a redirect to Azure AD B2C.</returns>
         [HttpGet("{scheme?}")]
         public IActionResult ResetPassword([FromRoute] string scheme)
         {
@@ -83,10 +83,10 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         }
 
         /// <summary>
-        /// In B2C applications, handles the Edit Profile policy
+        /// In B2C applications, handles the Edit Profile policy.
         /// </summary>
-        /// <param name="scheme">Authentication scheme</param>
-        /// <returns>Challenge generating a redirect to Azure AD B2C</returns>
+        /// <param name="scheme">Authentication scheme.</param>
+        /// <returns>Challenge generating a redirect to Azure AD B2C.</returns>
         [HttpGet("{scheme?}")]
         public async Task<IActionResult> EditProfile([FromRoute] string scheme)
         {

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/AccessDenied.cshtml.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/AccessDenied.cshtml.cs
@@ -1,16 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
 {
     /// <summary>
-    /// Page presenting the Access denied error
+    /// Page presenting the Access denied error.
     /// </summary>
     [AllowAnonymous]
     public class AccessDeniedModel : PageModel
     {
         /// <summary>
-        /// Method handling the Get Http verb
+        /// Method handling the HTTP GET method.
         /// </summary>
         public void OnGet()
         {

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml.cs
@@ -1,12 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using System.Diagnostics;
 
 namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
 {
     /// <summary>
-    /// Model for the Error page
+    /// Model for the Error page.
     /// </summary>
     [AllowAnonymous]
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
@@ -14,19 +17,19 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
     {
         /// <summary>
         /// This API supports infrastructure and is not intended to be used
-        /// directly from your code.This API may change or be removed in future releases
+        /// directly from your code.This API may change or be removed in future releases.
         /// </summary>
         public string RequestId { get; set; }
 
         /// <summary>
         /// This API supports infrastructure and is not intended to be used
-        /// directly from your code.This API may change or be removed in future releases
+        /// directly from your code.This API may change or be removed in future releases.
         /// </summary>
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
         /// <summary>
         /// This API supports infrastructure and is not intended to be used
-        /// directly from your code.This API may change or be removed in future releases
+        /// directly from your code.This API may change or be removed in future releases.
         /// </summary>
         public void OnGet()
         {

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/SignedOut.cshtml.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/SignedOut.cshtml.cs
@@ -1,7 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -9,14 +8,16 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
 {
     /// <summary>
-    /// Model for the SignOut page
+    /// Model for the SignOut page.
     /// </summary>
     [AllowAnonymous]
     public class SignedOutModel : PageModel
     {
-#pragma warning disable CS1591 // Imposed by the Blazor framework
+        /// <summary>
+        /// Method handling the HTTP GET method.
+        /// </summary>
+        /// <returns></returns>
         public IActionResult OnGet()
-#pragma warning restore CS1591 // // Imposed by the Blazor framework
         {
             if (User.Identity.IsAuthenticated)
             {

--- a/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.csproj
+++ b/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.csproj
@@ -28,6 +28,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
@@ -54,6 +58,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Microsoft.Identity.Web.UI/MicrosoftIdentityAccountControllerFeatureProvider.cs
+++ b/src/Microsoft.Identity.Web.UI/MicrosoftIdentityAccountControllerFeatureProvider.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers;
-using System.Collections.Generic;
-using System.Reflection;
 
 namespace Microsoft.Identity.Web.UI
 {

--- a/src/Microsoft.Identity.Web.UI/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.UI/ServiceCollectionExtensions.cs
@@ -7,14 +7,14 @@ namespace Microsoft.Identity.Web.UI
 {
     /// <summary>
     /// Extension method on <see cref="IMvcBuilder"/> to add UI
-    /// for Microsoft.Identity.Web
+    /// for Microsoft.Identity.Web.
     /// </summary>
     public static class ServiceCollectionExtensions
     {
         /// <summary>
         /// Adds a controller and Razor pages for the accounts management.
         /// </summary>
-        /// <param name="builder">MVC Builder</param>
+        /// <param name="builder">MVC Builder.</param>
         public static IMvcBuilder AddMicrosoftIdentityUI(this IMvcBuilder builder)
         {
             builder.ConfigureApplicationPartManager(apm =>

--- a/src/Microsoft.Identity.Web/AccountExtensions.cs
+++ b/src/Microsoft.Identity.Web/AccountExtensions.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client;
 using System.Security.Claims;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web
 {
@@ -12,11 +12,11 @@ namespace Microsoft.Identity.Web
     public static class AccountExtensions
     {
         /// <summary>
-        /// Creates the <see cref="ClaimsPrincipal"/> from the values found 
-        /// in an <see cref="IAccount"/>
+        /// Creates the <see cref="ClaimsPrincipal"/> from the values found
+        /// in an <see cref="IAccount"/>.
         /// </summary>
-        /// <param name="account">The IAccount instance</param>
-        /// <returns>A <see cref="ClaimsPrincipal"/> built from IAccount</returns>
+        /// <param name="account">The IAccount instance.</param>
+        /// <returns>A <see cref="ClaimsPrincipal"/> built from IAccount.</returns>
         public static ClaimsPrincipal ToClaimsPrincipal(this IAccount account)
         {
             if (account != null)
@@ -26,9 +26,8 @@ namespace Microsoft.Identity.Web
                     {
                         new Claim(ClaimConstants.Oid, account.HomeAccountId?.ObjectId),
                         new Claim(ClaimConstants.Tid, account.HomeAccountId?.TenantId),
-                        new Claim(ClaimTypes.Upn, account.Username)
-                    })
-                );
+                        new Claim(ClaimTypes.Upn, account.Username),
+                    }));
             }
 
             return null;

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Http;
 using System;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.Identity.Web
 {
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Web
             var domain = options.Domain;
             var tenantId = options.TenantId;
 
-            // If there are user flows, then it must build a B2C authority 
+            // If there are user flows, then it must build a B2C authority
             if (options.IsB2C)
             {
                 var userFlow = options.DefaultUserFlow;
@@ -31,7 +31,10 @@ namespace Microsoft.Identity.Web
         {
             authority = authority.Trim().TrimEnd('/');
             if (!authority.EndsWith("v2.0", StringComparison.InvariantCulture))
+            {
                 authority += "/v2.0";
+            }
+
             return authority;
         }
     }

--- a/src/Microsoft.Identity.Web/AuthorizeForScopesAttribute.cs
+++ b/src/Microsoft.Identity.Web/AuthorizeForScopesAttribute.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,9 +12,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Client;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Identity.Web
 {
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Web
     /// Filter used on a controller action to trigger incremental consent.
     /// </summary>
     /// <example>
-    /// The following controller action will trigger
+    /// The following controller action will trigger.
     /// <code>
     /// [AuthorizeForScopes(Scopes = new[] {"Mail.Send"})]
     /// public async Task&lt;IActionResult&gt; SendEmail()
@@ -30,23 +30,23 @@ namespace Microsoft.Identity.Web
     public class AuthorizeForScopesAttribute : ExceptionFilterAttribute
     {
         /// <summary>
-        /// Scopes to request
+        /// Scopes to request.
         /// </summary>
         public string[] Scopes { get; set; }
 
         /// <summary>
-        /// Key section on the configuration file that holds the scope value
+        /// Key section on the configuration file that holds the scope value.
         /// </summary>
         public string ScopeKeySection { get; set; }
 
         /// <summary>
-        /// Handles the MsalUiRequiredException
+        /// Handles the MsalUiRequiredException.
         /// </summary>
-        /// <param name="context">Context provided by ASP.NET Core</param>
+        /// <param name="context">Context provided by ASP.NET Core.</param>
         public override void OnException(ExceptionContext context)
         {
             // Do not re-use the attribute param Scopes. For more info: https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/issues/273
-            string[] incrementalConsentScopes = new string[] { };
+            string[] incrementalConsentScopes = Array.Empty<string>();
             MsalUiRequiredException msalUiRequiredException = context.Exception as MsalUiRequiredException;
 
             if (msalUiRequiredException == null)
@@ -76,14 +76,16 @@ namespace Microsoft.Identity.Web
                         }
 
                         incrementalConsentScopes = new string[] { configuration.GetValue<string>(ScopeKeySection) };
-                        
+
                         if (Scopes != null && Scopes.Length > 0 && incrementalConsentScopes != null && incrementalConsentScopes.Length > 0)
                         {
-                           throw new InvalidOperationException("no scopes provided in scopes...");
+                            throw new InvalidOperationException("no scopes provided in scopes...");
                         }
                     }
                     else
+                    {
                         incrementalConsentScopes = Scopes;
+                    }
 
                     var properties = BuildAuthenticationPropertiesForIncrementalConsent(incrementalConsentScopes, msalUiRequiredException, context.HttpContext);
                     context.Result = new ChallengeResult(properties);
@@ -107,10 +109,10 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Build Authentication properties needed for incremental consent.
         /// </summary>
-        /// <param name="scopes">Scopes to request</param>
-        /// <param name="ex">MsalUiRequiredException instance</param>
-        /// <param name="context">current http context in the pipeline</param>
-        /// <returns>AuthenticationProperties</returns>
+        /// <param name="scopes">Scopes to request.</param>
+        /// <param name="ex">MsalUiRequiredException instance.</param>
+        /// <param name="context">current http context in the pipeline.</param>
+        /// <returns>AuthenticationProperties.</returns>
         private AuthenticationProperties BuildAuthenticationPropertiesForIncrementalConsent(
             string[] scopes,
             MsalUiRequiredException ex,
@@ -120,9 +122,12 @@ namespace Microsoft.Identity.Web
 
             // Set the scopes, including the scopes that ADAL.NET / MSAL.NET need for the token cache
             string[] additionalBuiltInScopes =
-                {OidcConstants.ScopeOpenId,
-                OidcConstants.ScopeOfflineAccess,
-                OidcConstants.ScopeProfile};
+            {
+                 OidcConstants.ScopeOpenId,
+                 OidcConstants.ScopeOfflineAccess,
+                 OidcConstants.ScopeProfile,
+            };
+
             properties.SetParameter<ICollection<string>>(OpenIdConnectParameterNames.Scope,
                                                          scopes.Union(additionalBuiltInScopes).ToList());
 

--- a/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
+++ b/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Microsoft.Identity.Web
 {
@@ -41,32 +41,23 @@ namespace Microsoft.Identity.Web
             return Task.CompletedTask;
         }
 
-        private string BuildIssuerAddress(RedirectContext context, string defaultUserFlow, string userFlow)
-        {
-            if (!_userFlowToIssuerAddress.TryGetValue(userFlow, out var issuerAddress))
-            {
-                _userFlowToIssuerAddress[userFlow] = context.ProtocolMessage.IssuerAddress.ToLowerInvariant()
-                    .Replace($"/{defaultUserFlow.ToLowerInvariant()}/", $"/{userFlow.ToLowerInvariant()}/");
-            }
-
-            return _userFlowToIssuerAddress[userFlow];
-        }
-
         public Task OnRemoteFailure(RemoteFailureContext context)
         {
             context.HandleResponse();
-            // Handle the error code that Azure Active Directory B2C throws when trying to reset a password from the login page 
+
+            // Handle the error code that Azure Active Directory B2C throws when trying to reset a password from the login page
             // because password reset is not supported by a "sign-up or sign-in user flow".
             // Below is a sample error message:
             // 'access_denied', error_description: 'AADB2C90118: The user has forgotten their password.
             // Correlation ID: f99deff4-f43b-43cc-b4e7-36141dbaf0a0
             // Timestamp: 2018-03-05 02:49:35Z
-            //', error_uri: 'error_uri is null'.
+            // ', error_uri: 'error_uri is null'.
             if (context.Failure is OpenIdConnectProtocolException && context.Failure.Message.Contains("AADB2C90118"))
             {
                 // If the user clicked the reset password link, redirect to the reset password route
                 context.Response.Redirect($"{context.Request.PathBase}/MicrosoftIdentity/Account/ResetPassword/{SchemeName}");
             }
+
             // Access denied errors happen when a user cancels an action on the Azure Active Directory B2C UI. We just redirect back to
             // the main page in that case.
             // Message contains error: 'access_denied', error_description: 'AADB2C90091: The user has canceled entering self-asserted information.
@@ -83,6 +74,17 @@ namespace Microsoft.Identity.Web
             }
 
             return Task.CompletedTask;
+        }
+
+        private string BuildIssuerAddress(RedirectContext context, string defaultUserFlow, string userFlow)
+        {
+            if (!_userFlowToIssuerAddress.TryGetValue(userFlow, out var issuerAddress))
+            {
+                _userFlowToIssuerAddress[userFlow] = context.ProtocolMessage.IssuerAddress.ToLowerInvariant()
+                    .Replace($"/{defaultUserFlow.ToLowerInvariant()}/", $"/{userFlow.ToLowerInvariant()}/");
+            }
+
+            return _userFlowToIssuerAddress[userFlow];
         }
     }
 }

--- a/src/Microsoft.Identity.Web/Base64UrlHelpers.cs
+++ b/src/Microsoft.Identity.Web/Base64UrlHelpers.cs
@@ -16,16 +16,13 @@ namespace Microsoft.Identity.Web
         private const char Base64UrlCharacter63 = '_';
         private static readonly Encoding TextEncoding = Encoding.UTF8;
 
-        private static readonly string DoubleBase64PadCharacter = string.Format(CultureInfo.InvariantCulture, "{0}{0}",
-            Base64PadCharacter);
+        private static readonly string DoubleBase64PadCharacter = string.Format(CultureInfo.InvariantCulture, "{0}{0}", Base64PadCharacter);
 
-        //
         // The following functions perform base64url encoding which differs from regular base64 encoding as follows
         // * padding is skipped so the pad character '=' doesn't have to be percent encoded
         // * the 62nd and 63rd regular base64 encoding characters ('+' and '/') are replace with ('-' and '_')
         // The changes make the encoding alphabet file and URL safe
         // See RFC4648, section 5 for more info
-        //
         public static string Encode(string arg)
         {
             if (arg == null)

--- a/src/Microsoft.Identity.Web/ClaimConstants.cs
+++ b/src/Microsoft.Identity.Web/ClaimConstants.cs
@@ -9,82 +9,82 @@ namespace Microsoft.Identity.Web
     public static class ClaimConstants
     {
         /// <summary>
-        /// Name claim: "name"
+        /// Name claim: "name".
         /// </summary>
         public const string Name = "name";
 
         /// <summary>
-        /// Old Object Id claim: http://schemas.microsoft.com/identity/claims/objectidentifier
+        /// Old Object Id claim: http://schemas.microsoft.com/identity/claims/objectidentifier.
         /// </summary>
         public const string ObjectId = "http://schemas.microsoft.com/identity/claims/objectidentifier";
 
         /// <summary>
-        /// New Object id claim: "oid"
+        /// New Object id claim: "oid".
         /// </summary>
         public const string Oid = "oid";
 
         /// <summary>
-        /// PreferredUserName: "preferred_username"
+        /// PreferredUserName: "preferred_username".
         /// </summary>
         public const string PreferredUserName = "preferred_username";
 
         /// <summary>
-        /// Old TenantId claim: "http://schemas.microsoft.com/identity/claims/tenantid"
+        /// Old TenantId claim: "http://schemas.microsoft.com/identity/claims/tenantid".
         /// </summary>
         public const string TenantId = "http://schemas.microsoft.com/identity/claims/tenantid";
 
         /// <summary>
-        /// New Tenant Id claim: "tid"
+        /// New Tenant Id claim: "tid".
         /// </summary>
         public const string Tid = "tid";
 
         /// <summary>
-        /// ClientInfo claim: "client_info"
+        /// ClientInfo claim: "client_info".
         /// </summary>
         public const string ClientInfo = "client_info";
 
         /// <summary>
-        /// UniqueObjectIdentifier: "utid"
+        /// UniqueObjectIdentifier: "utid".
         /// </summary>
         public const string UniqueObjectIdentifier = "utid";
 
         /// <summary>
-        /// Older scope claim: "http://schemas.microsoft.com/identity/claims/scope"
+        /// Older scope claim: "http://schemas.microsoft.com/identity/claims/scope".
         /// </summary>
         public const string Scope = "http://schemas.microsoft.com/identity/claims/scope";
 
         /// <summary>
-        /// Newer scope claim: "scp"
+        /// Newer scope claim: "scp".
         /// </summary>
         public const string Scp = "scp";
 
         /// <summary>
-        /// New Roles claim = "roles"
+        /// New Roles claim = "roles".
         /// </summary>
         public const string Roles = "roles";
 
         /// <summary>
-        /// Old Role claim: "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+        /// Old Role claim: "http://schemas.microsoft.com/ws/2008/06/identity/claims/role".
         /// </summary>
         public const string Role = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
 
         /// <summary>
-        /// Subject claim: "sub"
+        /// Subject claim: "sub".
         /// </summary>
         public const string Sub = "sub";
 
         /// <summary>
-        /// Acr claim: "acr"
+        /// Acr claim: "acr".
         /// </summary>
         public const string Acr = "acr";
 
         /// <summary>
-        /// UserFlow claim: "http://schemas.microsoft.com/claims/authnclassreference"
+        /// UserFlow claim: "http://schemas.microsoft.com/claims/authnclassreference".
         /// </summary>
         public const string UserFlow = "http://schemas.microsoft.com/claims/authnclassreference";
 
         /// <summary>
-        /// Tfp claim: "tfp"
+        /// Tfp claim: "tfp".
         /// </summary>
         public const string Tfp = "tfp";
     }

--- a/src/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
+++ b/src/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Identity.Web
     public static class ClaimsPrincipalExtensions
     {
         /// <summary>
-        /// Gets the Account identifier for an MSAL.NET account from a <see cref="ClaimsPrincipal"/>
+        /// Gets the Account identifier for an MSAL.NET account from a <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">Claims principal</param>
-        /// <returns>A string corresponding to an account identifier as defined in <see cref="Microsoft.Identity.Client.AccountId.Identifier"/></returns>
+        /// <param name="claimsPrincipal">Claims principal.</param>
+        /// <returns>A string corresponding to an account identifier as defined in <see cref="Microsoft.Identity.Client.AccountId.Identifier"/>.</returns>
         public static string GetMsalAccountId(this ClaimsPrincipal claimsPrincipal)
         {
             string userObjectId = claimsPrincipal.GetObjectId();
@@ -40,11 +40,11 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Gets the unique object ID associated with the <see cref="ClaimsPrincipal"/>
+        /// Gets the unique object ID associated with the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the unique object ID</param>
-        /// <remarks>This method returns the object ID both in case the developer has enabled or not claims mapping</remarks>
-        /// <returns>Unique object ID of the identity, or <c>null</c> if it cannot be found</returns>
+        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the unique object ID.</param>
+        /// <remarks>This method returns the object ID both in case the developer has enabled or not claims mapping.</remarks>
+        /// <returns>Unique object ID of the identity, or <c>null</c> if it cannot be found.</returns>
         public static string GetObjectId(this ClaimsPrincipal claimsPrincipal)
         {
             string userObjectId = claimsPrincipal.FindFirstValue(ClaimConstants.Oid);
@@ -52,15 +52,16 @@ namespace Microsoft.Identity.Web
             {
                 userObjectId = claimsPrincipal.FindFirstValue(ClaimConstants.ObjectId);
             }
+
             return userObjectId;
         }
 
         /// <summary>
-        /// Gets the Tenant ID associated with the <see cref="ClaimsPrincipal"/>
+        /// Gets the Tenant ID associated with the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the tenant ID</param>
-        /// <returns>Tenant ID of the identity, or <c>null</c> if it cannot be found</returns>
-        /// <remarks>This method returns the tenant ID both in case the developer has enabled or not claims mapping</remarks>
+        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the tenant ID.</param>
+        /// <returns>Tenant ID of the identity, or <c>null</c> if it cannot be found.</returns>
+        /// <remarks>This method returns the tenant ID both in case the developer has enabled or not claims mapping.</remarks>
         public static string GetTenantId(this ClaimsPrincipal claimsPrincipal)
         {
             string tenantId = claimsPrincipal.FindFirstValue(ClaimConstants.Tid);
@@ -73,20 +74,20 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Gets the login-hint associated with a <see cref="ClaimsPrincipal"/>
+        /// Gets the login-hint associated with a <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">Identity for which to complete the login-hint</param>
-        /// <returns>login-hint for the identity, or <c>null</c> if it cannot be found</returns>
+        /// <param name="claimsPrincipal">Identity for which to complete the login-hint.</param>
+        /// <returns>login-hint for the identity, or <c>null</c> if it cannot be found.</returns>
         public static string GetLoginHint(this ClaimsPrincipal claimsPrincipal)
         {
             return GetDisplayName(claimsPrincipal);
         }
 
         /// <summary>
-        /// Gets the domain-hint associated with an identity
+        /// Gets the domain-hint associated with an identity.
         /// </summary>
-        /// <param name="claimsPrincipal">Identity for which to compute the domain-hint</param>
-        /// <returns>domain-hint for the identity, or <c>null</c> if it cannot be found</returns>
+        /// <param name="claimsPrincipal">Identity for which to compute the domain-hint.</param>
+        /// <returns>domain-hint for the identity, or <c>null</c> if it cannot be found.</returns>
         public static string GetDomainHint(this ClaimsPrincipal claimsPrincipal)
         {
             // Tenant for MSA accounts
@@ -101,12 +102,12 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Get the display name for the signed-in user, from the <see cref="ClaimsPrincipal"/>
+        /// Get the display name for the signed-in user, from the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">Claims about the user/account</param>
+        /// <param name="claimsPrincipal">Claims about the user/account.</param>
         /// <returns>A string containing the display name for the user, as determined by Azure AD (v1.0) and Microsoft identity platform (v2.0) tokens,
-        /// or <c>null</c> if the claims cannot be found</returns>
-        /// <remarks>See https://docs.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims </remarks>
+        /// or <c>null</c> if the claims cannot be found.</returns>
+        /// <remarks>See https://docs.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims. </remarks>
         public static string GetDisplayName(this ClaimsPrincipal claimsPrincipal)
         {
             // Use the claims in a Microsoft identity platform token first
@@ -130,10 +131,10 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Gets the user flow id associated with the <see cref="ClaimsPrincipal"/>
+        /// Gets the user flow id associated with the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the user flow id</param>
-        /// <returns>User Flow Id of the identity, or <c>null</c> if it cannot be found</returns>
+        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the user flow id.</param>
+        /// <returns>User Flow Id of the identity, or <c>null</c> if it cannot be found.</returns>
         public static string GetUserFlowId(this ClaimsPrincipal claimsPrincipal)
         {
             string userFlowId = claimsPrincipal.FindFirstValue(ClaimConstants.Tfp);
@@ -146,10 +147,10 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Gets the NameIdentifierId associated with the <see cref="ClaimsPrincipal"/>
+        /// Gets the NameIdentifierId associated with the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the sub claim</param>
-        /// <returns>Name identifier ID (sub) of the identity, or <c>null</c> if it cannot be found</returns>
+        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the sub claim.</param>
+        /// <returns>Name identifier ID (sub) of the identity, or <c>null</c> if it cannot be found.</returns>
         public static string GetNameIdentifierId(this ClaimsPrincipal claimsPrincipal)
         {
             return claimsPrincipal.FindFirstValue(ClaimConstants.UniqueObjectIdentifier);

--- a/src/Microsoft.Identity.Web/ClaimsPrincipalFactory.cs
+++ b/src/Microsoft.Identity.Web/ClaimsPrincipalFactory.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Identity.Web
         /// Instantiate a ClaimsPrincipal from an account objectId and tenantId. This can
         /// be useful when the Web app subscribes to another service on behalf of the user
         /// and then is called back by a notification where the user is identified by his tenant
-        /// id and object id (like in Microsoft Graph Web Hooks)
+        /// id and object id (like in Microsoft Graph Web Hooks).
         /// </summary>
-        /// <param name="tenantId">Tenant Id of the account</param>
-        /// <param name="objectId">Object Id of the account in this tenant ID</param>
-        /// <returns>A ClaimsPrincipal containing these two claims</returns>
+        /// <param name="tenantId">Tenant Id of the account.</param>
+        /// <param name="objectId">Object Id of the account in this tenant ID.</param>
+        /// <returns>A ClaimsPrincipal containing these two claims.</returns>
         ///
         /// <example>
         /// <code>
@@ -39,10 +39,8 @@ namespace Microsoft.Identity.Web
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimConstants.Tid, tenantId),
-                    new Claim(ClaimConstants.Oid, objectId)
-                })
-            );
+                    new Claim(ClaimConstants.Oid, objectId),
+                }));
         }
-
     }
 }

--- a/src/Microsoft.Identity.Web/ClientInfo.cs
+++ b/src/Microsoft.Identity.Web/ClientInfo.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace Microsoft.Identity.Web
 {

--- a/src/Microsoft.Identity.Web/CookiePolicyOptionsExtensions.cs
+++ b/src/Microsoft.Identity.Web/CookiePolicyOptionsExtensions.cs
@@ -1,20 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using System;
 
 namespace Microsoft.Identity.Web
 {
     /// <summary>
-    /// Extension class containing cookie policies (work around for same site)
+    /// Extension class containing cookie policies (work around for same site).
     /// </summary>
     public static class CookiePolicyOptionsExtensions
     {
         /// <summary>
         /// Handles SameSite cookie issue according to the https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1.
-        /// The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+        /// The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
@@ -25,10 +25,10 @@ namespace Microsoft.Identity.Web
 
         /// <summary>
         /// Handles SameSite cookie issue according to the docs: https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
-        /// The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+        /// The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
         /// </summary>
         /// <param name="options"></param>
-        /// <param name="disallowsSameSiteNone">If you dont want to use the default user-agent list implementation, the method sent in this parameter will be run against the user-agent and if returned true, SameSite value will be set to Unspecified. The default user-agent list used can be found at: https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/</param>
+        /// <param name="disallowsSameSiteNone">If you dont want to use the default user-agent list implementation, the method sent in this parameter will be run against the user-agent and if returned true, SameSite value will be set to Unspecified. The default user-agent list used can be found at: https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.</param>
         /// <returns></returns>
         public static CookiePolicyOptions HandleSameSiteCookieCompatibility(this CookiePolicyOptions options, Func<string, bool> disallowsSameSiteNone)
         {
@@ -53,10 +53,10 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="userAgent"></param>
-        /// <remarks>Method taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/</remarks>
+        /// <remarks>Method taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.</remarks>
         /// <returns></returns>
         public static bool DisallowsSameSiteNone(string userAgent)
         {
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Web
                 return true;
             }
 
-            // Cover Mac OS X based browsers that use the Mac OS networking stack. 
+            // Cover Mac OS X based browsers that use the Mac OS networking stack.
             // This includes:
             // - Safari on Mac OS X.
             // This does not include:
@@ -84,9 +84,9 @@ namespace Microsoft.Identity.Web
                 return true;
             }
 
-            // Cover Chrome 50-69, because some versions are broken by SameSite=None, 
+            // Cover Chrome 50-69, because some versions are broken by SameSite=None,
             // and none in this range require it.
-            // Note: this covers some pre-Chromium Edge versions, 
+            // Note: this covers some pre-Chromium Edge versions,
             // but pre-Chromium Edge does not require SameSite=None.
             if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
             {

--- a/src/Microsoft.Identity.Web/Extensions.cs
+++ b/src/Microsoft.Identity.Web/Extensions.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Identity.Web
 {
     /// <summary>
-    /// Extension methods
+    /// Extension methods.
     /// </summary>
     internal static class Extensions
     {
@@ -18,7 +18,9 @@ namespace Microsoft.Identity.Web
             foreach (string str in stringCollection)
             {
                 if (searchFor.Contains(str))
+                {
                     return true;
+                }
             }
 
             return false;

--- a/src/Microsoft.Identity.Web/GlobalSuppressions.cs
+++ b/src/Microsoft.Identity.Web/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "not applicable", Scope = "member", Target = "~F:Microsoft.Identity.Web.Resource.OpenIdConnectMiddlewareDiagnostics.s_onRedirectToIdentityProvider")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1308:Variable names should not be prefixed", Justification = "not applicable", Scope = "member", Target = "~F:Microsoft.Identity.Web.Resource.OpenIdConnectMiddlewareDiagnostics.s_onRedirectToIdentityProvider")]

--- a/src/Microsoft.Identity.Web/HttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/HttpContextExtensions.cs
@@ -1,29 +1,29 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Http;
 using System.IdentityModel.Tokens.Jwt;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.Identity.Web
 {
     internal static class HttpContextExtensions
     {
         /// <summary>
-        /// Keep the validated token associated with the Http request
+        /// Keep the validated token associated with the Http request.
         /// </summary>
-        /// <param name="httpContext">Http context</param>
+        /// <param name="httpContext">Http context.</param>
         /// <param name="token">Token to preserve after the token is validated so that
-        /// it can be used in the actions</param>
+        /// it can be used in the actions.</param>
         internal static void StoreTokenUsedToCallWebAPI(this HttpContext httpContext, JwtSecurityToken token)
         {
             httpContext.Items.Add("JwtSecurityTokenUsedToCallWebAPI", token);
         }
 
         /// <summary>
-        /// Get the parsed information about the token used to call the Web API
+        /// Get the parsed information about the token used to call the Web API.
         /// </summary>
-        /// <param name="httpContext">Http context associated with the current request</param>
-        /// <returns><see cref="JwtSecurityToken"/> used to call the Web API</returns>
+        /// <param name="httpContext">Http context associated with the current request.</param>
+        /// <returns><see cref="JwtSecurityToken"/> used to call the Web API.</returns>
         internal static JwtSecurityToken GetTokenUsedToCallWebAPI(this HttpContext httpContext)
         {
             return httpContext.Items["JwtSecurityTokenUsedToCallWebAPI"] as JwtSecurityToken;

--- a/src/Microsoft.Identity.Web/ITokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/ITokenAcquisition.cs
@@ -1,29 +1,27 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Identity.Client;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web
 {
     /// <summary>
-    /// Interface for the token acquisition service (encapsultating MSAL.NET)
+    /// Interface for the token acquisition service (encapsulating MSAL.NET).
     /// </summary>
     public interface ITokenAcquisition
     {
         /// <summary>
-        /// Typically used from an ASP.NET Core Web App or Web API controller, this method gets an access token 
+        /// Typically used from an ASP.NET Core Web App or Web API controller, this method gets an access token
         /// for a downstream API on behalf of the user account which claims are provided in the <see cref="HttpContext.User"/>
-        /// member of the controller's <see cref="HttpContext"/> parameter
+        /// member of the controller's <see cref="HttpContext"/> parameter.
         /// </summary>
-        /// <param name="scopes">Scopes to request for the downstream API to call</param>
-        /// <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the 
-        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant</param>
-        /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes</returns>
+        /// <param name="scopes">Scopes to request for the downstream API to call.</param>
+        /// <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the
+        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant.</param>
+        /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes.</returns>
         Task<string> GetAccessTokenForUserAsync(IEnumerable<string> scopes, string tenantId = null);
 
         /// <summary>
@@ -34,16 +32,16 @@ namespace Microsoft.Identity.Web
         /// should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
         /// Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
         /// in the portal, and cannot be overriden in the application.</param>
-        /// <returns>An access token for the app itself, based on its scopes</returns>
+        /// <returns>An access token for the app itself, based on its scopes.</returns>
         Task<string> GetAccessTokenForAppAsync(IEnumerable<string> scopes);
 
         /// <summary>
-        /// Used in Web APIs (which therefore cannot have an interaction with the user). 
+        /// Used in Web APIs (which therefore cannot have an interaction with the user).
         /// Replies to the client through the HttpResponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
-        /// the client can trigger an interaction with the user so the user can consent to more scopes
+        /// the client can trigger an interaction with the user so the user can consent to more scopes.
         /// </summary>
-        /// <param name="scopes">Scopes to consent to</param>
-        /// <param name="msalSeviceException"><see cref="MsalUiRequiredException"/> triggering the challenge</param>
+        /// <param name="scopes">Scopes to consent to.</param>
+        /// <param name="msalSeviceException"><see cref="MsalUiRequiredException"/> triggering the challenge.</param>
         void ReplyForbiddenWithWwwAuthenticateHeader(
             IEnumerable<string> scopes,
             MsalUiRequiredException msalSeviceException);

--- a/src/Microsoft.Identity.Web/ITokenAcquisitionInternal.cs
+++ b/src/Microsoft.Identity.Web/ITokenAcquisitionInternal.cs
@@ -1,35 +1,36 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 namespace Microsoft.Identity.Web
 {
+    /// <summary>
+    /// Interface for the internal operations of token acquisition service (encapsulating MSAL.NET).
+    /// </summary>
     internal interface ITokenAcquisitionInternal
     {
         /// <summary>
         /// In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App, when the authorization code is received (after the user
         /// signed-in and consented)
-        /// An On-behalf-of token contained in the <see cref="AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the 
+        /// An On-behalf-of token contained in the <see cref="AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the
         /// same user in order to call to downstream APIs.
         /// </summary>
         /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
-        /// <param name="scopes">Scopes to request</param>
+        /// <param name="scopes">Scopes to request.</param>
         /// <example>
-        /// From the configuration of the Authentication of the ASP.NET Core Web API: 
+        /// From the configuration of the Authentication of the ASP.NET Core Web API:
         /// <code>OpenIdConnectOptions options;</code>
-        /// 
+        ///
         /// Subscribe to the authorization code received event:
         /// <code>
         ///  options.Events = new OpenIdConnectEvents();
         ///  options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
         /// }
         /// </code>
-        /// 
+        ///
         /// And then in the OnAuthorizationCodeRecieved method, call <see cref="AddAccountToCacheFromAuthorizationCodeAsync"/>:
         /// <code>
         /// private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
@@ -42,10 +43,10 @@ namespace Microsoft.Identity.Web
         Task AddAccountToCacheFromAuthorizationCodeAsync(AuthorizationCodeReceivedContext context, IEnumerable<string> scopes);
 
         /// <summary>
-        /// Removes the account associated with context.HttpContext.User from the MSAL.NET cache
+        /// Removes the account associated with context.HttpContext.User from the MSAL.NET cache.
         /// </summary>
-        /// <param name="context">RedirectContext passed-in to a <see cref="OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/> 
-        /// Openidconnect event</param>
+        /// <param name="context">RedirectContext passed-in to a <see cref="OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/>
+        /// Openidconnect event.</param>
         /// <returns></returns>
         Task RemoveAccountAsync(RedirectContext context);
     }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerConfigurationRetriever.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerConfigurationRetriever.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Identity.Web.InstanceDiscovery
 {
     /// <summary>
-    /// An implementation of IConfigurationRetriever geared towards Azure AD issuers metadata />
+    /// An implementation of IConfigurationRetriever geared towards Azure AD issuers metadata />.
     /// </summary>
     internal class IssuerConfigurationRetriever : IConfigurationRetriever<IssuerMetadata>
     {
@@ -21,14 +21,18 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         /// <returns></returns>
         /// <exception cref="ArgumentNullException">address - Azure AD Issuer metadata address url is required
         /// or
-        /// retriever - No metadata document retriever is provided</exception>
+        /// retriever - No metadata document retriever is provided.</exception>
         public async Task<IssuerMetadata> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancel)
         {
             if (string.IsNullOrEmpty(address))
+            {
                 throw new ArgumentNullException(nameof(address), $"Azure AD Issuer metadata address url is required");
+            }
 
             if (retriever == null)
+            {
                 throw new ArgumentNullException(nameof(retriever), $"No metadata document retriever is provided");
+            }
 
             string doc = await retriever.GetDocumentAsync(address, cancel).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<IssuerMetadata>(doc);

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerMetadata.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerMetadata.cs
@@ -7,24 +7,24 @@ using Newtonsoft.Json;
 namespace Microsoft.Identity.Web.InstanceDiscovery
 {
     /// <summary>
-    /// Model class to hold information parsed from the Azure AD issuer endpoint
+    /// Model class to hold information parsed from the Azure AD issuer endpoint.
     /// </summary>
     internal class IssuerMetadata
     {
         /// <summary>
-        /// Tenant discovery endpoint
+        /// Tenant discovery endpoint.
         /// </summary>
         [JsonProperty(PropertyName = "tenant_discovery_endpoint")]
         public string TenantDiscoveryEndpoint { get; set; }
 
         /// <summary>
-        /// API Version
+        /// API Version.
         /// </summary>
         [JsonProperty(PropertyName = "api-version")]
         public string ApiVersion { get; set; }
 
         /// <summary>
-        /// List of metadata associated with the endpoint
+        /// List of metadata associated with the endpoint.
         /// </summary>
         [JsonProperty(PropertyName = "metadata")]
         public List<Metadata> Metadata { get; set; }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/Metadata.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/Metadata.cs
@@ -12,20 +12,20 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
     internal class Metadata
     {
         /// <summary>
-        /// Preferred alias
+        /// Preferred alias.
         /// </summary>
         [JsonProperty(PropertyName = "preferred_network")]
         public string PreferredNetwork { get; set; }
 
         /// <summary>
         /// Preferred alias to cache tokens emitted by one of the aliases (to avoid
-        /// SSO islands)
+        /// SSO islands).
         /// </summary>
         [JsonProperty(PropertyName = "preferred_cache")]
         public string PreferredCache { get; set; }
 
         /// <summary>
-        /// Aliases of issuer URLs which are equivalent
+        /// Aliases of issuer URLs which are equivalent.
         /// </summary>
         [JsonProperty(PropertyName = "aliases")]
         public List<string> Aliases { get; set; }

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -33,6 +33,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
@@ -70,6 +74,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.13.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
 </Project>

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 namespace Microsoft.Identity.Web
 {
     /// <summary>
-    /// Options for configuring authentication using Azure Active Directory. It has both AAD and B2C configuration attributes
+    /// Options for configuring authentication using Azure Active Directory. It has both AAD and B2C configuration attributes.
     /// </summary>
     public class MicrosoftIdentityOptions : OpenIdConnectOptions
     {
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Web
         public string DefaultUserFlow => SignUpSignInPolicyId;
 
         /// <summary>
-        /// Is considered B2C if the attribute SignUpSignInPolicyId is defined
+        /// Is considered B2C if the attribute SignUpSignInPolicyId is defined.
         /// </summary>
         internal bool IsB2C { get { return !string.IsNullOrWhiteSpace(DefaultUserFlow); } }
     }

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptionsValidation.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptionsValidation.cs
@@ -3,9 +3,6 @@
 
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Identity.Web
 {

--- a/src/Microsoft.Identity.Web/MsalAspNetCoreHttpClientFactory.cs
+++ b/src/Microsoft.Identity.Web/MsalAspNetCoreHttpClientFactory.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client;
 using System.Net.Http;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web
 {

--- a/src/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
+++ b/src/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Web.Resource
         private static readonly ConfigurationManager<IssuerMetadata> s_configManager = new ConfigurationManager<IssuerMetadata>(AzureADIssuerMetadataUrl, new IssuerConfigurationRetriever());
 
         /// <summary>
-        /// A list of all Issuers across the various Azure AD instances
+        /// A list of all Issuers across the various Azure AD instances.
         /// </summary>
         private readonly ISet<string> _issuerAliases;
 
@@ -39,13 +39,15 @@ namespace Microsoft.Identity.Web.Resource
         /// <summary>
         /// Gets an <see cref="AadIssuerValidator"/> for an authority.
         /// </summary>
-        /// <param name="aadAuthority">The authority to create the validator for, e.g. https://login.microsoftonline.com/ </param>
+        /// <param name="aadAuthority">The authority to create the validator for, e.g. https://login.microsoftonline.com/. </param>
         /// <returns>A <see cref="AadIssuerValidator"/> for the aadAuthority.</returns>
         /// <exception cref="ArgumentNullException">if <paramref name="aadAuthority"/> is null or empty.</exception>
         public static AadIssuerValidator GetIssuerValidator(string aadAuthority)
         {
             if (string.IsNullOrEmpty(aadAuthority))
+            {
                 throw new ArgumentNullException(nameof(aadAuthority));
+            }
 
             Uri.TryCreate(aadAuthority, UriKind.Absolute, out Uri authorityUri);
             string authorityHost = authorityUri?.Authority ?? new Uri(FallbackAuthority).Authority;
@@ -71,41 +73,53 @@ namespace Microsoft.Identity.Web.Resource
 
         /// <summary>
         /// Validate the issuer for multi-tenant applications of various audience (Work and School account, or Work and School accounts +
-        /// Personal accounts)
+        /// Personal accounts).
         /// </summary>
-        /// <param name="actualIssuer">Issuer to validate (will be tenanted)</param>
-        /// <param name="securityToken">Received Security Token</param>
-        /// <param name="validationParameters">Token Validation parameters</param>
+        /// <param name="actualIssuer">Issuer to validate (will be tenanted).</param>
+        /// <param name="securityToken">Received Security Token.</param>
+        /// <param name="validationParameters">Token Validation parameters.</param>
         /// <remarks>The issuer is considered as valid if it has the same HTTP scheme and authority as the
         /// authority from the configuration file, has a tenant ID, and optionally v2.0 (this web API
         /// accepts both V1 and V2 tokens).
-        /// Authority aliasing is also taken into account</remarks>
-        /// <returns>The <c>issuer</c> if it's valid, or otherwise <c>SecurityTokenInvalidIssuerException</c> is thrown</returns>
+        /// Authority aliasing is also taken into account.</remarks>
+        /// <returns>The <c>issuer</c> if it's valid, or otherwise <c>SecurityTokenInvalidIssuerException</c> is thrown.</returns>
         /// <exception cref="ArgumentNullException"> if <paramref name="securityToken"/> is null.</exception>
         /// <exception cref="ArgumentNullException"> if <paramref name="validationParameters"/> is null.</exception>
-        /// <exception cref="SecurityTokenInvalidIssuerException">if the issuer </exception>
+        /// <exception cref="SecurityTokenInvalidIssuerException">if the issuer. </exception>
         public string Validate(string actualIssuer, SecurityToken securityToken, TokenValidationParameters validationParameters)
         {
             if (string.IsNullOrEmpty(actualIssuer))
+            {
                 throw new ArgumentNullException(nameof(actualIssuer));
+            }
 
             if (securityToken == null)
+            {
                 throw new ArgumentNullException(nameof(securityToken));
+            }
 
             if (validationParameters == null)
+            {
                 throw new ArgumentNullException(nameof(validationParameters));
+            }
 
             string tenantId = GetTenantIdFromToken(securityToken);
             if (string.IsNullOrWhiteSpace(tenantId))
+            {
                 throw new SecurityTokenInvalidIssuerException("Neither `tid` nor `tenantId` claim is present in the token obtained from Microsoft identity platform.");
+            }
 
             if (validationParameters.ValidIssuers != null)
                 foreach (var validIssuerTemplate in validationParameters.ValidIssuers)
                     if (IsValidIssuer(validIssuerTemplate, tenantId, actualIssuer))
+                    {
                         return actualIssuer;
+                    }
 
             if (IsValidIssuer(validationParameters.ValidIssuer, tenantId, actualIssuer))
+            {
                 return actualIssuer;
+            }
 
             // If a valid issuer is not found, throw
             // brentsch - todo, create a list of all the possible valid issuers in TokenValidationParameters
@@ -115,7 +129,9 @@ namespace Microsoft.Identity.Web.Resource
         private bool IsValidIssuer(string validIssuerTemplate, string tenantId, string actualIssuer)
         {
             if (string.IsNullOrEmpty(validIssuerTemplate))
+            {
                 return false;
+            }
 
             try
             {
@@ -154,7 +170,9 @@ namespace Microsoft.Identity.Web.Resource
             if (securityToken is JwtSecurityToken jwtSecurityToken)
             {
                 if (jwtSecurityToken.Payload.TryGetValue(ClaimConstants.Tid, out object tenantId))
+                {
                     return tenantId as string;
+                }
 
                 // Since B2C doesn't have "tid" as default, get it from issuer
                 return GetTenantIdFromIss(jwtSecurityToken.Issuer);
@@ -164,7 +182,9 @@ namespace Microsoft.Identity.Web.Resource
             {
                 jsonWebToken.TryGetPayloadValue(ClaimConstants.Tid, out string tid);
                 if (tid != null)
+                {
                     return tid;
+                }
 
                 // Since B2C doesn't have "tid" as default, get it from issuer
                 return GetTenantIdFromIss(jsonWebToken.Issuer);
@@ -177,7 +197,9 @@ namespace Microsoft.Identity.Web.Resource
         private static string GetTenantIdFromIss(string iss)
         {
             if (string.IsNullOrEmpty(iss))
+            {
                 return string.Empty;
+            }
 
             var uri = new Uri(iss);
 

--- a/src/Microsoft.Identity.Web/Resource/IJwtBearerMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/IJwtBearerMiddlewareDiagnostics.cs
@@ -6,15 +6,15 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 namespace Microsoft.Identity.Web.Resource
 {
     /// <summary>
-    /// Interface implemented by diagnostics for the JwtBearer middleware
+    /// Interface implemented by diagnostics for the JwtBearer middleware.
     /// </summary>
     public interface IJwtBearerMiddlewareDiagnostics
     {
         /// <summary>
-        /// Called to subscribe to JwtBearerEvents
+        /// Called to subscribe to JwtBearerEvents.
         /// </summary>
-        /// <param name="events">JwtBearer events</param>
-        /// <returns>the events (for chaining)</returns>
+        /// <param name="events">JwtBearer events.</param>
+        /// <returns>the events (for chaining).</returns>
         JwtBearerEvents Subscribe(JwtBearerEvents events);
     }
 }

--- a/src/Microsoft.Identity.Web/Resource/IOpenIdConnectMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/IOpenIdConnectMiddlewareDiagnostics.cs
@@ -7,14 +7,14 @@ namespace Microsoft.Identity.Web.Resource
 {
     /// <summary>
     /// Diagnostics used in the Open Id Connect middleware
-    /// (used in Web Apps)
+    /// (used in Web Apps).
     /// </summary>
     public interface IOpenIdConnectMiddlewareDiagnostics
     {
         /// <summary>
-        /// Method to subscribe to OpenIDConnect events
+        /// Method to subscribe to OpenIDConnect events.
         /// </summary>
-        /// <param name="events">Open Id connect events</param>
+        /// <param name="events">Open Id connect events.</param>
         void Subscribe(OpenIdConnectEvents events);
     }
 }

--- a/src/Microsoft.Identity.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Identity.Web.Resource
 {
     /// <summary>
-    /// Diagnostics for the JwtBearer middleware (used in Web APIs)
+    /// Diagnostics for the JwtBearer middleware (used in Web APIs).
     /// </summary>
     public class JwtBearerMiddlewareDiagnostics : IJwtBearerMiddlewareDiagnostics
     {
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Web.Resource
         /// Constructor for a <see cref="JwtBearerMiddlewareDiagnostics"/>. This constructor
         /// is used by dependency injection.
         /// </summary>
-        /// <param name="logger">Logger</param>
+        /// <param name="logger">Logger.</param>
         public JwtBearerMiddlewareDiagnostics(ILogger<JwtBearerMiddlewareDiagnostics> logger)
         {
             _logger = logger;
@@ -47,9 +47,9 @@ namespace Microsoft.Identity.Web.Resource
 
         /// <summary>
         /// Subscribes to all the JwtBearer events, to help debugging, while
-        /// preserving the previous handlers (which are called)
+        /// preserving the previous handlers (which are called).
         /// </summary>
-        /// <param name="events">Events to subscribe to</param>
+        /// <param name="events">Events to subscribe to.</param>
         public JwtBearerEvents Subscribe(JwtBearerEvents events)
         {
             if (events == null)
@@ -75,6 +75,7 @@ namespace Microsoft.Identity.Web.Resource
         private async Task OnMessageReceivedAsync(MessageReceivedContext context)
         {
             _logger.LogDebug($"1. Begin {nameof(OnMessageReceivedAsync)}");
+
             // Place a breakpoint here and examine the bearer token (context.Request.Headers.HeaderAuthorization / context.Request.Headers["Authorization"])
             // Use https://jwt.ms to decode the token and observe claims
             await s_onMessageReceived(context).ConfigureAwait(false);
@@ -84,6 +85,7 @@ namespace Microsoft.Identity.Web.Resource
         private async Task OnAuthenticationFailedAsync(AuthenticationFailedContext context)
         {
             _logger.LogDebug($"99. Begin {nameof(OnAuthenticationFailedAsync)}");
+
             // Place a breakpoint here and examine context.Exception
             await s_onAuthenticationFailed(context).ConfigureAwait(false);
             _logger.LogDebug($"99. End - {nameof(OnAuthenticationFailedAsync)}");

--- a/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Web.Resource
 {
     /// <summary>
     /// Diagnostics used in the Open Id Connect middleware
-    /// (used in Web Apps)
+    /// (used in Web Apps).
     /// </summary>
     public class OpenIdConnectMiddlewareDiagnostics : IOpenIdConnectMiddlewareDiagnostics
     {
@@ -19,15 +19,14 @@ namespace Microsoft.Identity.Web.Resource
 
         /// <summary>
         /// Constructor of the <see cref="OpenIdConnectMiddlewareDiagnostics"/>, used
-        /// by dependency injection
+        /// by dependency injection.
         /// </summary>
-        /// <param name="logger">Logger used to log the diagnostics</param>
+        /// <param name="logger">Logger used to log the diagnostics.</param>
         public OpenIdConnectMiddlewareDiagnostics(ILogger<OpenIdConnectMiddlewareDiagnostics> logger)
         {
             _logger = logger;
         }
 
-        //
         // Summary:
         //     Invoked before redirecting to the identity provider to authenticate. This can
         //     be used to set ProtocolMessage.State that will be persisted through the authentication
@@ -35,60 +34,50 @@ namespace Microsoft.Identity.Web.Resource
         //     sent to the identity provider.
         private Func<RedirectContext, Task> s_onRedirectToIdentityProvider;
 
-        //
         // Summary:
         //     Invoked when a protocol message is first received.
         private Func<MessageReceivedContext, Task> s_onMessageReceived;
 
-        //
         // Summary:
         //     Invoked after security token validation if an authorization code is present in
         //     the protocol message.
         private Func<AuthorizationCodeReceivedContext, Task> s_onAuthorizationCodeReceived;
 
-        //
         // Summary:
         //     Invoked after "authorization code" is redeemed for tokens at the token endpoint.
         private Func<TokenResponseReceivedContext, Task> s_onTokenResponseReceived;
 
-        //
         // Summary:
         //     Invoked when an IdToken has been validated and produced an AuthenticationTicket.
         private Func<TokenValidatedContext, Task> s_onTokenValidated;
 
-        //
         // Summary:
         //     Invoked when user information is retrieved from the UserInfoEndpoint.
         private Func<UserInformationReceivedContext, Task> s_onUserInformationReceived;
 
-        //
         // Summary:
         //     Invoked if exceptions are thrown during request processing. The exceptions will
         //     be re-thrown after this event unless suppressed.
         private Func<AuthenticationFailedContext, Task> s_onAuthenticationFailed;
 
-        //
         // Summary:
         //     Invoked when a request is received on the RemoteSignOutPath.
         private Func<RemoteSignOutContext, Task> s_onRemoteSignOut;
 
-        //
         // Summary:
         //     Invoked before redirecting to the identity provider to sign out.
         private Func<RedirectContext, Task> s_onRedirectToIdentityProviderForSignOut;
 
-        //
         // Summary:
         //     Invoked before redirecting to the Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.SignedOutRedirectUri
         //     at the end of a remote sign-out flow.
         private Func<RemoteSignOutContext, Task> s_onSignedOutCallbackRedirect;
 
-
         /// <summary>
         /// Subscribes to all the OpenIdConnect events, to help debugging, while
-        /// preserving the previous handlers (which are called)
+        /// preserving the previous handlers (which are called).
         /// </summary>
-        /// <param name="events">Events to subscribe to</param>
+        /// <param name="events">Events to subscribe to.</param>
         public void Subscribe(OpenIdConnectEvents events)
         {
             s_onRedirectToIdentityProvider = events.OnRedirectToIdentityProvider;
@@ -124,13 +113,13 @@ namespace Microsoft.Identity.Web.Resource
 
         private async Task OnRedirectToIdentityProviderAsync(RedirectContext context)
         {
-             _logger.LogDebug($"1. Begin {nameof(OnRedirectToIdentityProviderAsync)}");
+            _logger.LogDebug($"1. Begin {nameof(OnRedirectToIdentityProviderAsync)}");
 
             await s_onRedirectToIdentityProvider(context).ConfigureAwait(false);
 
-             _logger.LogDebug("   Sending OpenIdConnect message:");
+            _logger.LogDebug("   Sending OpenIdConnect message:");
             DisplayProtocolMessage(context.ProtocolMessage);
-             _logger.LogDebug($"1. End - {nameof(OnRedirectToIdentityProviderAsync)}");
+            _logger.LogDebug($"1. End - {nameof(OnRedirectToIdentityProviderAsync)}");
         }
 
         private void DisplayProtocolMessage(OpenIdConnectMessage message)
@@ -140,74 +129,74 @@ namespace Microsoft.Identity.Web.Resource
                 object value = property.GetValue(message);
                 if (value != null)
                 {
-                     _logger.LogDebug($"   - {property.Name}={value}");
+                    _logger.LogDebug($"   - {property.Name}={value}");
                 }
             }
         }
 
         private async Task OnMessageReceivedAsync(MessageReceivedContext context)
         {
-             _logger.LogDebug($"2. Begin {nameof(OnMessageReceivedAsync)}");
-             _logger.LogDebug("   Received from STS the OpenIdConnect message:");
+            _logger.LogDebug($"2. Begin {nameof(OnMessageReceivedAsync)}");
+            _logger.LogDebug("   Received from STS the OpenIdConnect message:");
             DisplayProtocolMessage(context.ProtocolMessage);
             await s_onMessageReceived(context).ConfigureAwait(false);
-             _logger.LogDebug($"2. End - {nameof(OnMessageReceivedAsync)}");
+            _logger.LogDebug($"2. End - {nameof(OnMessageReceivedAsync)}");
         }
 
         private async Task OnAuthorizationCodeReceivedAsync(AuthorizationCodeReceivedContext context)
         {
-             _logger.LogDebug($"4. Begin {nameof(OnAuthorizationCodeReceivedAsync)}");
+            _logger.LogDebug($"4. Begin {nameof(OnAuthorizationCodeReceivedAsync)}");
             await s_onAuthorizationCodeReceived(context).ConfigureAwait(false);
-             _logger.LogDebug($"4. End - {nameof(OnAuthorizationCodeReceivedAsync)}");
+            _logger.LogDebug($"4. End - {nameof(OnAuthorizationCodeReceivedAsync)}");
         }
 
         private async Task OnTokenResponseReceivedAsync(TokenResponseReceivedContext context)
         {
-             _logger.LogDebug($"5. Begin {nameof(OnTokenResponseReceivedAsync)}");
+            _logger.LogDebug($"5. Begin {nameof(OnTokenResponseReceivedAsync)}");
             await s_onTokenResponseReceived(context).ConfigureAwait(false);
-             _logger.LogDebug($"5. End - {nameof(OnTokenResponseReceivedAsync)}");
+            _logger.LogDebug($"5. End - {nameof(OnTokenResponseReceivedAsync)}");
         }
 
         private async Task OnTokenValidatedAsync(TokenValidatedContext context)
         {
-             _logger.LogDebug($"3. Begin {nameof(OnTokenValidatedAsync)}");
+            _logger.LogDebug($"3. Begin {nameof(OnTokenValidatedAsync)}");
             await s_onTokenValidated(context).ConfigureAwait(false);
-             _logger.LogDebug($"3. End - {nameof(OnTokenValidatedAsync)}");
+            _logger.LogDebug($"3. End - {nameof(OnTokenValidatedAsync)}");
         }
 
         private async Task OnUserInformationReceivedAsync(UserInformationReceivedContext context)
         {
-             _logger.LogDebug($"6. Begin {nameof(OnUserInformationReceivedAsync)}");
+            _logger.LogDebug($"6. Begin {nameof(OnUserInformationReceivedAsync)}");
             await s_onUserInformationReceived(context).ConfigureAwait(false);
-             _logger.LogDebug($"6. End - {nameof(OnUserInformationReceivedAsync)}");
+            _logger.LogDebug($"6. End - {nameof(OnUserInformationReceivedAsync)}");
         }
 
         private async Task OnAuthenticationFailedAsync(AuthenticationFailedContext context)
         {
-             _logger.LogDebug($"99. Begin {nameof(OnAuthenticationFailedAsync)}");
+            _logger.LogDebug($"99. Begin {nameof(OnAuthenticationFailedAsync)}");
             await s_onAuthenticationFailed(context).ConfigureAwait(false);
-             _logger.LogDebug($"99. End - {nameof(OnAuthenticationFailedAsync)}");
+            _logger.LogDebug($"99. End - {nameof(OnAuthenticationFailedAsync)}");
         }
 
         private async Task OnRedirectToIdentityProviderForSignOutAsync(RedirectContext context)
         {
-             _logger.LogDebug($"10. Begin {nameof(OnRedirectToIdentityProviderForSignOutAsync)}");
+            _logger.LogDebug($"10. Begin {nameof(OnRedirectToIdentityProviderForSignOutAsync)}");
             await s_onRedirectToIdentityProviderForSignOut(context).ConfigureAwait(false);
-             _logger.LogDebug($"10. End - {nameof(OnRedirectToIdentityProviderForSignOutAsync)}");
+            _logger.LogDebug($"10. End - {nameof(OnRedirectToIdentityProviderForSignOutAsync)}");
         }
 
         private async Task OnRemoteSignOutAsync(RemoteSignOutContext context)
         {
-             _logger.LogDebug($"11. Begin {nameof(OnRemoteSignOutAsync)}");
+            _logger.LogDebug($"11. Begin {nameof(OnRemoteSignOutAsync)}");
             await s_onRemoteSignOut(context).ConfigureAwait(false);
-             _logger.LogDebug($"11. End - {nameof(OnRemoteSignOutAsync)}");
+            _logger.LogDebug($"11. End - {nameof(OnRemoteSignOutAsync)}");
         }
 
         private async Task OnSignedOutCallbackRedirectAsync(RemoteSignOutContext context)
         {
-             _logger.LogDebug($"12. Begin {nameof(OnSignedOutCallbackRedirectAsync)}");
+            _logger.LogDebug($"12. Begin {nameof(OnSignedOutCallbackRedirectAsync)}");
             await s_onSignedOutCallbackRedirect(context).ConfigureAwait(false);
-             _logger.LogDebug($"12. End {nameof(OnSignedOutCallbackRedirectAsync)}");
+            _logger.LogDebug($"12. End {nameof(OnSignedOutCallbackRedirectAsync)}");
         }
     }
 }

--- a/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
-using Microsoft.AspNetCore.Http;
 using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.Identity.Web.Resource
 {
@@ -18,13 +18,13 @@ namespace Microsoft.Identity.Web.Resource
     {
         /// <summary>
         /// When applied to an <see cref="HttpContext"/>, verifies that the user authenticated in the
-        /// web API has any of the accepted scopes. 
+        /// web API has any of the accepted scopes.
         /// If the authenticated user does not have any of these <paramref name="acceptedScopes"/>, the
-        /// method throws an HTTP Unauthorized with the message telling which scopes are expected in the token
+        /// method throws an HTTP Unauthorized with the message telling which scopes are expected in the token.
         /// </summary>
-        /// <param name="context">HttpContext (from the controller)</param>
-        /// <param name="acceptedScopes">Scopes accepted by this web API</param>
-        /// <exception cref="HttpRequestException"/> with a <see cref="HttpResponse.StatusCode"/> set to 
+        /// <param name="context">HttpContext (from the controller).</param>
+        /// <param name="acceptedScopes">Scopes accepted by this web API.</param>
+        /// <exception cref="HttpRequestException"/> with a <see cref="HttpResponse.StatusCode"/> set to
         /// <see cref="HttpStatusCode.Unauthorized"/>
         public static void VerifyUserHasAnyAcceptedScope(this HttpContext context, params string[] acceptedScopes)
         {

--- a/src/Microsoft.Identity.Web/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/ServiceCollectionExtensions.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Add the token acquisition service.
         /// </summary>
-        /// <param name="services">Service collection</param>
-        /// <returns>the service collection</returns>
+        /// <param name="services">Service collection.</param>
+        /// <returns>the service collection.</returns>
         /// <example>
         /// This method is typically called from the Startup.ConfigureServices(IServiceCollection services)
         /// Note that the implementation of the token cache can be chosen separately.

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Web.TokenCacheProviders;
-using Microsoft.Net.Http.Headers;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -19,11 +10,20 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web.TokenCacheProviders;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.Identity.Web
 {
     /// <summary>
-    /// Token acquisition service
+    /// Token acquisition service.
     /// </summary>
     internal class TokenAcquisition : ITokenAcquisition, ITokenAcquisitionInternal
     {
@@ -41,14 +41,14 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Constructor of the TokenAcquisition service. This requires the Azure AD Options to
         /// configure the confidential client application and a token cache provider.
-        /// This constructor is called by ASP.NET Core dependency injection
+        /// This constructor is called by ASP.NET Core dependency injection.
         /// </summary>
-        /// <param name="tokenCacheProvider">The App token cache provider</param>
-        /// <param name="httpContextAccessor">Access to the HttpContext of the request</param>
-        /// <param name="microsoftIdentityOptions">Configuration options</param>
-        /// <param name="applicationOptions">MSAL.NET configuration options</param>
-        /// <param name="httpClientFactory">Http client factory</param>
-        /// <param name="logger">Logger</param>
+        /// <param name="tokenCacheProvider">The App token cache provider.</param>
+        /// <param name="httpContextAccessor">Access to the HttpContext of the request.</param>
+        /// <param name="microsoftIdentityOptions">Configuration options.</param>
+        /// <param name="applicationOptions">MSAL.NET configuration options.</param>
+        /// <param name="httpClientFactory">Http client factory.</param>
+        /// <param name="logger">Logger.</param>
         public TokenAcquisition(
             IMsalTokenCacheProvider tokenCacheProvider,
             IHttpContextAccessor httpContextAccessor,
@@ -66,13 +66,13 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Scopes which are already requested by MSAL.NET. They should not be re-requested;
+        /// Scopes which are already requested by MSAL.NET. They should not be re-requested;.
         /// </summary>
         private readonly string[] _scopesRequestedByMsal = new string[]
         {
             OidcConstants.ScopeOpenId,
             OidcConstants.ScopeProfile,
-            OidcConstants.ScopeOfflineAccess
+            OidcConstants.ScopeOfflineAccess,
         };
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.Identity.Web
         /// in order to call to downstream APIs.
         /// </summary>
         /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
-        /// <param name="scopes">scopes to request access to</param>
+        /// <param name="scopes">scopes to request access to.</param>
         /// <example>
         /// From the configuration of the Authentication of the ASP.NET Core Web API:
         /// <code>OpenIdConnectOptions options;</code>
@@ -159,18 +159,18 @@ namespace Microsoft.Identity.Web
         /// for a downstream API using;
         /// 1) the token cache (for Web Apps and Web APIs) if a token exists in the cache
         /// 2) or the <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a>
-        /// in Web APIs, for the user account that is ascertained from claims are provided in the <see cref="HttpContext.User"/> 
-        /// instance of the current HttpContext
+        /// in Web APIs, for the user account that is ascertained from claims are provided in the <see cref="HttpContext.User"/>
+        /// instance of the current HttpContext.
         /// </summary>
-        /// <param name="scopes">Scopes to request for the downstream API to call</param>
+        /// <param name="scopes">Scopes to request for the downstream API to call.</param>
         /// <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
-        /// cases where a given account is a guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in</param>
-        /// <returns>An access token to call the downstream API and populated with this downstream Api's scopes</returns>
-        /// <remarks>Calling this method from a Web API supposes that you have previously called, 
+        /// cases where a given account is a guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
+        /// <returns>An access token to call the downstream API and populated with this downstream Api's scopes.</returns>
+        /// <remarks>Calling this method from a Web API supposes that you have previously called,
         /// in a method called by JwtBearerOptions.Events.OnTokenValidated, the HttpContextExtensions.StoreTokenUsedToCallWebAPI method
         /// passing the validated token (as a JwtSecurityToken). Calling it from a Web App supposes that
         /// you have previously called AddAccountToCacheFromAuthorizationCodeAsync from a method called by
-        /// OpenIdConnectOptions.Events.OnAuthorizationCodeReceived</remarks>
+        /// OpenIdConnectOptions.Events.OnAuthorizationCodeReceived.</remarks>
         [Obsolete("This method has been deprecated, please use the GetAccessTokenForUserAsync() method instead.")]
         public async Task<string> GetAccessTokenOnBehalfOfUserAsync(
             IEnumerable<string> scopes,
@@ -184,18 +184,18 @@ namespace Microsoft.Identity.Web
         /// for a downstream API using;
         /// 1) the token cache (for Web Apps and Web APis) if a token exists in the cache
         /// 2) or the <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a>
-        /// in Web APIs, for the user account that is ascertained from claims are provided in the <see cref="HttpContext.User"/> 
-        /// instance of the current HttpContext
+        /// in Web APIs, for the user account that is ascertained from claims are provided in the <see cref="HttpContext.User"/>
+        /// instance of the current HttpContext.
         /// </summary>
-        /// <param name="scopes">Scopes to request for the downstream API to call</param>
+        /// <param name="scopes">Scopes to request for the downstream API to call.</param>
         /// <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
-        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in</param>
-        /// <returns>An access token to call the downstream API and populated with this downstream Api's scopes</returns>
-        /// <remarks>Calling this method from a Web API supposes that you have previously called, 
+        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
+        /// <returns>An access token to call the downstream API and populated with this downstream Api's scopes.</returns>
+        /// <remarks>Calling this method from a Web API supposes that you have previously called,
         /// in a method called by JwtBearerOptions.Events.OnTokenValidated, the HttpContextExtensions.StoreTokenUsedToCallWebAPI method
         /// passing the validated token (as a JwtSecurityToken). Calling it from a Web App supposes that
         /// you have previously called AddAccountToCacheFromAuthorizationCodeAsync from a method called by
-        /// OpenIdConnectOptions.Events.OnAuthorizationCodeReceived</remarks>
+        /// OpenIdConnectOptions.Events.OnAuthorizationCodeReceived.</remarks>
         public async Task<string> GetAccessTokenForUserAsync(
             IEnumerable<string> scopes,
             string tenant = null)
@@ -237,7 +237,7 @@ namespace Microsoft.Identity.Web
                     accessToken = result.AccessToken;
                 }
 
-                // Case of the Web App: we let the MsalUiRequiredException be caught by the 
+                // Case of the Web App: we let the MsalUiRequiredException be caught by the
                 // AuthorizeForScopesAttribute exception filter so that the user can consent, do 2FA, etc ...
                 else
                 {
@@ -256,7 +256,7 @@ namespace Microsoft.Identity.Web
         /// should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
         /// Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
         /// in the portal, and cannot be overriden in the application.</param>
-        /// <returns>An access token for the app itself, based on its scopes</returns>
+        /// <returns>An access token for the app itself, based on its scopes.</returns>
         public async Task<string> GetAccessTokenForAppAsync(IEnumerable<string> scopes)
         {
             if (scopes == null)
@@ -277,10 +277,10 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Removes the account associated with context.HttpContext.User from the MSAL.NET cache
+        /// Removes the account associated with context.HttpContext.User from the MSAL.NET cache.
         /// </summary>
         /// <param name="context">RedirectContext passed-in to a <see cref="OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/>
-        /// Openidconnect event</param>
+        /// Openidconnect event.</param>
         /// <returns></returns>
         public async Task RemoveAccountAsync(RedirectContext context)
         {
@@ -321,7 +321,7 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Creates an MSAL Confidential client application if needed
+        /// Creates an MSAL Confidential client application if needed.
         /// </summary>
         /// <returns></returns>
         private async Task<IConfidentialClientApplication> GetOrBuildConfidentialClientApplicationAsync()
@@ -334,12 +334,14 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Creates an MSAL Confidential client application
+        /// Creates an MSAL Confidential client application.
         /// </summary>
         private async Task<IConfidentialClientApplication> BuildConfidentialClientApplicationAsync()
         {
             if (!_applicationOptions.Instance.EndsWith("/", StringComparison.InvariantCulture))
+            {
                 _applicationOptions.Instance += "/";
+            }
 
             string authority;
             IConfidentialClientApplication app;
@@ -393,13 +395,13 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Gets an access token for a downstream API on behalf of the user described by its claimsPrincipal
+        /// Gets an access token for a downstream API on behalf of the user described by its claimsPrincipal.
         /// </summary>
         /// <param name="application"></param>
-        /// <param name="claimsPrincipal">Claims principal for the user on behalf of whom to get a token</param>
-        /// <param name="scopes">Scopes for the downstream API to call</param>
+        /// <param name="claimsPrincipal">Claims principal for the user on behalf of whom to get a token.</param>
+        /// <param name="scopes">Scopes for the downstream API to call.</param>
         /// <param name="tenant">(optional) Specific tenant for which to acquire a token to access the scopes
-        /// on behalf of the user described in the claimsPrincipal</param>
+        /// on behalf of the user described in the claimsPrincipal.</param>
         private async Task<string> GetAccessTokenOnBehalfOfUserFromCacheAsync(
             IConfidentialClientApplication application,
             ClaimsPrincipal claimsPrincipal,
@@ -420,7 +422,9 @@ namespace Microsoft.Identity.Web
                 if (!_microsoftIdentityOptions.IsB2C && account == null)
                 {
                     if (loginHint == null)
+                    {
                         throw new ArgumentNullException(nameof(loginHint));
+                    }
 
                     var accounts = await application.GetAccountsAsync().ConfigureAwait(false);
                     account = accounts.FirstOrDefault(a => a.Username == loginHint);
@@ -438,12 +442,12 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Gets an access token for a downstream API on behalf of the user which account is passed as an argument
+        /// Gets an access token for a downstream API on behalf of the user which account is passed as an argument.
         /// </summary>
         /// <param name="application"></param>
         /// <param name="account">User IAccount for which to acquire a token.
-        /// See <see cref="Microsoft.Identity.Client.AccountId.Identifier"/></param>
-        /// <param name="scopes">Scopes for the downstream API to call</param>
+        /// See <see cref="Microsoft.Identity.Client.AccountId.Identifier"/>.</param>
+        /// <param name="scopes">Scopes for the downstream API to call.</param>
         /// <param name="tenant"></param>
         private async Task<string> GetAccessTokenOnBehalfOfUserFromCacheAsync(
             IConfidentialClientApplication application,
@@ -497,10 +501,10 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Used in Web APIs (which therefore cannot have an interaction with the user).
         /// Replies to the client through the HttpResponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
-        /// the client can trigger an interaction with the user so that the user consents to more scopes
+        /// the client can trigger an interaction with the user so that the user consents to more scopes.
         /// </summary>
-        /// <param name="scopes">Scopes to consent to</param>
-        /// <param name="msalServiceException"><see cref="MsalUiRequiredException"/> triggering the challenge</param>
+        /// <param name="scopes">Scopes to consent to.</param>
+        /// <param name="msalServiceException"><see cref="MsalUiRequiredException"/> triggering the challenge.</param>
         public void ReplyForbiddenWithWwwAuthenticateHeader(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException)
         {
             // A user interaction is required, but we are in a Web API, and therefore, we need to report back to the client through a www-Authenticate header https://tools.ietf.org/html/rfc6750#section-3.1
@@ -522,7 +526,7 @@ namespace Microsoft.Identity.Web
                     { "consentUri", consentUrl },
                     { "claims", msalServiceException.Claims },
                     { "scopes", string.Join(",", scopes) },
-                    { "proposedAction", proposedAction }
+                    { "proposedAction", proposedAction },
                 };
 
             string parameterString = string.Join(", ", parameters.Select(p => $"{p.Key}=\"{p.Value}\""));
@@ -549,7 +553,7 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Gets an IAccount for the current B2C user flow in the user claims
+        /// Gets an IAccount for the current B2C user flow in the user claims.
         /// </summary>
         /// <param name="accounts"></param>
         /// <param name="userFlow"></param>
@@ -560,7 +564,9 @@ namespace Microsoft.Identity.Web
             {
                 string accountIdentifier = account.HomeAccountId.ObjectId.Split('.')[0];
                 if (accountIdentifier.EndsWith(userFlow.ToLower(CultureInfo.InvariantCulture), StringComparison.InvariantCulture))
+                {
                     return account;
+                }
             }
 
             return null;

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/DistributedTokenCacheAdapterExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/DistributedTokenCacheAdapterExtension.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 {
     /// <summary>
-    /// Extension class used to add an in-memory token cache serializer to MSAL
+    /// Extension class used to add an in-memory token cache serializer to MSAL.
     /// </summary>
     public static class DistributedTokenCacheAdapterExtension
     {

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
@@ -16,27 +15,28 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
     public class MsalDistributedTokenCacheAdapter : MsalAbstractTokenCacheProvider
     {
         /// <summary>
-        /// .NET Core Memory cache
+        /// .NET Core Memory cache.
         /// </summary>
         private readonly IDistributedCache _distributedCache;
 
         /// <summary>
-        /// Msal memory token cache options
+        /// Msal memory token cache options.
         /// </summary>
         private readonly DistributedCacheEntryOptions _cacheOptions;
 
         /// <summary>
-        /// Constructor
+        /// Initializes a new instance of the <see cref="MsalDistributedTokenCacheAdapter"/> class.
         /// </summary>
         /// <param name="microsoftIdentityOptions"></param>
         /// <param name="httpContextAccessor"></param>
         /// <param name="memoryCache"></param>
         /// <param name="cacheOptions"></param>
-        public MsalDistributedTokenCacheAdapter(IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
+        public MsalDistributedTokenCacheAdapter(
+                                            IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
                                             IHttpContextAccessor httpContextAccessor,
                                             IDistributedCache memoryCache,
-                                            IOptions<DistributedCacheEntryOptions> cacheOptions) :
-            base(microsoftIdentityOptions, httpContextAccessor)
+                                            IOptions<DistributedCacheEntryOptions> cacheOptions)
+            : base(microsoftIdentityOptions, httpContextAccessor)
         {
             _distributedCache = memoryCache;
             _cacheOptions = cacheOptions.Value;
@@ -44,34 +44,34 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 
         /// <summary>
         /// Removes a specific token cache, described by its cache key
-        /// from the distributed cache
+        /// from the distributed cache.
         /// </summary>
-        /// <param name="cacheKey">Key of the cache to remove</param>
+        /// <param name="cacheKey">Key of the cache to remove.</param>
         protected override async Task RemoveKeyAsync(string cacheKey)
         {
             await _distributedCache.RemoveAsync(cacheKey).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Read a specific token cache, described by its cache key, from the 
-        /// distributed cache
+        /// Read a specific token cache, described by its cache key, from the
+        /// distributed cache.
         /// </summary>
         /// <param name="cacheKey"></param>
         /// <returns>Read blob representing a token cache for the cache key
-        /// (account or app)</returns>
+        /// (account or app).</returns>
         protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey)
         {
             return await _distributedCache.GetAsync(cacheKey).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Writes a token cache blob to the serialization cache (by key)
+        /// Writes a token cache blob to the serialization cache (by key).
         /// </summary>
-        /// <param name="cacheKey">Cache key</param>
-        /// <param name="bytes">blob to write</param>
+        /// <param name="cacheKey">Cache key.</param>
+        /// <param name="bytes">blob to write.</param>
         protected override async Task WriteCacheBytesAsync(string cacheKey, byte[] bytes)
         {
-            await _distributedCache.SetAsync(cacheKey, bytes, _cacheOptions).ConfigureAwait(false) ;
+            await _distributedCache.SetAsync(cacheKey, bytes, _cacheOptions).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider .cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider .cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders
 {
@@ -12,14 +12,14 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
     public interface IMsalTokenCacheProvider
     {
         /// <summary>
-        /// Initializes a token cache (which can be a user token cache or an app token cache)
+        /// Initializes a token cache (which can be a user token cache or an app token cache).
         /// </summary>
-        /// <param name="tokenCache">Token cache for which to initialize the serialization</param>
+        /// <param name="tokenCache">Token cache for which to initialize the serialization.</param>
         /// <returns></returns>
         Task InitializeAsync(ITokenCache tokenCache);
 
         /// <summary>
-        /// Clear the cache
+        /// Clear the cache.
         /// </summary>
         /// <returns></returns>
         Task ClearAsync();

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/InMemoryTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/InMemoryTokenCacheProviderExtension.cs
@@ -6,13 +6,13 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
 {
     /// <summary>
-    /// Extension class used to add an in-memory token cache serializer to MSAL
+    /// Extension class used to add an in-memory token cache serializer to MSAL.
     /// </summary>
     public static class InMemoryTokenCacheProviderExtension
     {
         /// <summary>Adds both the app and per-user in-memory token caches.</summary>
         /// <param name="services">The services collection to add to.</param>
-        /// <returns>the services (for chaining)</returns>
+        /// <returns>the services (for chaining).</returns>
         public static IServiceCollection AddInMemoryTokenCaches(
             this IServiceCollection services)
         {

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheOptions.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheOptions.cs
@@ -6,10 +6,17 @@ using System;
 namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
 {
     /// <summary>
-    /// MSAL's in-memory token cache options
+    /// MSAL's in-memory token cache options.
     /// </summary>
     public class MsalMemoryTokenCacheOptions
     {
+        /// <summary>Initializes a new instance of the <see cref="MsalMemoryTokenCacheOptions"/> class.
+        /// By default, the sliding expiration is set for 14 days.</summary>
+        public MsalMemoryTokenCacheOptions()
+        {
+            SlidingExpiration = TimeSpan.FromDays(14);
+        }
+
         /// <summary>
         /// Gets or sets the value of the duration after which the cache entry will expire unless it's used
         /// This is the duration the tokens are kept in memory cache.
@@ -22,13 +29,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         {
             get;
             set;
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="MsalMemoryTokenCacheOptions"/> class.
-        /// By default, the sliding expiration is set for 14 days.</summary>
-        public MsalMemoryTokenCacheOptions()
-        {
-            SlidingExpiration = TimeSpan.FromDays(14);
         }
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheProvider.cs
@@ -16,27 +16,26 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
     public class MsalMemoryTokenCacheProvider : MsalAbstractTokenCacheProvider
     {
         /// <summary>
-        /// .NET Core Memory cache
+        /// .NET Core Memory cache.
         /// </summary>
         private readonly IMemoryCache _memoryCache;
 
         /// <summary>
-        /// Msal memory token cache options
+        /// Msal memory token cache options.
         /// </summary>
         private readonly MsalMemoryTokenCacheOptions _cacheOptions;
 
         /// <summary>
-        /// Constructor
+        /// Constructor.
         /// </summary>
-        /// <param name="microsoftIdentityOptions">Configuration options</param>
-        /// <param name="httpContextAccessor">Accessor to the HttpContext</param>
-        /// <param name="memoryCache">serialization cache</param>
-        /// <param name="cacheOptions">Memory cache options</param>
+        /// <param name="microsoftIdentityOptions">Configuration options.</param>
+        /// <param name="httpContextAccessor">Accessor to the HttpContext.</param>
+        /// <param name="memoryCache">serialization cache.</param>
+        /// <param name="cacheOptions">Memory cache options.</param>
         public MsalMemoryTokenCacheProvider(IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
                                             IHttpContextAccessor httpContextAccessor,
                                             IMemoryCache memoryCache,
-                                            IOptions<MsalMemoryTokenCacheOptions> cacheOptions) :
-            base(microsoftIdentityOptions, httpContextAccessor)
+                                            IOptions<MsalMemoryTokenCacheOptions> cacheOptions) : base(microsoftIdentityOptions, httpContextAccessor)
         {
             if (cacheOptions == null)
             {
@@ -48,9 +47,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
 
         /// <summary>
         /// Removes a token cache identitied by its key, from the serialization
-        /// cache
+        /// cache.
         /// </summary>
-        /// <param name="cacheKey">token cache key</param>
+        /// <param name="cacheKey">token cache key.</param>
         protected override Task RemoveKeyAsync(string cacheKey)
         {
             _memoryCache.Remove(cacheKey);
@@ -58,10 +57,10 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         }
 
         /// <summary>
-        /// Reads a blob from the serialization cache (identitied by its key)
+        /// Reads a blob from the serialization cache (identitied by its key).
         /// </summary>
-        /// <param name="cacheKey">Token cache key</param>
-        /// <returns>Read Bytes</returns>
+        /// <param name="cacheKey">Token cache key.</param>
+        /// <returns>Read Bytes.</returns>
         protected override Task<byte[]> ReadCacheBytesAsync(string cacheKey)
         {
             byte[] tokenCacheBytes = (byte[])_memoryCache.Get(cacheKey);
@@ -69,10 +68,10 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         }
 
         /// <summary>
-        /// Writes a token cache blob to the serialization cache (identitied by its key)
+        /// Writes a token cache blob to the serialization cache (identitied by its key).
         /// </summary>
-        /// <param name="cacheKey">Token cache key</param>
-        /// <param name="bytes">Bytes to write</param>
+        /// <param name="cacheKey">Token cache key.</param>
+        /// <param name="bytes">Bytes to write.</param>
         protected override Task WriteCacheBytesAsync(string cacheKey, byte[] bytes)
         {
             _memoryCache.Set(cacheKey, bytes, _cacheOptions.SlidingExpiration);

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
-using Microsoft.Identity.Client;
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders
 {
@@ -16,20 +15,20 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
     public abstract class MsalAbstractTokenCacheProvider : IMsalTokenCacheProvider
     {
         /// <summary>
-        /// Azure AD options
+        /// Azure AD options.
         /// </summary>
         protected readonly IOptions<MicrosoftIdentityOptions> _microsoftIdentityOptions;
 
         /// <summary>
-        /// Http accessor
+        /// Http accessor.
         /// </summary>
         protected readonly IHttpContextAccessor _httpContextAccessor;
 
         /// <summary>
-        /// Constructor of the abstract token cache provider
+        /// Constructor of the abstract token cache provider.
         /// </summary>
-        /// <param name="microsoftIdentityOptions">Configuration options</param>
-        /// <param name="httpContextAccessor">Accessor for the HttpContext</param>
+        /// <param name="microsoftIdentityOptions">Configuration options.</param>
+        /// <param name="httpContextAccessor">Accessor for the HttpContext.</param>
         protected MsalAbstractTokenCacheProvider(IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions, IHttpContextAccessor httpContextAccessor)
         {
             _microsoftIdentityOptions = microsoftIdentityOptions;
@@ -39,7 +38,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// <summary>
         /// Initializes the token cache serialization.
         /// </summary>
-        /// <param name="tokenCache">Token cache to serialize/deserialize</param>
+        /// <param name="tokenCache">Token cache to serialize/deserialize.</param>
         /// <returns></returns>
         public Task InitializeAsync(ITokenCache tokenCache)
         {
@@ -55,7 +54,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         }
 
         /// <summary>
-        /// Cache key
+        /// Cache key.
         /// </summary>
         private string GetCacheKey(bool isAppTokenCache)
         {
@@ -106,9 +105,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         }
 
         /// <summary>
-        /// if you want to ensure that no concurrent write takes place, use this notification to place a lock on the entry
+        /// if you want to ensure that no concurrent write takes place, use this notification to place a lock on the entry.
         /// </summary>
-        /// <param name="args">Token cache notification arguments</param>
+        /// <param name="args">Token cache notification arguments.</param>
         /// <returns></returns>
         protected virtual Task OnBeforeWriteAsync(TokenCacheNotificationArgs args)
         {
@@ -116,7 +115,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         }
 
         /// <summary>
-        /// Clear the cache
+        /// Clear the cache.
         /// </summary>
         public async Task ClearAsync()
         {
@@ -128,24 +127,24 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         }
 
         /// <summary>
-        /// Method to be implemented by concrete cache serializers to write the cache bytes
+        /// Method to be implemented by concrete cache serializers to write the cache bytes.
         /// </summary>
-        /// <param name="cacheKey">Cache key</param>
-        /// <param name="bytes">Bytes to write</param>
+        /// <param name="cacheKey">Cache key.</param>
+        /// <param name="bytes">Bytes to write.</param>
         /// <returns></returns>
         protected abstract Task WriteCacheBytesAsync(string cacheKey, byte[] bytes);
 
         /// <summary>
-        /// Method to be implemented by concrete cache serializers to Read the cache bytes
+        /// Method to be implemented by concrete cache serializers to Read the cache bytes.
         /// </summary>
-        /// <param name="cacheKey">Cache key</param>
-        /// <returns>Read bytes</returns>
+        /// <param name="cacheKey">Cache key.</param>
+        /// <returns>Read bytes.</returns>
         protected abstract Task<byte[]> ReadCacheBytesAsync(string cacheKey);
 
         /// <summary>
-        /// Method to be implemented by concrete cache serializers to remove an entry from the cache
+        /// Method to be implemented by concrete cache serializers to remove an entry from the cache.
         /// </summary>
-        /// <param name="cacheKey">Cache key</param>
+        /// <param name="cacheKey">Cache key.</param>
         protected abstract Task RemoveKeyAsync(string cacheKey);
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.Session
 {
@@ -32,26 +32,25 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         private ILogger _logger;
 
         /// <summary>
-        /// Msal Token cache provider constructor
+        /// Msal Token cache provider constructor.
         /// </summary>
-        /// <param name="microsoftIdentityOptions">Configuration options</param>
-        /// <param name="httpContextAccessor">accessor for an HttpContext</param>
-        /// <param name="logger">Logger</param>
+        /// <param name="microsoftIdentityOptions">Configuration options.</param>
+        /// <param name="httpContextAccessor">accessor for an HttpContext.</param>
+        /// <param name="logger">Logger.</param>
         public MsalSessionTokenCacheProvider(
             IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
             IHttpContextAccessor httpContextAccessor,
-            ILogger<MsalSessionTokenCacheProvider> logger) : 
-            base(microsoftIdentityOptions, httpContextAccessor)
+            ILogger<MsalSessionTokenCacheProvider> logger) : base(microsoftIdentityOptions, httpContextAccessor)
         {
             _logger = logger;
         }
 
         /// <summary>
-        /// Read a blob representing the token cache from its key
+        /// Read a blob representing the token cache from its key.
         /// </summary>
         /// <param name="cacheKey">Key representing the token cache
-        /// (account or app)</param>
-        /// <returns>Read blob</returns>
+        /// (account or app).</param>
+        /// <returns>Read blob.</returns>
         protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey)
         {
             await CurrentHttpContext.Session.LoadAsync().ConfigureAwait(false);
@@ -76,10 +75,10 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         }
 
         /// <summary>
-        /// Writes the token cache identitied by its key to the serialization mechanism
+        /// Writes the token cache identitied by its key to the serialization mechanism.
         /// </summary>
-        /// <param name="cacheKey">key for the cache (account ID or app ID)</param>
-        /// <param name="bytes">blob to write to the cache</param>
+        /// <param name="cacheKey">key for the cache (account ID or app ID).</param>
+        /// <param name="bytes">blob to write to the cache.</param>
         protected override async Task WriteCacheBytesAsync(string cacheKey, byte[] bytes)
         {
             s_sessionLock.EnterWriteLock();
@@ -98,9 +97,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         }
 
         /// <summary>
-        /// Removes a cache described from its key
+        /// Removes a cache described from its key.
         /// </summary>
-        /// <param name="cacheKey">key of the token cache (user account or app ID)</param>
+        /// <param name="cacheKey">key of the token cache (user account or app ID).</param>
         protected override async Task RemoveKeyAsync(string cacheKey)
         {
             s_sessionLock.EnterWriteLock();

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using System.Linq;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.Session
 {
     /// <summary>
-    /// Extension class to add a session token cache serializer to MSAL
+    /// Extension class to add a session token cache serializer to MSAL.
     /// </summary>
     public static class SessionTokenCacheProviderExtension
     {
@@ -99,8 +99,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         {
             services.AddHttpContextAccessor();
             services.AddSession(option =>
-            { option.Cookie.IsEssential = true; }
-            );
+                {
+                    option.Cookie.IsEssential = true;
+                });
             services.AddScoped<IMsalTokenCacheProvider, MsalSessionTokenCacheProvider>();
             return services;
         }

--- a/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
@@ -9,10 +13,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.Resource;
 using Microsoft.IdentityModel.Tokens;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Identity.Web
 {
@@ -25,15 +25,15 @@ namespace Microsoft.Identity.Web
         /// Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
         /// This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
         /// </summary>
-        /// <param name="builder">AuthenticationBuilder to which to add this configuration</param>
-        /// <param name="configuration">The Configuration object</param>
-        /// <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options</param>
-        /// <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer"</param>
-        /// <param name="tokenDecryptionCertificate">Token decryption certificate (null by default)</param>
+        /// <param name="builder">AuthenticationBuilder to which to add this configuration.</param>
+        /// <param name="configuration">The Configuration object.</param>
+        /// <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options.</param>
+        /// <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer".</param>
+        /// <param name="tokenDecryptionCertificate">Token decryption certificate (null by default).</param>
         /// <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the JwtBearer events.
         /// </param>
-        /// <returns>The authentication builder to chain</returns>
+        /// <returns>The authentication builder to chain.</returns>
         public static AuthenticationBuilder AddProtectedWebApi(
             this AuthenticationBuilder builder,
             IConfiguration configuration,
@@ -53,16 +53,16 @@ namespace Microsoft.Identity.Web
         /// Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
         /// This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
         /// </summary>
-        /// <param name="builder">AuthenticationBuilder to which to add this configuration</param>
-        /// <param name="configureJwtBearerOptions">The action to configure <see cref="JwtBearerOptions"/></param>
+        /// <param name="builder">AuthenticationBuilder to which to add this configuration.</param>
+        /// <param name="configureJwtBearerOptions">The action to configure <see cref="JwtBearerOptions"/>.</param>
         /// <param name="configureMicrosoftIdentityOptions">The action to configure the <see cref="MicrosoftIdentityOptions"/>
-        /// configuration options</param>
-        /// <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer"</param>
-        /// <param name="tokenDecryptionCertificate">Token decryption certificate</param>
+        /// configuration options.</param>
+        /// <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer".</param>
+        /// <param name="tokenDecryptionCertificate">Token decryption certificate.</param>
         /// <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the JwtBearer events.
         /// </param>
-        /// <returns>The authentication builder to chain</returns>
+        /// <returns>The authentication builder to chain.</returns>
         public static AuthenticationBuilder AddProtectedWebApi(
         this AuthenticationBuilder builder,
             Action<JwtBearerOptions> configureJwtBearerOptions,
@@ -88,16 +88,18 @@ namespace Microsoft.Identity.Web
             {
                 // TODO:
                 // Suspect. Why not get the IOption<MicrosoftIdentityOptions>?
-                var microsoftIdentityOptions = new MicrosoftIdentityOptions();// configuration.GetSection(configSectionName).Get<MicrosoftIdentityOptions>();
+                var microsoftIdentityOptions = new MicrosoftIdentityOptions(); // configuration.GetSection(configSectionName).Get<MicrosoftIdentityOptions>();
                 configureMicrosoftIdentityOptions(microsoftIdentityOptions);
 
                 if (string.IsNullOrWhiteSpace(options.Authority))
+                {
                     options.Authority = AuthorityHelpers.BuildAuthority(microsoftIdentityOptions);
+                }
 
                 // This is a Microsoft identity platform Web API
                 options.Authority = AuthorityHelpers.EnsureAuthorityIsV2(options.Authority);
 
-                // The valid audience could be given as Client Id or as Uri. 
+                // The valid audience could be given as Client Id or as Uri.
                 // If it does not start with 'api://', this variant is added to the list of valid audiences.
                 EnsureValidAudiencesContainsApiGuidIfGuidProvided(options, microsoftIdentityOptions);
 
@@ -116,7 +118,9 @@ namespace Microsoft.Identity.Web
                 }
 
                 if (options.Events == null)
+                {
                     options.Events = new JwtBearerEvents();
+                }
 
                 // When an access token for our own Web API is validated, we add it to MSAL.NET's cache so that it can
                 // be used from the controllers.
@@ -149,11 +153,11 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Ensure that if the audience is a GUID, api://{audience} is also added
         /// as a valid audience (this is the default App ID URL in the app registration
-        /// portal)
+        /// portal).
         /// </summary>
         /// <param name="options"><see cref="JwtBearerOptions"/> for which to ensure that
-        /// api://GUID is a valid audience</param>
-        /// <param name="msIdentityOptions">Configuration options</param>
+        /// api://GUID is a valid audience.</param>
+        /// <param name="msIdentityOptions">Configuration options.</param>
         internal static void EnsureValidAudiencesContainsApiGuidIfGuidProvided(JwtBearerOptions options, MicrosoftIdentityOptions msIdentityOptions)
         {
             options.TokenValidationParameters.ValidAudiences ??= new List<string>();
@@ -163,7 +167,9 @@ namespace Microsoft.Identity.Web
                 validAudiences.Add(options.Audience);
                 if (!options.Audience.StartsWith("api://", StringComparison.OrdinalIgnoreCase)
                                                  && Guid.TryParse(options.Audience, out _))
+                {
                     validAudiences.Add($"api://{options.Audience}");
+                }
             }
             else
             {

--- a/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Client;
-using System;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web
 {
@@ -22,15 +22,15 @@ namespace Microsoft.Identity.Web
         /// Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
         /// This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
         /// </summary>
-        /// <param name="services">Service collection to which to add authentication</param>
-        /// <param name="configuration">The Configuration object</param>
-        /// <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options</param>
-        /// <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer"</param>
-        /// <param name="tokenDecryptionCertificate">Token decryption certificate (null by default)</param>
+        /// <param name="services">Service collection to which to add authentication.</param>
+        /// <param name="configuration">The Configuration object.</param>
+        /// <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options.</param>
+        /// <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer".</param>
+        /// <param name="tokenDecryptionCertificate">Token decryption certificate (null by default).</param>
         /// <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the JwtBearer events.
         /// </param>
-        /// <returns>The service collection to chain</returns>
+        /// <returns>The service collection to chain.</returns>
         public static IServiceCollection AddProtectedWebApi(
             this IServiceCollection services,
             IConfiguration configuration,
@@ -52,15 +52,15 @@ namespace Microsoft.Identity.Web
         /// Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
         /// This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
         /// </summary>
-        /// <param name="services">Service collection to which to add authentication</param>
-        /// <param name="configureJwtBearerOptions">The action to configure <see cref="JwtBearerOptions"/></param>
-        /// <param name="configureMicrosoftIdentityOptions">The action to configure <see cref="MicrosoftIdentityOptions"/></param>
-        /// <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer"</param>
-        /// <param name="tokenDecryptionCertificate">Token decryption certificate (null by default)</param>
+        /// <param name="services">Service collection to which to add authentication.</param>
+        /// <param name="configureJwtBearerOptions">The action to configure <see cref="JwtBearerOptions"/>.</param>
+        /// <param name="configureMicrosoftIdentityOptions">The action to configure <see cref="MicrosoftIdentityOptions"/>.</param>
+        /// <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer".</param>
+        /// <param name="tokenDecryptionCertificate">Token decryption certificate (null by default).</param>
         /// <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the JwtBearer events.
         /// </param>
-        /// <returns>The service collection to chain</returns>
+        /// <returns>The service collection to chain.</returns>
         public static IServiceCollection AddProtectedWebApi(
             this IServiceCollection services,
             Action<JwtBearerOptions> configureJwtBearerOptions,
@@ -81,13 +81,13 @@ namespace Microsoft.Identity.Web
 
         /// <summary>
         /// Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
-        /// This supposes that the configuration files have a section named configSectionName (typically "AzureAD")
+        /// This supposes that the configuration files have a section named configSectionName (typically "AzureAD").
         /// </summary>
-        /// <param name="services">Service collection to which to add authentication</param>
-        /// <param name="configuration">Configuration</param>
-        /// <param name="configSectionName">Section name in the config file (by default "AzureAD")</param>
-        /// <param name="jwtBearerScheme">Scheme for the JwtBearer token</param>
-        /// <returns>The service collection to chain</returns>
+        /// <param name="services">Service collection to which to add authentication.</param>
+        /// <param name="configuration">Configuration.</param>
+        /// <param name="configSectionName">Section name in the config file (by default "AzureAD").</param>
+        /// <param name="jwtBearerScheme">Scheme for the JwtBearer token.</param>
+        /// <returns>The service collection to chain.</returns>
         public static IServiceCollection AddProtectedWebApiCallsProtectedWebApi(
             this IServiceCollection services,
             IConfiguration configuration,
@@ -102,13 +102,13 @@ namespace Microsoft.Identity.Web
 
         /// <summary>
         /// Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
-        /// This supposes that the configuration files have a section named configSectionName (typically "AzureAD")
+        /// This supposes that the configuration files have a section named configSectionName (typically "AzureAD").
         /// </summary>
-        /// <param name="services">Service collection to which to add authentication</param>
-        /// <param name="configureConfidentialClientApplicationOptions">The action to configure <see cref="ConfidentialClientApplicationOptions"/></param>
-        /// <param name="configureMicrosoftIdentityOptions">The action to configure <see cref="MicrosoftIdentityOptions"/></param>
-        /// <param name="jwtBearerScheme">Scheme for the JwtBearer token</param>
-        /// <returns>The service collection to chain</returns>
+        /// <param name="services">Service collection to which to add authentication.</param>
+        /// <param name="configureConfidentialClientApplicationOptions">The action to configure <see cref="ConfidentialClientApplicationOptions"/>.</param>
+        /// <param name="configureMicrosoftIdentityOptions">The action to configure <see cref="MicrosoftIdentityOptions"/>.</param>
+        /// <param name="jwtBearerScheme">Scheme for the JwtBearer token.</param>
+        /// <returns>The service collection to chain.</returns>
         public static IServiceCollection AddProtectedWebApiCallsProtectedWebApi(
             this IServiceCollection services,
             Action<ConfidentialClientApplicationOptions> configureConfidentialClientApplicationOptions,

--- a/src/Microsoft.Identity.Web/WebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppAuthenticationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -10,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.Resource;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using System;
 
 namespace Microsoft.Identity.Web
 {
@@ -23,15 +23,15 @@ namespace Microsoft.Identity.Web
         /// Add authentication with Microsoft identity platform.
         /// This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
         /// </summary>
-        /// <param name="builder">AuthenticationBuilder to which to add this configuration</param>
-        /// <param name="configuration">The IConfiguration object</param>
-        /// <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options</param>
-        /// <param name="openIdConnectScheme">The OpenIdConnect scheme name to be used. By default it uses "OpenIdConnect"</param>
-        /// <param name="cookieScheme">The Cookies scheme name to be used. By default it uses "Cookies"</param>
+        /// <param name="builder">AuthenticationBuilder to which to add this configuration.</param>
+        /// <param name="configuration">The IConfiguration object.</param>
+        /// <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options.</param>
+        /// <param name="openIdConnectScheme">The OpenIdConnect scheme name to be used. By default it uses "OpenIdConnect".</param>
+        /// <param name="cookieScheme">The Cookies scheme name to be used. By default it uses "Cookies".</param>
         /// <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the OpenIdConnect events.
         /// </param>
-        /// <returns>The authentication builder for chaining</returns>
+        /// <returns>The authentication builder for chaining.</returns>
         public static AuthenticationBuilder AddSignIn(
             this AuthenticationBuilder builder,
             IConfiguration configuration,
@@ -50,15 +50,15 @@ namespace Microsoft.Identity.Web
         /// Add authentication with Microsoft identity platform.
         /// This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
         /// </summary>
-        /// <param name="builder">AuthenticationBuilder to which to add this configuration</param>
-        /// <param name="configureOpenIdConnectOptions">The IConfiguration object</param>
-        /// <param name="configureMicrosoftIdentityOptions">The configuration section with the necessary settings to initialize authentication options</param>
-        /// <param name="openIdConnectScheme">The OpenIdConnect scheme name to be used. By default it uses "OpenIdConnect"</param>
-        /// <param name="cookieScheme">The Cookies scheme name to be used. By default it uses "Cookies"</param>
+        /// <param name="builder">AuthenticationBuilder to which to add this configuration.</param>
+        /// <param name="configureOpenIdConnectOptions">The IConfiguration object.</param>
+        /// <param name="configureMicrosoftIdentityOptions">The configuration section with the necessary settings to initialize authentication options.</param>
+        /// <param name="openIdConnectScheme">The OpenIdConnect scheme name to be used. By default it uses "OpenIdConnect".</param>
+        /// <param name="cookieScheme">The Cookies scheme name to be used. By default it uses "Cookies".</param>
         /// <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the OpenIdConnect events.
         /// </param>
-        /// <returns>The authentication builder for chaining</returns>
+        /// <returns>The authentication builder for chaining.</returns>
         public static AuthenticationBuilder AddSignIn(
             this AuthenticationBuilder builder,
             Action<OpenIdConnectOptions> configureOpenIdConnectOptions,
@@ -85,16 +85,22 @@ namespace Microsoft.Identity.Web
                 options.SignInScheme = cookieScheme;
 
                 if (string.IsNullOrWhiteSpace(options.Authority))
+                {
                     options.Authority = AuthorityHelpers.BuildAuthority(microsoftIdentityOptions);
+                }
 
                 // This is a Microsoft identity platform Web app
                 options.Authority = AuthorityHelpers.EnsureAuthorityIsV2(options.Authority);
 
                 // B2C doesn't have preferred_username claims
                 if (microsoftIdentityOptions.IsB2C)
+                {
                     options.TokenValidationParameters.NameClaimType = "name";
+                }
                 else
+                {
                     options.TokenValidationParameters.NameClaimType = "preferred_username";
+                }
 
                 // If the developer registered an IssuerValidator, do not overwrite it
                 if (options.TokenValidationParameters.IssuerValidator == null)
@@ -134,6 +140,7 @@ namespace Microsoft.Identity.Web
                     if (microsoftIdentityOptions.IsB2C)
                     {
                         context.ProtocolMessage.SetParameter("client_info", "1");
+
                         // When a new Challenge is returned using any B2C user flow different than susi, we must change
                         // the ProtocolMessage.IssuerAddress to the desired user flow otherwise the redirect would use the susi user flow
                         await b2cOidcHandlers.OnRedirectToIdentityProvider(context).ConfigureAwait(false);
@@ -148,7 +155,7 @@ namespace Microsoft.Identity.Web
                     options.Events.OnRemoteFailure = async context =>
                     {
                         // Handles the error when a user cancels an action on the Azure Active Directory B2C UI.
-                        // Handle the error code that Azure Active Directory B2C throws when trying to reset a password from the login page 
+                        // Handle the error code that Azure Active Directory B2C throws when trying to reset a password from the login page
                         // because password reset is not supported by a "sign-up or sign-in user flow".
                         await b2cOidcHandlers.OnRemoteFailure(context).ConfigureAwait(false);
 

--- a/src/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -8,10 +12,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Client;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Claims;
 
 namespace Microsoft.Identity.Web
 {
@@ -22,22 +22,22 @@ namespace Microsoft.Identity.Web
     {
         /// <summary>
         /// Add authentication with Microsoft identity platform.
-        /// This method expects the configuration file will have a section, (by default named "AzureAd"), with the necessary settings to 
+        /// This method expects the configuration file will have a section, (by default named "AzureAd"), with the necessary settings to
         /// initialize the authentication options.
         /// </summary>
-        /// <param name="services">Service collection to which to add authentication</param>
-        /// <param name="configuration">The IConfiguration object</param>
+        /// <param name="services">Service collection to which to add authentication.</param>
+        /// <param name="configuration">The IConfiguration object.</param>
         /// <param name="configSectionName">The name of the configuration section with the necessary
-        /// settings to initialize authentication options</param>
-        /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme 
+        /// settings to initialize authentication options.</param>
+        /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
         /// (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
         /// several OpenIdConnect identity providers.</param>
-        /// <param name="cookieScheme">Optional name for the acookie uthentication scheme 
-        /// (by default OpenIdConnectDefaults.AuthenticationScheme) </param>
+        /// <param name="cookieScheme">Optional name for the acookie uthentication scheme
+        /// (by default OpenIdConnectDefaults.AuthenticationScheme). </param>
         /// <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the OpenIdConnect events.
         /// </param>
-        /// <returns>The service collection for chaining</returns>
+        /// <returns>The service collection for chaining.</returns>
         public static IServiceCollection AddSignIn(
             this IServiceCollection services,
             IConfiguration configuration,
@@ -60,18 +60,18 @@ namespace Microsoft.Identity.Web
         /// Add authentication with Microsoft identity platform.
         /// This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
         /// </summary>
-        /// <param name="services">Service collection to which to add authentication</param>
-        /// <param name="configureOpenIdConnectOptions">the action to configure the <see cref="OpenIdConnectOptions"/></param>
-        /// <param name="configureMicrosoftIdentityOptions">the action to configure the <see cref="MicrosoftIdentityOptions"/></param>
-        /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme 
+        /// <param name="services">Service collection to which to add authentication.</param>
+        /// <param name="configureOpenIdConnectOptions">the action to configure the <see cref="OpenIdConnectOptions"/>.</param>
+        /// <param name="configureMicrosoftIdentityOptions">the action to configure the <see cref="MicrosoftIdentityOptions"/>.</param>
+        /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
         /// (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
         /// several OpenIdConnect identity providers.</param>
-        /// <param name="cookieScheme">Optional name for the acookie uthentication scheme 
-        /// (by default OpenIdConnectDefaults.AuthenticationScheme) </param>
+        /// <param name="cookieScheme">Optional name for the acookie uthentication scheme
+        /// (by default OpenIdConnectDefaults.AuthenticationScheme). </param>
         /// <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the OpenIdConnect events.
         /// </param>
-        /// <returns>Yhe service collection for chaining</returns>
+        /// <returns>Yhe service collection for chaining.</returns>
         public static IServiceCollection AddSignIn(
             this IServiceCollection services,
             Action<OpenIdConnectOptions> configureOpenIdConnectOptions,
@@ -91,17 +91,17 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Add MSAL support to the Web App or Web API
+        /// Add MSAL support to the Web App or Web API.
         /// </summary>
-        /// <param name="services">Service collection to which to add authentication</param>
-        /// <param name="configuration">Configuration</param>
-        /// <param name="initialScopes">Initial scopes to request at sign-in</param>
+        /// <param name="services">Service collection to which to add authentication.</param>
+        /// <param name="configuration">Configuration.</param>
+        /// <param name="initialScopes">Initial scopes to request at sign-in.</param>
         /// <param name="configSectionName">The name of the configuration section with the necessary
-        /// settings to initialize authentication options</param>
-        /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme 
+        /// settings to initialize authentication options.</param>
+        /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
         /// (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
         /// several OpenIdConnect identity providers.</param>
-        /// <returns>Yhe service collection for chaining</returns>
+        /// <returns>Yhe service collection for chaining.</returns>
         public static IServiceCollection AddWebAppCallsProtectedWebApi(
             this IServiceCollection services,
             IConfiguration configuration,
@@ -118,16 +118,16 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Add MSAL support to the Web App or Web API
+        /// Add MSAL support to the Web App or Web API.
         /// </summary>
-        /// <param name="services">Service collection to which to add authentication</param>
-        /// <param name="initialScopes">Initial scopes to request at sign-in</param>
-        /// <param name="configureMicrosoftIdentityOptions">The action to set the <see cref="MicrosoftIdentityOptions"/></param>
-        /// <param name="configureConfidentialClientApplicationOptions">The action to set the <see cref="ConfidentialClientApplicationOptions"/></param>
-        /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme 
+        /// <param name="services">Service collection to which to add authentication.</param>
+        /// <param name="initialScopes">Initial scopes to request at sign-in.</param>
+        /// <param name="configureMicrosoftIdentityOptions">The action to set the <see cref="MicrosoftIdentityOptions"/>.</param>
+        /// <param name="configureConfidentialClientApplicationOptions">The action to set the <see cref="ConfidentialClientApplicationOptions"/>.</param>
+        /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
         /// (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
         /// several OpenIdConnect identity providers.</param>
-        /// <returns>The service collection for chaining</returns>
+        /// <returns>The service collection for chaining.</returns>
         public static IServiceCollection AddWebAppCallsProtectedWebApi(
             this IServiceCollection services,
             IEnumerable<string> initialScopes,

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,23 @@
+﻿{
+    // ACTION REQUIRED: This file was automatically added to your project, but it
+    // will not take effect until additional steps are taken to enable it. See the
+    // following page for additional information:
+    //
+    // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/EnableConfiguration.md
+
+    "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+    "settings": {
+        "documentationRules": {
+            "xmlHeader": false,
+            "companyName": "Microsoft Corporation",
+            "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the {licenseName}.",
+            "variables": {
+                "licenseName": "MIT License"
+            },
+            "documentInternalElements": false
+        },
+        "orderingRules": {
+            "usingDirectivesPlacement": "outsideNamespace"
+        }
+    }
+}

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,7 +1,21 @@
 # NOTE: Requires **VS2019 16.3** or later
 
+# Rules for files in tests directory
+
 # Code files
 [*.{cs,vb}]
 
-# CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = none
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = none
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = none
+
+# SA1117: Parameters should be on same line or separate lines
+dotnet_diagnostic.SA1117.severity = none
+
+# SA1124: Do not use regions
+dotnet_diagnostic.SA1124.severity = none

--- a/tests/Microsoft.Identity.Web.Test.Common/GlobalSuppressions.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/GlobalSuppressions.cs
@@ -5,4 +5,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.AccessDeniedModel.OnGet")]
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1618:Generic type parameters should be documented", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.Identity.Web.Test.Common.Mocks.LoggerMock`1")]

--- a/tests/Microsoft.Identity.Web.Test.Common/Microsoft.Identity.Web.Test.Common.csproj
+++ b/tests/Microsoft.Identity.Web.Test.Common/Microsoft.Identity.Web.Test.Common.csproj
@@ -5,9 +5,17 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Microsoft.Identity.Web.Test.Common/Mocks/LoggerMock.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/Mocks/LoggerMock.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
     /// <remarks>
     /// <see cref="Microsoft.Extensions.Logging.ILogger"/> has only one logging method - Log.
     /// LogDebug, LogInformation, LogError, etc. are actually extension methods located in <see cref="Microsoft.Extensions.Logging.LoggerExtensions"/>, which all end up calling the Log method in the ILogger.
-    /// Since extension methods are concrete, NSubstitute cannot mock them. 
+    /// Since extension methods are concrete, NSubstitute cannot mock them.
     /// Subsequently Log method should be mocked; however, LoggerExtensions class passes a FormattedLogValues internal struct to the Log method.
     /// This prevents NSubstitute from successfully matching the method calls by parameters.
     /// More information:
     /// https://github.com/dotnet/extensions/issues?q=FormattedLogValues
     /// https://github.com/dotnet/extensions/issues/1319
     /// https://github.com/nsubstitute/NSubstitute/issues/597
-    /// https://github.com/moq/moq4/issues/918
+    /// https://github.com/moq/moq4/issues/918.
     /// </remarks>
     public class LoggerMock<T> : ILogger<T>
     {

--- a/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
@@ -61,22 +61,22 @@ namespace Microsoft.Identity.Web.Test.Common
         // Claims
         public const string ClaimNameTid = "tid";
         public const string ClaimNameIss = "iss";
-        public const string ClaimNameTfp = "tfp"; //Trust Framework Policy for B2C (aka userflow/policy)
+        public const string ClaimNameTfp = "tfp"; // Trust Framework Policy for B2C (aka userflow/policy)
 
         public static readonly IEnumerable<string> s_aliases = new[]
         {
             ProductionPrefNetworkEnvironment,
-            ProductionNotPrefEnvironmentAlias
+            ProductionNotPrefEnvironmentAlias,
         };
 
         public static readonly IEnumerable<string> s_scopesForApp = new[]
         {
-            "https://graph.microsoft.com/.default"
+            "https://graph.microsoft.com/.default",
         };
 
         public static readonly IEnumerable<string> s_scopesForUser = new[]
         {
-            "user.read"
+            "user.read",
         };
 
         public const string InvalidScopeError = "The scope user.read is not valid.";
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string ConfidentialClientId = "16dab2ba-145d-4b1b-8569-bf4b9aed4dc8";
         public const string ConfidentialClientLabTenant = "72f988bf-86f1-41af-91ab-2d7cd011db47";
 
-        //This value is only for testing purposes. It is for a certificate that is not used for anything other than running tests
+        // This value is only for testing purposes. It is for a certificate that is not used for anything other than running tests
         public const string CertificateX5c = @"MIIDHzCCAgegAwIBAgIQM6NFYNBJ9rdOiK+C91ZzFDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwHhcNMTIwNTIyMj
             IxMTIyWhcNMzAwNTIyMDcwMDAwWjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCh7HjK
             YyVMDZDT64OgtcGKWxHmK2wqzi2LJb65KxGdNfObWGxh5HQtjzrgHDkACPsgyYseqxhGxHh8I/TR6wBKx/AAKuPHE8jB4hJ1W6FczPfb7FaMV9xP0qNQrbNGZU

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/HttpContextUtilities.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/HttpContextUtilities.cs
@@ -31,9 +31,8 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
             httpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.Scope, string.Join(' ', userScopes))
-                })
-            );
+                    new Claim(ClaimConstants.Scope, string.Join(' ', userScopes)),
+                }));
 
             return httpContext;
         }

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/InMemoryTokenCache.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/InMemoryTokenCache.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
     public class InMemoryTokenCache
     {
         private byte[] _cacheData;
-        /// <summary>
-        /// Path to the token cache
-        /// </summary>
 
+        /// <summary>
+        /// Path to the token cache.
+        /// </summary>
         public void BeforeAccessNotification(TokenCacheNotificationArgs args)
         {
             args.TokenCache.DeserializeMsalV3(_cacheData);

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/MsalTestTokenCacheProvider.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/MsalTestTokenCacheProvider.cs
@@ -1,31 +1,32 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.TokenCacheProviders;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
-using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web.Test.Common.TestHelpers
 {
     public class MsalTestTokenCacheProvider : MsalAbstractTokenCacheProvider
     {
-        public IMemoryCache MemoryCache { get; }
-        private readonly MsalMemoryTokenCacheOptions _cacheOptions;
-        public int Count { get; internal set; }
-
         public MsalTestTokenCacheProvider(
             IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
             IHttpContextAccessor httpContextAccessor,
             IMemoryCache memoryCache,
-            IOptions<MsalMemoryTokenCacheOptions> cacheOptions) :
-            base(microsoftIdentityOptions, httpContextAccessor)
+            IOptions<MsalMemoryTokenCacheOptions> cacheOptions) : base(microsoftIdentityOptions, httpContextAccessor)
         {
             MemoryCache = memoryCache;
             _cacheOptions = cacheOptions.Value;
         }
+
+        public IMemoryCache MemoryCache { get; }
+
+        public int Count { get; internal set; }
+
+        private readonly MsalMemoryTokenCacheOptions _cacheOptions;
 
         protected override Task<byte[]> ReadCacheBytesAsync(string cacheKey)
         {

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,10 +16,6 @@ using Microsoft.Identity.Web.Test.Common.TestHelpers;
 using Microsoft.Identity.Web.Test.LabInfrastructure;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 using NSubstitute;
-using System;
-using System.Globalization;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using IHttpContextAccessor = Microsoft.AspNetCore.Http.IHttpContextAccessor;
@@ -34,14 +34,14 @@ namespace Microsoft.Identity.Web.Test.Integration
         private string _ccaSecret;
         private readonly ITestOutputHelper _output;
 
-        public AcquireTokenForAppIntegrationTests(ITestOutputHelper output) //test set-up
+        public AcquireTokenForAppIntegrationTests(ITestOutputHelper output) // test set-up
         {
             _output = output;
 
             _keyVault = new KeyVaultSecretsProvider();
             _ccaSecret = _keyVault.GetSecret(TestConstants.ConfidentialClientKeyVaultUri).Value;
 
-            if (!string.IsNullOrEmpty(_ccaSecret)) //Need the secret before building the services
+            if (!string.IsNullOrEmpty(_ccaSecret)) // Need the secret before building the services
             {
                 BuildTheRequiredServices();
             }
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             async Task result() =>
                 await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopesForUser).ConfigureAwait(false);
 
-            MsalServiceException ex = await Assert.ThrowsAsync<MsalServiceException>(result);
+            MsalServiceException ex = await Assert.ThrowsAsync<MsalServiceException>(result).ConfigureAwait(false);
 
             Assert.Contains(TestConstants.InvalidScopeError, ex.Message);
             Assert.Equal(TestConstants.InvalidScope, ex.ErrorCode);
@@ -99,7 +99,7 @@ namespace Microsoft.Identity.Web.Test.Integration
 
             var options = new ConfidentialClientApplicationOptions
             {
-                ClientSecret = clientSecret
+                ClientSecret = clientSecret,
             };
 
             MicrosoftIdentityOptionsValidation microsoftIdentityOptionsValidation = new MicrosoftIdentityOptionsValidation();
@@ -129,7 +129,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             string redirectUri,
             bool expectConfiguredUri)
         {
-            string httpContextRedirectUri = "https://IdentityDotNetSDKAutomation/";       
+            string httpContextRedirectUri = "https://IdentityDotNetSDKAutomation/";
 
             InitializeTokenAcquisitionObjects();
             microsoftIdentityOptions.Value.RedirectUri = redirectUri;
@@ -189,7 +189,7 @@ namespace Microsoft.Identity.Web.Test.Integration
                 {
                     Authority = TestConstants.AuthorityCommonTenant,
                     ClientId = TestConstants.ConfidentialClientId,
-                    CallbackPath = ""
+                    CallbackPath = "",
                 }));
             services.AddTransient(
                 _provider => Options.Create(new ConfidentialClientApplicationOptions
@@ -197,7 +197,7 @@ namespace Microsoft.Identity.Web.Test.Integration
                     Instance = TestConstants.AadInstance,
                     TenantId = TestConstants.ConfidentialClientLabTenant,
                     ClientId = TestConstants.ConfidentialClientId,
-                    ClientSecret = _ccaSecret
+                    ClientSecret = _ccaSecret,
                 }
                 ));
             services.AddLogging();

--- a/tests/Microsoft.Identity.Web.Test.Integration/GlobalSuppressions.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1108:Block statements should not contain embedded comments", Justification = "not applicable", Scope = "member", Target = "~M:Microsoft.Identity.Web.Test.Integration.AcquireTokenForAppIntegrationTests.#ctor(Xunit.Abstractions.ITestOutputHelper)")]
+[assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "not applicable", Scope = "member", Target = "~M:Microsoft.Identity.Web.Test.Integration.AcquireTokenForAppIntegrationTests.#ctor(Xunit.Abstractions.ITestOutputHelper)")]

--- a/tests/Microsoft.Identity.Web.Test.Integration/Microsoft.Identity.Web.Test.Integration.csproj
+++ b/tests/Microsoft.Identity.Web.Test.Integration/Microsoft.Identity.Web.Test.Integration.csproj
@@ -15,11 +15,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/CertificateHelper.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/CertificateHelper.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         /// Try and locate a certificate matching the given <paramref name="thumbprint"/> by searching in
         /// the <see cref="StoreName.My"/> store name for all available <see cref="StoreLocation"/>s.
         /// </summary>
-        /// <param name="thumbprint">Thumbprint of certificate to locate</param>
-        /// <returns><see cref="X509Certificate2"/> with <paramref name="thumbprint"/>, or null if no matching certificate was found</returns>
+        /// <param name="thumbprint">Thumbprint of certificate to locate.</param>
+        /// <returns><see cref="X509Certificate2"/> with <paramref name="thumbprint"/>, or null if no matching certificate was found.</returns>
         public static X509Certificate2 FindCertificateByThumbprint(string thumbprint)
         {
             foreach (StoreLocation storeLocation in Enum.GetValues(typeof(StoreLocation)))
@@ -32,10 +32,10 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         /// Try and locate a certificate matching the given <paramref name="thumbprint"/> by searching in
         /// the in the given <see cref="StoreName"/> and <see cref="StoreLocation"/>.
         /// </summary>
-        /// <param name="thumbprint">Thumbprint of certificate to locate</param>
-        /// <param name="location"><see cref="StoreLocation"/> in which to search for a matching certificate</param>
-        /// <param name="name"><see cref="StoreName"/> in which to search for a matching certificate</param>
-        /// <returns><see cref="X509Certificate2"/> with <paramref name="thumbprint"/>, or null if no matching certificate was found</returns>
+        /// <param name="thumbprint">Thumbprint of certificate to locate.</param>
+        /// <param name="location"><see cref="StoreLocation"/> in which to search for a matching certificate.</param>
+        /// <param name="name"><see cref="StoreName"/> in which to search for a matching certificate.</param>
+        /// <returns><see cref="X509Certificate2"/> with <paramref name="thumbprint"/>, or null if no matching certificate was found.</returns>
         public static X509Certificate2 FindCertificateByThumbprint(string thumbprint, StoreLocation location, StoreName name)
         {
             // Don't validate certs, since the test root isn't installed.
@@ -49,7 +49,6 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
                 return collection.Count == 0
                     ? null
                     : collection[0];
-
             }
         }
     }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/GlobalSuppressions.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/GlobalSuppressions.cs
@@ -1,0 +1,10 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "not applicable", Scope = "type", Target = "~T:Microsoft.Identity.Web.Test.LabInfrastructure.LabAccessAuthenticationType")]
+[assembly: SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "not applicable", Scope = "type", Target = "~T:Microsoft.Identity.Web.Test.LabInfrastructure.LabUserNotFoundException")]
+[assembly: SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "not applicable", Scope = "member", Target = "~M:Microsoft.Identity.Web.Test.LabInfrastructure.LabServiceApi.#ctor")]

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/KeyVaultConfiguration.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/KeyVaultConfiguration.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         public string CertThumbprint { get; set; }
 
         /// <summary>
-        /// Secret value used to access Key Vault
+        /// Secret value used to access Key Vault.
         /// </summary>
         public string KeyVaultSecret { get; set; }
     }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.KeyVault;
-using Microsoft.Azure.KeyVault.Models;
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault;
+using Microsoft.Azure.KeyVault.Models;
 
 namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         ///     The "keyVault" configuration section should define:
         ///         "authType": "ClientCertificate"
         ///         "clientId": [client ID]
-        ///         "certThumbprint": [certificate thumbprint]
+        ///         "certThumbprint": [certificate thumbprint].
         /// </para>
         /// <para>
         /// Authentication using <see cref="LabAccessAuthenticationType.UserCredential"/>
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         ///
         ///     The "keyVault" configuration section should define:
         ///         "authType": "UserCredential"
-        ///         "clientId": [client ID]
+        ///         "clientId": [client ID].
         /// </para>
         /// </remarks>
         public KeyVaultSecretsProvider()
@@ -71,15 +71,15 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
             return certificate;
         }
 
-        private async Task<string> AuthenticationCallbackAsync(string authority, string resource, string scope)
-        {
-            return await LabAuthenticationHelper.GetLabAccessTokenAsync(authority, new[] { resource + "/.default" }).ConfigureAwait(false);
-        }
-
         public void Dispose()
         {
             _keyVaultClient?.Dispose();
             GC.SuppressFinalize(this);
+        }
+
+        private async Task<string> AuthenticationCallbackAsync(string authority, string resource, string scope)
+        {
+            return await LabAuthenticationHelper.GetLabAccessTokenAsync(authority, new[] { resource + "/.default" }).ConfigureAwait(false);
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabAuthenticationHelper.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabAuthenticationHelper.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Web.Test.Common.TestHelpers;
 using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web.Test.Common.TestHelpers;
 
 namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
@@ -23,9 +23,9 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
 
         static LabAuthenticationHelper()
         {
-            //The data.txt is a place holder for the keyvault secret. It will only be written to during build time when testing appcenter.
-            //After the tests are finished in appcenter, the file will be deleted from the appcenter servers.
-            //The file will then be deleted locally Via VSTS task.
+            // The data.txt is a place holder for the keyvault secret. It will only be written to during build time when testing appcenter.
+            // After the tests are finished in appcenter, the file will be deleted from the appcenter servers.
+            // The file will then be deleted locally Via VSTS task.
             if (File.Exists(DataFileName))
             {
                 var data = File.ReadAllText(DataFileName);
@@ -136,6 +136,6 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
     {
         ClientCertificate,
         ClientSecret,
-        UserCredential
+        UserCredential,
     }
 }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabResponse.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabResponse.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         // TODO: this is a list, but lab sends a string. Not used today, discuss with lab to return a list
         [JsonProperty("authority")]
         public string Authority { get; set; }
-
     }
 
     public class Lab

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabServiceApi.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabServiceApi.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
     /// <summary>
-    /// Wrapper for lab service API
+    /// Wrapper for lab service API.
     /// </summary>
     public class LabServiceApi : ILabService
     {
@@ -39,9 +39,20 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
             return response;
         }
 
+        public async Task<string> GetUserSecretAsync(string lab)
+        {
+            IDictionary<string, string> queryDict = new Dictionary<string, string>
+            {
+                { "secret", lab },
+            };
+
+            string result = await SendLabRequestAsync(LabApiConstants.LabUserCredentialEndpoint, queryDict).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<LabCredentialResponse>(result).Secret;
+        }
+
         private async Task<LabResponse> GetLabResponseFromApiAsync(UserQuery query)
         {
-            //Fetch user
+            // Fetch user
             string result = await RunQueryAsync(query).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(result))
@@ -71,7 +82,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
             {
                 User = user,
                 App = labApps[0],
-                Lab = labs[0]
+                Lab = labs[0],
             };
         }
 
@@ -79,8 +90,8 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         {
             IDictionary<string, string> queryDict = new Dictionary<string, string>();
 
-            //Building user query
-            //Required parameters will be set to default if not supplied by the test code
+            // Building user query
+            // Required parameters will be set to default if not supplied by the test code
             queryDict.Add(LabApiConstants.MultiFactorAuthentication, query.MFA != null ? query.MFA.ToString() : MFA.None.ToString());
             queryDict.Add(LabApiConstants.ProtectionPolicy, query.ProtectionPolicy != null ? query.ProtectionPolicy.ToString() : ProtectionPolicy.None.ToString());
 
@@ -126,7 +137,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         {
             UriBuilder uriBuilder = new UriBuilder(requestUrl)
             {
-                Query = string.Join("&", queryDict.Select(x => x.Key + "=" + x.Value.ToString()))
+                Query = string.Join("&", queryDict.Select(x => x.Key + "=" + x.Value.ToString(CultureInfo.InvariantCulture))),
             };
 
             return await GetLabResponseAsync(uriBuilder.ToString()).ConfigureAwait(false);
@@ -135,24 +146,15 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         private async Task<string> GetLabResponseAsync(string address)
         {
             if (string.IsNullOrWhiteSpace(_labApiAccessToken))
+            {
                 _labApiAccessToken = await LabAuthenticationHelper.GetAccessTokenForLabAPIAsync(_labAccessAppId, _labAccessClientSecret).ConfigureAwait(false);
+            }
 
             using (HttpClient httpClient = new HttpClient())
             {
                 httpClient.DefaultRequestHeaders.Add("Authorization", string.Format(CultureInfo.InvariantCulture, "bearer {0}", _labApiAccessToken));
                 return await httpClient.GetStringAsync(address).ConfigureAwait(false);
             }
-        }
-
-        public async Task<string> GetUserSecretAsync(string lab)
-        {
-            IDictionary<string, string> queryDict = new Dictionary<string, string>
-            {
-                { "secret", lab }
-            };
-
-            string result = await SendLabRequestAsync(LabApiConstants.LabUserCredentialEndpoint, queryDict).ConfigureAwait(false);
-            return JsonConvert.DeserializeObject<LabCredentialResponse>(result).Secret;
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabServiceParameters.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabServiceParameters.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         Shibboleth,
         ADFSv2019,
         B2C,
-        Ping
+        Ping,
     }
 
     public enum B2CIdentityProvider
@@ -26,12 +26,12 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         MSA,
         Amazon,
         Microsoft,
-        Twitter
+        Twitter,
     }
 
     public enum UserType
     {
-        Member, //V1 lab api only
+        Member, // V1 lab api only
         Guest,
         B2C,
         Cloud,
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
     {
         None,
         MfaOnAll,
-        AutoMfaOnAll
+        AutoMfaOnAll,
     }
 
     public enum ProtectionPolicy
@@ -56,18 +56,18 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         MDM,
         MDMCA,
         MAMCA,
-        MAMSPO
+        MAMSPO,
     }
 
-    public enum HomeDomain //Must add ".com" to end for lab queury
+    public enum HomeDomain // Must add ".com" to end for lab queury
     {
         None,
         MsidLab2,
         MsidLab3,
-        MsidLab4
+        MsidLab4,
     }
 
-    public enum HomeUPN //Must replace "_" with "@" add ".com" to end for lab queury
+    public enum HomeUPN // Must replace "_" with "@" add ".com" to end for lab queury
     {
         None,
         GidLab_Msidlab2,
@@ -82,13 +82,13 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         azurechinacloud,
         azuregermanycloud,
         azureppe,
-        azureusgovernment
+        azureusgovernment,
     }
 
     public enum SignInAudience
     {
         AzureAdMyOrg,
         AzureAdMultipleOrgs,
-        AzureAdAndPersonalMicrosoftAccount
+        AzureAdAndPersonalMicrosoftAccount,
     }
 }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabUserHelper.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabUserHelper.cs
@@ -10,17 +10,17 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
     public static class LabUserHelper
     {
-        private static readonly LabServiceApi s_labService;
-        private static readonly IDictionary<UserQuery, LabResponse> s_userCache =
-            new Dictionary<UserQuery, LabResponse>();
-
-        public static KeyVaultSecretsProvider KeyVaultSecretsProvider { get; }
-
         static LabUserHelper()
         {
             KeyVaultSecretsProvider = new KeyVaultSecretsProvider();
             s_labService = new LabServiceApi();
         }
+
+        private static readonly LabServiceApi s_labService;
+        private static readonly IDictionary<UserQuery, LabResponse> s_userCache =
+            new Dictionary<UserQuery, LabResponse>();
+
+        public static KeyVaultSecretsProvider KeyVaultSecretsProvider { get; }
 
         public static async Task<LabResponse> GetLabUserDataAsync(UserQuery query)
         {
@@ -75,13 +75,15 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
             {
                 response.User.HomeUPN = response.User.Upn;
             }
+
             return response;
         }
 
         public static Task<LabResponse> GetSpecificUserAsync(string upn)
         {
             var query = new UserQuery();
-            //query.Upn = upn;
+
+            // query.Upn = upn;
             return GetLabUserDataAsync(query);
         }
 

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabUserNotFoundException.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabUserNotFoundException.cs
@@ -7,11 +7,12 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
     public class LabUserNotFoundException : Exception
     {
-        public UserQuery Parameters { get; set; }
-
-        public LabUserNotFoundException(UserQuery parameters, string message) : base(message)
+        public LabUserNotFoundException(UserQuery parameters, string message)
+            : base(message)
         {
             Parameters = parameters;
         }
+
+        public UserQuery Parameters { get; set; }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/Microsoft.Identity.Web.Test.LabInfrastructure.csproj
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/Microsoft.Identity.Web.Test.LabInfrastructure.csproj
@@ -5,12 +5,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.13.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/UserQuery.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/UserQuery.cs
@@ -8,48 +8,56 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
     public class UserQuery
     {
         public UserType? UserType { get; set; }
+
         public MFA? MFA { get; set; }
+
         public ProtectionPolicy? ProtectionPolicy { get; set; }
+
         public HomeDomain? HomeDomain { get; set; }
+
         public HomeUPN? HomeUPN { get; set; }
+
         public B2CIdentityProvider? B2CIdentityProvider { get; set; }
-        public FederationProvider? FederationProvider { get; set; } //Requires userType to be set to federated
+
+        public FederationProvider? FederationProvider { get; set; } // Requires userType to be set to federated
+
         public AzureEnvironment? AzureEnvironment { get; set; }
+
         public SignInAudience? SignInAudience { get; set; }
 
         public static UserQuery PublicAadUserQuery => new UserQuery()
         {
             UserType = LabInfrastructure.UserType.Cloud,
-            AzureEnvironment = LabInfrastructure.AzureEnvironment.azurecloud
+            AzureEnvironment = LabInfrastructure.AzureEnvironment.azurecloud,
         };
 
         public static UserQuery MsaUserQuery => new UserQuery
         {
-            UserType = LabInfrastructure.UserType.MSA
+            UserType = LabInfrastructure.UserType.MSA,
         };
 
         public static UserQuery B2CLocalAccountUserQuery => new UserQuery
         {
             UserType = LabInfrastructure.UserType.B2C,
-            B2CIdentityProvider = LabInfrastructure.B2CIdentityProvider.Local
+            B2CIdentityProvider = LabInfrastructure.B2CIdentityProvider.Local,
         };
 
         public static UserQuery B2CFacebookUserQuery => new UserQuery
         {
             UserType = LabInfrastructure.UserType.B2C,
-            B2CIdentityProvider = LabInfrastructure.B2CIdentityProvider.Facebook
+            B2CIdentityProvider = LabInfrastructure.B2CIdentityProvider.Facebook,
         };
 
         public static UserQuery B2CGoogleUserQuery => new UserQuery
         {
             UserType = LabInfrastructure.UserType.B2C,
-            B2CIdentityProvider = LabInfrastructure.B2CIdentityProvider.Google
+            B2CIdentityProvider = LabInfrastructure.B2CIdentityProvider.Google,
         };
 
         public static UserQuery B2CMSAUserQuery => new UserQuery
         {
             UserType = LabInfrastructure.UserType.B2C,
-            B2CIdentityProvider = LabInfrastructure.B2CIdentityProvider.MSA
+            B2CIdentityProvider = LabInfrastructure.B2CIdentityProvider.MSA,
         };
 
         // generated code, re-generate or update manually if you change the members of this class !
@@ -76,15 +84,15 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
         public override int GetHashCode()
         {
             var hashCode = 1863312741;
-            hashCode = hashCode * -1521134295 + EqualityComparer<UserType?>.Default.GetHashCode(UserType);
-            hashCode = hashCode * -1521134295 + EqualityComparer<MFA?>.Default.GetHashCode(MFA);
-            hashCode = hashCode * -1521134295 + EqualityComparer<ProtectionPolicy?>.Default.GetHashCode(ProtectionPolicy);
-            hashCode = hashCode * -1521134295 + EqualityComparer<HomeDomain?>.Default.GetHashCode(HomeDomain);
-            hashCode = hashCode * -1521134295 + EqualityComparer<HomeUPN?>.Default.GetHashCode(HomeUPN);
-            hashCode = hashCode * -1521134295 + EqualityComparer<B2CIdentityProvider?>.Default.GetHashCode(B2CIdentityProvider);
-            hashCode = hashCode * -1521134295 + EqualityComparer<FederationProvider?>.Default.GetHashCode(FederationProvider);
-            hashCode = hashCode * -1521134295 + EqualityComparer<AzureEnvironment?>.Default.GetHashCode(AzureEnvironment);
-            hashCode = hashCode * -1521134295 + EqualityComparer<SignInAudience?>.Default.GetHashCode(SignInAudience);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<UserType?>.Default.GetHashCode(UserType);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<MFA?>.Default.GetHashCode(MFA);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<ProtectionPolicy?>.Default.GetHashCode(ProtectionPolicy);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<HomeDomain?>.Default.GetHashCode(HomeDomain);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<HomeUPN?>.Default.GetHashCode(HomeUPN);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<B2CIdentityProvider?>.Default.GetHashCode(B2CIdentityProvider);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<FederationProvider?>.Default.GetHashCode(FederationProvider);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<AzureEnvironment?>.Default.GetHashCode(AzureEnvironment);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<SignInAudience?>.Default.GetHashCode(SignInAudience);
             return hashCode;
         }
         #endregion

--- a/tests/Microsoft.Identity.Web.Test/AccountExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AccountExtensionsTests.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Security.Claims;
 using Microsoft.Identity.Client;
 using NSubstitute;
 using Xunit;
-using System.Linq;
 
 namespace Microsoft.Identity.Web.Test
 {

--- a/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Web.Test
             {
                 Domain = TestConstants.B2CTenant,
                 Instance = TestConstants.B2CInstance,
-                SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow
+                SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow,
             };
             string expectedResult = $"{options.Instance}/{options.Domain}/{options.DefaultUserFlow}/v2.0";
 
@@ -40,7 +40,7 @@ namespace Microsoft.Identity.Web.Test
             MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
             {
                 TenantId = TestConstants.TenantIdAsGuid,
-                Instance = TestConstants.AadInstance
+                Instance = TestConstants.AadInstance,
             };
             string expectedResult = $"{options.Instance}/{options.TenantId}/v2.0";
 
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Web.Test
             MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
             {
                 TenantId = TestConstants.TenantIdAsGuid,
-                Instance = TestConstants.AadInstance + "/"
+                Instance = TestConstants.AadInstance + "/",
             };
             string expectedResult = $"{TestConstants.AadInstance}/{options.TenantId}/v2.0";
 
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Web.Test
         {
             OpenIdConnectOptions options = new OpenIdConnectOptions
             {
-                Authority = initialAuthority
+                Authority = initialAuthority,
             };
 
             options.Authority = AuthorityHelpers.EnsureAuthorityIsV2(options.Authority);

--- a/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Web.Test
             authProperties.Items.Add(OidcConstants.PolicyKey, CustomUserFlow);
             var context = new RedirectContext(httpContext, _authScheme, new OpenIdConnectOptions(), authProperties) { ProtocolMessage = new OpenIdConnectMessage() { IssuerAddress = _defaultIssuer } };
 
-            await handler.OnRedirectToIdentityProvider(context);
+            await handler.OnRedirectToIdentityProvider(context).ConfigureAwait(false);
 
             Assert.Equal(OpenIdConnectScope.OpenIdProfile, context.ProtocolMessage.Scope);
             Assert.Equal(OpenIdConnectResponseType.IdToken, context.ProtocolMessage.ResponseType);
@@ -54,7 +54,7 @@ namespace Microsoft.Identity.Web.Test
             authProperties.Items.Add(OidcConstants.PolicyKey, DefaultUserFlow);
             var context = new RedirectContext(httpContext, _authScheme, new OpenIdConnectOptions(), authProperties) { ProtocolMessage = new OpenIdConnectMessage() { IssuerAddress = _defaultIssuer } };
 
-            await handler.OnRedirectToIdentityProvider(context);
+            await handler.OnRedirectToIdentityProvider(context).ConfigureAwait(false);
 
             Assert.Null(context.ProtocolMessage.Scope);
             Assert.Null(context.ProtocolMessage.ResponseType);
@@ -70,8 +70,8 @@ namespace Microsoft.Identity.Web.Test
             var handler = new AzureADB2COpenIDConnectEventHandlers(OpenIdConnectDefaults.AuthenticationScheme, new MicrosoftIdentityOptions());
 
             var passwordResetException = "'access_denied', error_description: 'AADB2C90118: The user has forgotten their password. Correlation ID: f99deff4-f43b-43cc-b4e7-36141dbaf0a0 Timestamp: 2018-03-05 02:49:35Z', error_uri: 'error_uri is null'";
-            
-            await handler.OnRemoteFailure(new RemoteFailureContext(httpContext, _authScheme, new OpenIdConnectOptions(), new OpenIdConnectProtocolException(passwordResetException)));
+
+            await handler.OnRemoteFailure(new RemoteFailureContext(httpContext, _authScheme, new OpenIdConnectOptions(), new OpenIdConnectProtocolException(passwordResetException))).ConfigureAwait(false);
 
             httpContext.Response.Received().Redirect($"{httpContext.Request.PathBase}/MicrosoftIdentity/Account/ResetPassword/{OpenIdConnectDefaults.AuthenticationScheme}");
         }
@@ -85,10 +85,14 @@ namespace Microsoft.Identity.Web.Test
 
             var cancelException = "'access_denied', error_description: 'AADB2C90091: The user has canceled entering self-asserted information. Correlation ID: d01c8878-0732-4eb2-beb8-da82a57432e0 Timestamp: 2018-03-05 02:56:49Z ', error_uri: 'error_uri is null'";
 
-            await handler.OnRemoteFailure(new RemoteFailureContext(httpContext, _authScheme, new OpenIdConnectOptions(), new OpenIdConnectProtocolException(cancelException)));
+            await handler.OnRemoteFailure(
+                new RemoteFailureContext(
+                    httpContext,
+                    _authScheme,
+                    new OpenIdConnectOptions(),
+                    new OpenIdConnectProtocolException(cancelException))).ConfigureAwait(false);
 
             httpContext.Response.Received().Redirect($"{httpContext.Request.PathBase}/");
-
         }
 
         [Fact]
@@ -100,7 +104,12 @@ namespace Microsoft.Identity.Web.Test
 
             var otherException = "Generic exception.";
 
-            await handler.OnRemoteFailure(new RemoteFailureContext(httpContext, _authScheme, new OpenIdConnectOptions(), new OpenIdConnectProtocolException(otherException)));
+            await handler.OnRemoteFailure(
+                new RemoteFailureContext(
+                    httpContext,
+                    _authScheme,
+                    new OpenIdConnectOptions(),
+                    new OpenIdConnectProtocolException(otherException))).ConfigureAwait(false);
 
             httpContext.Response.Received().Redirect($"{httpContext.Request.PathBase}/MicrosoftIdentity/Account/Error");
         }

--- a/tests/Microsoft.Identity.Web.Test/Base64UrlHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Base64UrlHelpersTests.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Theory]
-        [InlineData("123456", "MTIzNDU2")] //No padding
-        [InlineData("12345678", "MTIzNDU2Nzg")] //1 padding
-        [InlineData("1234567", "MTIzNDU2Nw")] //2 padding
-        [InlineData("12>123", "MTI-MTIz")] //With Base64 plus
-        [InlineData("12?123", "MTI_MTIz")] //With Base64 slash
-        [InlineData("", "")] //Empty string
+        [InlineData("123456", "MTIzNDU2")] // No padding
+        [InlineData("12345678", "MTIzNDU2Nzg")] // 1 padding
+        [InlineData("1234567", "MTIzNDU2Nw")] // 2 padding
+        [InlineData("12>123", "MTI-MTIz")] // With Base64 plus
+        [InlineData("12?123", "MTI_MTIz")] // With Base64 slash
+        [InlineData("", "")] // Empty string
         public void Encode_UTF8ByteArrayOfDecodedString_ReturnsValidEncodedString(string stringToEncode, string expectedEncodedString)
         {
             var actualEncodedString = Base64UrlHelpers.Encode(Encoding.UTF8.GetBytes(stringToEncode));
@@ -38,26 +38,26 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Theory]
-        [InlineData("123456", "MTIzNDU2")] //No padding
-        [InlineData("12345678", "MTIzNDU2Nzg")] //1 padding
-        [InlineData("1234567", "MTIzNDU2Nw")] //2 padding
-        [InlineData("12>123", "MTI-MTIz")] //With Base64 plus
-        [InlineData("12?123", "MTI_MTIz")] //With Base64 slash
-        [InlineData("", "")] //Empty string
+        [InlineData("123456", "MTIzNDU2")] // No padding
+        [InlineData("12345678", "MTIzNDU2Nzg")] // 1 padding
+        [InlineData("1234567", "MTIzNDU2Nw")] // 2 padding
+        [InlineData("12>123", "MTI-MTIz")] // With Base64 plus
+        [InlineData("12?123", "MTI_MTIz")] // With Base64 slash
+        [InlineData("", "")] // Empty string
         public void Encode_DecodedString_ReturnsEncodedString(string stringToEncode, string expectedEncodedString)
-        {          
+        {
             var actualEncodedString = Base64UrlHelpers.Encode(stringToEncode);
 
             Assert.Equal(expectedEncodedString, actualEncodedString);
         }
 
         [Theory]
-        [InlineData("MTIzNDU2", "123456")] //No padding
-        [InlineData("MTIzNDU2Nzg", "12345678")] //1 padding
-        [InlineData("MTIzNDU2Nw", "1234567")] //2 padding
-        [InlineData("MTI-MTIz", "12>123")] //With Base64 plus
-        [InlineData("MTI_MTIz", "12?123")] //With Base64 slash
-        [InlineData("", "")] //Empty string
+        [InlineData("MTIzNDU2", "123456")] // No padding
+        [InlineData("MTIzNDU2Nzg", "12345678")] // 1 padding
+        [InlineData("MTIzNDU2Nw", "1234567")] // 2 padding
+        [InlineData("MTI-MTIz", "12>123")] // With Base64 plus
+        [InlineData("MTI_MTIz", "12?123")] // With Base64 slash
+        [InlineData("", "")] // Empty string
         public void DecodeToString_ValidBase64UrlString_ReturnsDecodedString(string stringToDecode, string expectedDecodedString)
         {
             var actualDecodedString = Base64UrlHelpers.DecodeToString(stringToDecode);
@@ -89,12 +89,12 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Theory]
-        [InlineData("MTIzNDU2", "123456")] //No padding
-        [InlineData("MTIzNDU2Nzg", "12345678")] //1 padding
-        [InlineData("MTIzNDU2Nw", "1234567")] //2 padding
-        [InlineData("MTI-MTIz", "12>123")] //With Base64 plus
-        [InlineData("MTI_MTIz", "12?123")] //With Base64 slash
-        [InlineData("", "")] //Empty string
+        [InlineData("MTIzNDU2", "123456")] // No padding
+        [InlineData("MTIzNDU2Nzg", "12345678")] // 1 padding
+        [InlineData("MTIzNDU2Nw", "1234567")] // 2 padding
+        [InlineData("MTI-MTIz", "12>123")] // With Base64 plus
+        [InlineData("MTI_MTIz", "12?123")] // With Base64 slash
+        [InlineData("", "")] // Empty string
         public void DecodeToBytes_ValidBase64UrlString_ReturnsByteArray(string stringToDecode, string expectedDecodedString)
         {
             var expectedDecodedByteArray = Encoding.UTF8.GetBytes(expectedDecodedString);

--- a/tests/Microsoft.Identity.Web.Test/ClaimsPrincipalExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClaimsPrincipalExtensionsTests.cs
@@ -26,9 +26,8 @@ namespace Microsoft.Identity.Web.Test
             var claimsPrincipalWithUtid = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.UniqueObjectIdentifier, Utid)
-                })
-            );
+                    new Claim(ClaimConstants.UniqueObjectIdentifier, Utid),
+                }));
 
             Assert.Equal(Utid, claimsPrincipalWithUtid.GetNameIdentifierId());
         }
@@ -41,29 +40,25 @@ namespace Microsoft.Identity.Web.Test
             Assert.Null(claimsPrincipal.GetNameIdentifierId());
         }
 
-
         [Fact]
         public void GetUserFlowId_WithTfpOrUserFlowClaims_ReturnsUserFlowId()
         {
             var claimsPrincipalWithTfp = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.Tfp, Tfp)
-                })
-            );
+                    new Claim(ClaimConstants.Tfp, Tfp),
+                }));
             var claimsPrincipalWithUserFlow = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.UserFlow, Userflow)
-                })
-            );
+                    new Claim(ClaimConstants.UserFlow, Userflow),
+                }));
             var claimsPrincipalWithTfpAndUserFlow = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimConstants.Tfp, Tfp),
-                    new Claim(ClaimConstants.UserFlow, Userflow)
-                })
-            );
+                    new Claim(ClaimConstants.UserFlow, Userflow),
+                }));
 
             Assert.Equal(Tfp, claimsPrincipalWithTfp.GetUserFlowId());
             Assert.Equal(Userflow, claimsPrincipalWithUserFlow.GetUserFlowId());
@@ -84,22 +79,19 @@ namespace Microsoft.Identity.Web.Test
             var claimsPrincipalWithOid = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.Oid, Oid)
-                })
-            );
+                    new Claim(ClaimConstants.Oid, Oid),
+                }));
             var claimsPrincipalWithObjectId = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.ObjectId, ObjectId)
-                })
-            );
+                    new Claim(ClaimConstants.ObjectId, ObjectId),
+                }));
             var claimsPrincipalWithOidAndObjectId = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimConstants.Oid, Oid),
-                    new Claim(ClaimConstants.ObjectId, ObjectId)
-                })
-            );
+                    new Claim(ClaimConstants.ObjectId, ObjectId),
+                }));
 
             Assert.Equal(Oid, claimsPrincipalWithOid.GetObjectId());
             Assert.Equal(ObjectId, claimsPrincipalWithObjectId.GetObjectId());
@@ -120,22 +112,19 @@ namespace Microsoft.Identity.Web.Test
             var claimsPrincipalWithTid = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.Tid, Tid)
-                })
-            );
+                    new Claim(ClaimConstants.Tid, Tid),
+                }));
             var claimsPrincipalWithTenantId = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.TenantId, TenantId)
-                })
-            );
+                    new Claim(ClaimConstants.TenantId, TenantId),
+                }));
             var claimsPrincipalWithTidAndTenantId = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimConstants.Tid, Tid),
-                    new Claim(ClaimConstants.TenantId, TenantId)
-                })
-            );
+                    new Claim(ClaimConstants.TenantId, TenantId),
+                }));
 
             Assert.Equal(Tid, claimsPrincipalWithTid.GetTenantId());
             Assert.Equal(TenantId, claimsPrincipalWithTenantId.GetTenantId());
@@ -156,36 +145,31 @@ namespace Microsoft.Identity.Web.Test
             var claimsPrincipalWithPreferredUsername = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.PreferredUserName, PreferredUsername)
-                })
-            );
+                    new Claim(ClaimConstants.PreferredUserName, PreferredUsername),
+                }));
             var claimsPrincipalWithNameV1 = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1)
-                })
-            );
+                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1),
+                }));
             var claimsPrincipalWithName = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.Name, Name)
-                })
-            );
+                    new Claim(ClaimConstants.Name, Name),
+                }));
             var claimsPrincipalWithNameV1AndName = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimConstants.Name, Name),
-                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1)
-                })
-            );
+                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1),
+                }));
             var claimsPrincipalWithPreferredUsernameAndNameV1AndName = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimConstants.Name, Name),
                     new Claim(ClaimConstants.PreferredUserName, PreferredUsername),
-                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1)
-                })
-            );
+                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1),
+                }));
 
             Assert.Equal(PreferredUsername, claimsPrincipalWithPreferredUsername.GetDisplayName());
             Assert.Equal(NameV1, claimsPrincipalWithNameV1.GetDisplayName());
@@ -210,16 +194,14 @@ namespace Microsoft.Identity.Web.Test
             var claimsPrincipalWithMsaTenant = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.TenantId, msaTenantId)
-                })
-            );
+                    new Claim(ClaimConstants.TenantId, msaTenantId),
+                }));
 
             var claimsPrincipalWithNonMsaTenant = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.TenantId, TestConstants.TenantIdAsGuid)
-                })
-            );
+                    new Claim(ClaimConstants.TenantId, TestConstants.TenantIdAsGuid),
+                }));
 
             Assert.Equal("consumers", claimsPrincipalWithMsaTenant.GetDomainHint());
             Assert.Equal("organizations", claimsPrincipalWithNonMsaTenant.GetDomainHint());
@@ -239,36 +221,31 @@ namespace Microsoft.Identity.Web.Test
             var claimsPrincipalWithPreferredUsername = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.PreferredUserName, PreferredUsername)
-                })
-            );
+                    new Claim(ClaimConstants.PreferredUserName, PreferredUsername),
+                }));
             var claimsPrincipalWithNameV1 = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1)
-                })
-            );
+                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1),
+                }));
             var claimsPrincipalWithName = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.Name, Name)
-                })
-            );
+                    new Claim(ClaimConstants.Name, Name),
+                }));
             var claimsPrincipalWithNameV1AndName = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimConstants.Name, Name),
-                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1)
-                })
-            );
+                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1),
+                }));
             var claimsPrincipalWithPreferredUsernameAndNameV1AndName = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimConstants.Name, Name),
                     new Claim(ClaimConstants.PreferredUserName, PreferredUsername),
-                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1)
-                })
-            );
+                    new Claim(ClaimsIdentity.DefaultNameClaimType, NameV1),
+                }));
 
             Assert.Equal(PreferredUsername, claimsPrincipalWithPreferredUsername.GetLoginHint());
             Assert.Equal(NameV1, claimsPrincipalWithNameV1.GetLoginHint());
@@ -297,17 +274,15 @@ namespace Microsoft.Identity.Web.Test
                     new Claim(ClaimConstants.Oid, Oid),
                     new Claim(ClaimConstants.UniqueObjectIdentifier, Utid),
                     new Claim(ClaimConstants.TenantId, Tid),
-                    new Claim(ClaimConstants.Tfp, Userflow)
-                })
-            );
+                    new Claim(ClaimConstants.Tfp, Userflow),
+                }));
             var claimsPrincipalForAad = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                                 new Claim(ClaimConstants.Oid, Oid),
                                 new Claim(ClaimConstants.PreferredUserName, Utid),
-                                new Claim(ClaimConstants.TenantId, Tid)
-                })
-            );
+                                new Claim(ClaimConstants.TenantId, Tid),
+                }));
 
             Assert.Equal(b2cPattern, claimsPrincipalForB2c.GetMsalAccountId());
             Assert.Equal(aadPattern, claimsPrincipalForAad.GetMsalAccountId());

--- a/tests/Microsoft.Identity.Web.Test/ClientInfoTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClientInfoTests.cs
@@ -69,12 +69,12 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void DeserializeFromJson_NullOrEmptyJsonByteArray_ReturnsNull()
         {
-            var actualClientInfo = ClientInfo.DeserializeFromJson<ClientInfo>(new byte[0]);
+            var actualClientInfo = ClientInfo.DeserializeFromJson<ClientInfo>(Array.Empty<byte>());
 
             Assert.Null(actualClientInfo);
 
             actualClientInfo = ClientInfo.DeserializeFromJson<ClientInfo>(null);
-            
+
             Assert.Null(actualClientInfo);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/CookiePolicyOptionsExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CookiePolicyOptionsExtensionsTests.cs
@@ -24,14 +24,14 @@ namespace Microsoft.Identity.Web.Test
         {
             _cookiePolicyOptions = new CookiePolicyOptions()
             {
-                MinimumSameSitePolicy = SameSiteMode.Strict
+                MinimumSameSitePolicy = SameSiteMode.Strict,
             };
             _httpContext = HttpContextUtilities.CreateHttpContext();
         }
 
         [Theory]
-        [InlineData(SameSiteMode.None, SameSiteMode.Unspecified, "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148")] //Allow SameSite None
-        [InlineData(SameSiteMode.None, SameSiteMode.None, "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1")] //Disallow SameSite None
+        [InlineData(SameSiteMode.None, SameSiteMode.Unspecified, "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148")] // Allow SameSite None
+        [InlineData(SameSiteMode.None, SameSiteMode.None, "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1")] // Disallow SameSite None
         [InlineData(SameSiteMode.Strict, SameSiteMode.Strict, "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148")]
         public void HandleSameSiteCookieCompatibility_Default_ExecutesSuccessfully(SameSiteMode initialSameSiteMode, SameSiteMode expectedSameSiteMode, string userAgent)
         {
@@ -53,8 +53,8 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Theory]
-        [InlineData(SameSiteMode.None, SameSiteMode.Unspecified, true, "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148")] //Allow SameSite None
-        [InlineData(SameSiteMode.None, SameSiteMode.None, true, "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1")] //Disallow SameSite None
+        [InlineData(SameSiteMode.None, SameSiteMode.Unspecified, true, "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148")] // Allow SameSite None
+        [InlineData(SameSiteMode.None, SameSiteMode.None, true, "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1")] // Disallow SameSite None
         [InlineData(SameSiteMode.Strict, SameSiteMode.Strict, false, "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148")]
         public void HandleSameSiteCookieCompatibility_CustomFilter_ExecutesSuccessfully(SameSiteMode initialSameSiteMode, SameSiteMode expectedSameSiteMode, bool expectedEventCalled, string userAgent)
         {
@@ -66,7 +66,8 @@ namespace Microsoft.Identity.Web.Test
             var appendEventCalled = false;
             var deleteEventCalled = false;
 
-            _cookiePolicyOptions.HandleSameSiteCookieCompatibility((userAgent) => {
+            _cookiePolicyOptions.HandleSameSiteCookieCompatibility((userAgent) =>
+            {
                 appendEventCalled = true;
                 return CookiePolicyOptionsExtensions.DisallowsSameSiteNone(userAgent);
             });
@@ -77,7 +78,8 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(expectedSameSiteMode, appendCookieOptions.SameSite);
             Assert.Equal(expectedEventCalled, appendEventCalled);
 
-            _cookiePolicyOptions.HandleSameSiteCookieCompatibility((userAgent) => {
+            _cookiePolicyOptions.HandleSameSiteCookieCompatibility((userAgent) =>
+            {
                 deleteEventCalled = true;
                 return CookiePolicyOptionsExtensions.DisallowsSameSiteNone(userAgent);
             });

--- a/tests/Microsoft.Identity.Web.Test/HttpContextExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/HttpContextExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Web.Test
     public class HttpContextExtensionsTests
     {
         private const string WebApiTokenKeyName = "JwtSecurityTokenUsedToCallWebAPI";
-        
+
         [Fact]
         public void StoreTokenUsedToCallWebAPI()
         {

--- a/tests/Microsoft.Identity.Web.Test/InstanceDiscovery/IssuerConfigurationRetrieverTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/InstanceDiscovery/IssuerConfigurationRetrieverTests.cs
@@ -23,13 +23,13 @@ namespace Microsoft.Identity.Web.Test.InstanceDiscovery
             var expectedAddressExceptionMessage = "Azure AD Issuer metadata address url is required (Parameter 'address')";
             var expectedRetrieverExceptionMessage = "No metadata document retriever is provided (Parameter 'retriever')";
 
-            var exception = await Assert.ThrowsAsync<ArgumentNullException>("address", () => configurationRetriever.GetConfigurationAsync(null, null, CancellationToken.None));
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>("address", () => configurationRetriever.GetConfigurationAsync(null, null, CancellationToken.None)).ConfigureAwait(false);
             Assert.Equal(expectedAddressExceptionMessage, exception.Message);
 
-            exception = await Assert.ThrowsAsync<ArgumentNullException>("address", () => configurationRetriever.GetConfigurationAsync("", null, CancellationToken.None));
+            exception = await Assert.ThrowsAsync<ArgumentNullException>("address", () => configurationRetriever.GetConfigurationAsync(string.Empty, null, CancellationToken.None)).ConfigureAwait(false);
             Assert.Equal(expectedAddressExceptionMessage, exception.Message);
 
-            exception = await Assert.ThrowsAsync<ArgumentNullException>("retriever", () => configurationRetriever.GetConfigurationAsync("address", null, CancellationToken.None));
+            exception = await Assert.ThrowsAsync<ArgumentNullException>("retriever", () => configurationRetriever.GetConfigurationAsync("address", null, CancellationToken.None)).ConfigureAwait(false);
             Assert.Equal(expectedRetrieverExceptionMessage, exception.Message);
         }
 
@@ -44,8 +44,8 @@ namespace Microsoft.Identity.Web.Test.InstanceDiscovery
             var documentRetriever = Substitute.For<IDocumentRetriever>();
             documentRetriever.GetDocumentAsync(metadataAddress, CancellationToken.None).Returns(Task.FromResult(metadata));
 
-            var actualIssuerMetadata = await configurationRetriever.GetConfigurationAsync(metadataAddress, documentRetriever, CancellationToken.None);
-            
+            var actualIssuerMetadata = await configurationRetriever.GetConfigurationAsync(metadataAddress, documentRetriever, CancellationToken.None).ConfigureAwait(false);
+
             Assert.Equal(expectedIssuerMetadata, actualIssuerMetadata, new IssuerMetadataComparer());
         }
 
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Web.Test.InstanceDiscovery
                             "login.microsoftonline.com"
                         }
                     }
-                }
+                },
             };
         }
 
@@ -75,9 +75,13 @@ namespace Microsoft.Identity.Web.Test.InstanceDiscovery
             public bool Equals([AllowNull] IssuerMetadata x, [AllowNull] IssuerMetadata y)
             {
                 if (x == null && y == null)
+                {
                     return true;
+                }
                 else if (x == null || y == null)
+                {
                     return false;
+                }
 
                 return x.TenantDiscoveryEndpoint == y.TenantDiscoveryEndpoint &&
                         x.ApiVersion == y.ApiVersion &&
@@ -92,9 +96,13 @@ namespace Microsoft.Identity.Web.Test.InstanceDiscovery
             public bool Equals([AllowNull] Metadata x, [AllowNull] Metadata y)
             {
                 if (x == null && y == null)
+                {
                     return true;
+                }
                 else if (x == null || y == null)
+                {
                     return false;
+                }
 
                 return x.PreferredNetwork == y.PreferredNetwork &&
                     x.PreferredCache == y.PreferredCache &&

--- a/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
+++ b/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -18,13 +22,17 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.13" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />
     <ProjectReference Include="..\Microsoft.Identity.Web.Test.Common\Microsoft.Identity.Web.Test.Common.csproj" />

--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.Test.Common;
-using System.Globalization;
 using Xunit;
 
 namespace Microsoft.Identity.Web.Test
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Web.Test
         {
             var options = new MicrosoftIdentityOptions()
             {
-                SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow
+                SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow,
             };
 
             Assert.True(options.IsB2C);
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Web.Test
 
             Assert.False(options.IsB2C);
 
-            options.SignUpSignInPolicyId = "";
+            options.SignUpSignInPolicyId = string.Empty;
 
             Assert.False(options.IsB2C);
         }
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Web.Test
             ClientId = 1,
             Instance = 2,
             TenantId = 3,
-            Domain = 4
+            Domain = 4,
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/Resource/AadIssuerValidatorTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/AadIssuerValidatorTests.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Web.Resource;
-using Microsoft.IdentityModel.Tokens;
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using Xunit;
+using Microsoft.Identity.Web.Resource;
 using Microsoft.Identity.Web.Test.Common;
 using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 using NSubstitute;
+using Xunit;
 
 namespace Microsoft.Identity.Web.Test.Resource
 {
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Web.Test.Resource
             var securityToken = Substitute.For<SecurityToken>();
             var validationParameters = new TokenValidationParameters();
             var expectedErrorMessage = "Neither `tid` nor `tenantId` claim is present in the token obtained from Microsoft identity platform.";
-            
+
             var exception = Assert.Throws<SecurityTokenInvalidIssuerException>(() => validator.Validate(TestConstants.AadIssuer, jwtSecurityToken, validationParameters));
             Assert.Equal(expectedErrorMessage, exception.Message);
 
@@ -124,7 +124,7 @@ namespace Microsoft.Identity.Web.Test.Resource
 
             var actualIssuer = validator.Validate(TestConstants.AadIssuer, jwtSecurityToken,
                 new TokenValidationParameters() { ValidIssuers = new[] { TestConstants.AadIssuer } });
-            
+
             Assert.Equal(TestConstants.AadIssuer, actualIssuer);
         }
 
@@ -170,8 +170,8 @@ namespace Microsoft.Identity.Web.Test.Resource
             var jwtSecurityToken = new JwtSecurityToken(issuer: TestConstants.AadIssuer, claims: new[] { issClaim, tidClaim });
             var expectedErrorMessage = $"Issuer: '{TestConstants.AadIssuer}', does not match any of the valid issuers provided for this application.";
 
-            var exception = Assert.Throws<SecurityTokenInvalidIssuerException>(() => 
-                validator.Validate(TestConstants.AadIssuer, jwtSecurityToken, 
+            var exception = Assert.Throws<SecurityTokenInvalidIssuerException>(() =>
+                validator.Validate(TestConstants.AadIssuer, jwtSecurityToken,
                     new TokenValidationParameters() { ValidIssuer = TestConstants.B2CIssuer }));
             Assert.Equal(expectedErrorMessage, exception.Message);
         }
@@ -207,7 +207,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                         ValidIssuers = new[] {
                             "https://host1/{tenantid}/v2.0",
                             "https://host2/{tenantid}/v2.0"
-                        }
+                        },
                     }));
             Assert.Equal(expectedErrorMessage, exception.Message);
         }
@@ -225,7 +225,7 @@ namespace Microsoft.Identity.Web.Test.Resource
             var expectedErrorMessage = $"Issuer: '{invalidIssuerToValidate}', does not match any of the valid issuers provided for this application.";
 
             var exception = Assert.Throws<SecurityTokenInvalidIssuerException>(() =>
-                validator.Validate(invalidIssuerToValidate,jwtSecurityToken,
+                validator.Validate(invalidIssuerToValidate, jwtSecurityToken,
                     new TokenValidationParameters() { ValidIssuers = new[] { TestConstants.AadIssuer } }));
             Assert.Equal(expectedErrorMessage, exception.Message);
         }
@@ -246,7 +246,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 jwtSecurityToken,
                 new TokenValidationParameters()
                 {
-                    ValidIssuers = new[] { TestConstants.B2CIssuer }
+                    ValidIssuers = new[] { TestConstants.B2CIssuer },
                 });
         }
 
@@ -267,7 +267,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 jwtSecurityToken,
                 new TokenValidationParameters()
                 {
-                    ValidIssuers = new[] { TestConstants.B2CIssuer }
+                    ValidIssuers = new[] { TestConstants.B2CIssuer },
                 });
         }
 
@@ -288,7 +288,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                     jwtSecurityToken,
                     new TokenValidationParameters()
                     {
-                        ValidIssuers = new[] { TestConstants.B2CIssuer }
+                        ValidIssuers = new[] { TestConstants.B2CIssuer },
                     })
                 );
         }
@@ -311,7 +311,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                     jwtSecurityToken,
                     new TokenValidationParameters()
                     {
-                        ValidIssuers = new[] { TestConstants.B2CIssuer }
+                        ValidIssuers = new[] { TestConstants.B2CIssuer },
                     })
                 );
         }
@@ -332,7 +332,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 jwtSecurityToken,
                 new TokenValidationParameters()
                 {
-                    ValidIssuers = new[] { TestConstants.B2CCustomDomainIssuer }
+                    ValidIssuers = new[] { TestConstants.B2CCustomDomainIssuer },
                 });
         }
     }

--- a/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerMiddlewareDiagnosticsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerMiddlewareDiagnosticsTests.cs
@@ -5,13 +5,13 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web.Resource;
+using Microsoft.Identity.Web.Test.Common.Mocks;
 using Microsoft.Identity.Web.Test.Common.TestHelpers;
 using NSubstitute;
 using Xunit;
-using Microsoft.Identity.Web.Test.Common.Mocks;
-using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.Identity.Web.Test.Resource
 {
@@ -38,7 +38,8 @@ namespace Microsoft.Identity.Web.Test.Resource
             _jwtOptions = new JwtBearerOptions();
             _jwtEvents = new JwtBearerEvents();
             _authScheme = new AuthenticationScheme(JwtBearerDefaults.AuthenticationScheme, JwtBearerDefaults.AuthenticationScheme, typeof(JwtBearerHandler));
-            _eventHandler = (context) => {
+            _eventHandler = (context) =>
+            {
                 _customEventWasRaised = true;
                 return Task.CompletedTask;
             };
@@ -46,9 +47,9 @@ namespace Microsoft.Identity.Web.Test.Resource
 
         [Fact]
         public async void Subscribe_OnAuthenticationFailed_CompletesSuccessfully()
-        {          
+        {
             _jwtEvents.OnAuthenticationFailed = _eventHandler;
-            _jwtDiagnostics.Subscribe(_jwtEvents);         
+            _jwtDiagnostics.Subscribe(_jwtEvents);
             await _jwtEvents.AuthenticationFailed(new AuthenticationFailedContext(_httpContext, _authScheme, _jwtOptions)).ConfigureAwait(false);
 
             AssertSuccess();

--- a/tests/Microsoft.Identity.Web.Test/Resource/OpenIdConnectMiddlewareDiagnosticsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/OpenIdConnectMiddlewareDiagnosticsTests.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Identity.Web.Test.Resource
             _openIdEvents = new OpenIdConnectEvents();
             _authProperties = new AuthenticationProperties();
             _authScheme = new AuthenticationScheme(OpenIdConnectDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme, typeof(OpenIdConnectHandler));
-            _eventHandler = (context) => {
+            _eventHandler = (context) =>
+            {
                 _customEventWasRaised = true;
                 return Task.CompletedTask;
             };

--- a/tests/Microsoft.Identity.Web.Test/Resource/ScopesRequiredHttpContextExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/ScopesRequiredHttpContextExtensionsTests.cs
@@ -6,8 +6,8 @@ using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Identity.Web.Resource;
-using Xunit;
 using Microsoft.Identity.Web.Test.Common.TestHelpers;
+using Xunit;
 
 namespace Microsoft.Identity.Web.Test.Resource
 {
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             HttpContext httpContext = null;
 
-            Assert.Throws<NullReferenceException>(() => httpContext.VerifyUserHasAnyAcceptedScope(""));
+            Assert.Throws<NullReferenceException>(() => httpContext.VerifyUserHasAnyAcceptedScope(string.Empty));
 
             httpContext = HttpContextUtilities.CreateHttpContext();
 

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -18,15 +18,18 @@ namespace Microsoft.Identity.Web.Test
 
             services.AddTokenAcquisition();
 
-            Assert.Collection(services.OrderBy(s => s.ServiceType.Name),
-                actual => {
+            Assert.Collection(
+                services.OrderBy(s => s.ServiceType.Name),
+                actual =>
+                {
                     Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
                     Assert.Equal(typeof(IHttpContextAccessor), actual.ServiceType);
                     Assert.Equal(typeof(HttpContextAccessor), actual.ImplementationType);
                     Assert.Null(actual.ImplementationInstance);
                     Assert.Null(actual.ImplementationFactory);
                 },
-                actual => {
+                actual =>
+                {
                     Assert.Equal(ServiceLifetime.Scoped, actual.Lifetime);
                     Assert.Equal(typeof(ITokenAcquisition), actual.ServiceType);
                     Assert.Equal(typeof(TokenAcquisition), actual.ImplementationType);

--- a/tests/Microsoft.Identity.Web.Test/WebApiExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebApiExtensionsTests.cs
@@ -58,14 +58,16 @@ namespace Microsoft.Identity.Web.Test
                 .AddLogging();
 
             if (useServiceCollectionExtension)
+            {
                 services.AddProtectedWebApi(config, _configSectionName, _jwtBearerScheme, _certificate, true);
+            }
             else
                 new AuthenticationBuilder(services)
                     .AddProtectedWebApi(config, _configSectionName, _jwtBearerScheme, _certificate, true);
 
             var provider = services.BuildServiceProvider();
 
-            //Config bind actions added correctly
+            // Config bind actions added correctly
             provider.GetRequiredService<IOptionsFactory<JwtBearerOptions>>().Create(_jwtBearerScheme);
             provider.GetRequiredService<IOptionsFactory<MicrosoftIdentityOptions>>().Create(string.Empty);
             config.Received(3).GetSection(_configSectionName);
@@ -82,14 +84,16 @@ namespace Microsoft.Identity.Web.Test
                 .AddLogging();
 
             if (useServiceCollectionExtension)
+            {
                 services.AddProtectedWebApi(_configureJwtOptions, _configureMsOptions, _certificate, _jwtBearerScheme, true);
+            }
             else
                 new AuthenticationBuilder(services)
                     .AddProtectedWebApi(_configureJwtOptions, _configureMsOptions, _certificate, _jwtBearerScheme, true);
 
             var provider = services.BuildServiceProvider();
 
-            //Configure options actions added correctly
+            // Configure options actions added correctly
             var configuredJwtOptions = provider.GetServices<IConfigureOptions<JwtBearerOptions>>().Cast<ConfigureNamedOptions<JwtBearerOptions>>();
             var configuredMsOptions = provider.GetServices<IConfigureOptions<MicrosoftIdentityOptions>>().Cast<ConfigureNamedOptions<MicrosoftIdentityOptions>>();
 
@@ -101,19 +105,19 @@ namespace Microsoft.Identity.Web.Test
 
         private void AddProtectedWebApi_TestCommon(IServiceCollection services, ServiceProvider provider)
         {
-            //Correct services added
+            // Correct services added
             Assert.Contains(services, s => s.ServiceType == typeof(IHttpContextAccessor));
             Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<MicrosoftIdentityOptions>));
             Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>));
             Assert.Contains(services, s => s.ServiceType == typeof(IJwtBearerMiddlewareDiagnostics));
             Assert.Equal(ServiceLifetime.Singleton, services.First(s => s.ServiceType == typeof(IJwtBearerMiddlewareDiagnostics)).Lifetime);
 
-            //JWT options added correctly
+            // JWT options added correctly
             var configuredJwtOptions = provider.GetService<IConfigureOptions<JwtBearerOptions>>() as ConfigureNamedOptions<JwtBearerOptions>;
 
             Assert.Equal(_jwtBearerScheme, configuredJwtOptions.Name);
 
-            //Issuer validator and certificate set
+            // Issuer validator and certificate set
             var jwtOptions = provider.GetRequiredService<IOptionsFactory<JwtBearerOptions>>().Create(_jwtBearerScheme);
 
             Assert.NotNull(jwtOptions.Authority);
@@ -139,7 +143,9 @@ namespace Microsoft.Identity.Web.Test
                 .AddLogging();
 
             if (useServiceCollectionExtension)
+            {
                 services.AddProtectedWebApi(config, _configSectionName, _jwtBearerScheme, _certificate, true);
+            }
             else
                 new AuthenticationBuilder(services)
                     .AddProtectedWebApi(config, _configSectionName, _jwtBearerScheme, _certificate, true);
@@ -166,7 +172,9 @@ namespace Microsoft.Identity.Web.Test
                 .AddLogging();
 
             if (useServiceCollectionExtension)
+            {
                 services.AddProtectedWebApi(_configureJwtOptions, _configureMsOptions, _certificate, _jwtBearerScheme, true);
+            }
             else
                 new AuthenticationBuilder(services)
                     .AddProtectedWebApi(_configureJwtOptions, _configureMsOptions, _certificate, _jwtBearerScheme, true);
@@ -189,17 +197,17 @@ namespace Microsoft.Identity.Web.Test
             var tokenValidatedContext = new TokenValidatedContext(httpContext, authScheme, jwtOptions);
             tokenValidatedContext.Principal = new ClaimsPrincipal();
 
-            //No scopes throws exception
+            // No scopes throws exception
             var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => { await jwtOptions.Events.TokenValidated(tokenValidatedContext).ConfigureAwait(false); }).ConfigureAwait(false);
             Assert.Equal(expectedExceptionMessage, exception.Message);
 
-            //At least one scope executes successfully
+            // At least one scope executes successfully
             foreach (var scopeType in scopeTypes)
             {
                 tokenValidatedContext.Principal = new ClaimsPrincipal(
                     new ClaimsIdentity(new Claim[]
                     {
-                        new Claim(scopeType, scopeValue)
+                        new Claim(scopeType, scopeValue),
                     })
                 );
                 await jwtOptions.Events.TokenValidated(tokenValidatedContext).ConfigureAwait(false);
@@ -224,7 +232,9 @@ namespace Microsoft.Identity.Web.Test
                 .AddLogging();
 
             if (useServiceCollectionExtension)
+            {
                 services.AddProtectedWebApi(config, _configSectionName, _jwtBearerScheme, _certificate, subscribeToDiagnostics);
+            }
             else
                 new AuthenticationBuilder(services)
                     .AddProtectedWebApi(config, _configSectionName, _jwtBearerScheme, _certificate, subscribeToDiagnostics);
@@ -237,9 +247,13 @@ namespace Microsoft.Identity.Web.Test
             var jwtOptions = provider.GetRequiredService<IOptionsFactory<JwtBearerOptions>>().Create(_jwtBearerScheme);
 
             if (subscribeToDiagnostics)
+            {
                 diagnostics.Received().Subscribe(Arg.Any<JwtBearerEvents>());
+            }
             else
+            {
                 diagnostics.DidNotReceive().Subscribe(Arg.Any<JwtBearerEvents>());
+            }
         }
 
         [Theory]
@@ -255,7 +269,9 @@ namespace Microsoft.Identity.Web.Test
                 .AddLogging();
 
             if (useServiceCollectionExtension)
+            {
                 services.AddProtectedWebApi(_configureJwtOptions, _configureMsOptions, _certificate, _jwtBearerScheme, subscribeToDiagnostics);
+            }
             else
                 new AuthenticationBuilder(services)
                     .AddProtectedWebApi(_configureJwtOptions, _configureMsOptions, _certificate, _jwtBearerScheme, subscribeToDiagnostics);
@@ -268,9 +284,13 @@ namespace Microsoft.Identity.Web.Test
             var jwtOptions = provider.GetRequiredService<IOptionsFactory<JwtBearerOptions>>().Create(_jwtBearerScheme);
 
             if (subscribeToDiagnostics)
+            {
                 diagnostics.Received().Subscribe(Arg.Any<JwtBearerEvents>());
+            }
             else
+            {
                 diagnostics.DidNotReceive().Subscribe(Arg.Any<JwtBearerEvents>());
+            }
         }
 
         private IConfigurationSection GetConfigSection(string configSectionName)
@@ -280,7 +300,7 @@ namespace Microsoft.Identity.Web.Test
                 { configSectionName, null },
                 { $"{configSectionName}:Instance", TestConstants.AadInstance },
                 { $"{configSectionName}:TenantId", TestConstants.TenantIdAsGuid },
-                { $"{configSectionName}:ClientId", TestConstants.TenantIdAsGuid }
+                { $"{configSectionName}:ClientId", TestConstants.TenantIdAsGuid },
             };
             var memoryConfigSource = new MemoryConfigurationSource { InitialData = configAsDictionary };
             var configBuilder = new ConfigurationBuilder();
@@ -298,7 +318,7 @@ namespace Microsoft.Identity.Web.Test
                 .AddProtectedWebApiCallsProtectedWebApi(config, _configSectionName, _jwtBearerScheme);
             var provider = services.BuildServiceProvider();
 
-            //Config bind actions added correctly
+            // Config bind actions added correctly
             provider.GetRequiredService<IOptionsFactory<ConfidentialClientApplicationOptions>>().Create(string.Empty);
             provider.GetRequiredService<IOptionsFactory<MicrosoftIdentityOptions>>().Create(string.Empty);
 
@@ -314,7 +334,7 @@ namespace Microsoft.Identity.Web.Test
                 .AddProtectedWebApiCallsProtectedWebApi(_configureAppOptions, _configureMsOptions, _jwtBearerScheme);
             var provider = services.BuildServiceProvider();
 
-            //Configure options actions added correctly
+            // Configure options actions added correctly
             var configuredAppOptions = provider.GetServices<IConfigureOptions<ConfidentialClientApplicationOptions>>().Cast<ConfigureNamedOptions<ConfidentialClientApplicationOptions>>();
             var configuredMsOptions = provider.GetServices<IConfigureOptions<MicrosoftIdentityOptions>>().Cast<ConfigureNamedOptions<MicrosoftIdentityOptions>>();
 
@@ -326,19 +346,19 @@ namespace Microsoft.Identity.Web.Test
 
         private void AddProtectedWebApiCallsProtectedWebApi_TestCommon(IServiceCollection services, ServiceProvider provider)
         {
-            //Correct services added
+            // Correct services added
             Assert.Contains(services, s => s.ServiceType == typeof(IHttpContextAccessor));
             Assert.Contains(services, s => s.ServiceType == typeof(ITokenAcquisition));
             Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<ConfidentialClientApplicationOptions>));
             Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<MicrosoftIdentityOptions>));
             Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>));
 
-            //JWT options added correctly
+            // JWT options added correctly
             var configuredJwtOptions = provider.GetService<IConfigureOptions<JwtBearerOptions>>() as ConfigureNamedOptions<JwtBearerOptions>;
 
             Assert.Equal(_jwtBearerScheme, configuredJwtOptions.Name);
 
-            //Token validated event added correctly
+            // Token validated event added correctly
             var jwtOptions = provider.GetRequiredService<IOptionsFactory<JwtBearerOptions>>().Create(_jwtBearerScheme);
             var httpContext = HttpContextUtilities.CreateHttpContext();
             var authScheme = new AuthenticationScheme(JwtBearerDefaults.AuthenticationScheme, JwtBearerDefaults.AuthenticationScheme, typeof(JwtBearerHandler));
@@ -368,11 +388,11 @@ namespace Microsoft.Identity.Web.Test
                 TokenValidationParameters = new TokenValidationParameters()
                 {
                     ValidAudiences = initialAudiences
-                }
+                },
             };
             MicrosoftIdentityOptions msIdentityOptions = new MicrosoftIdentityOptions()
             {
-                ClientId = TestConstants.ApiClientId
+                ClientId = TestConstants.ApiClientId,
             };
 
             WebApiAuthenticationBuilderExtensions.EnsureValidAudiencesContainsApiGuidIfGuidProvided(jwtOptions, msIdentityOptions);

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -42,7 +43,7 @@ namespace Microsoft.Identity.Web.Test
             options.TenantId = TestConstants.TenantIdAsGuid;
             options.ClientId = TestConstants.ClientId;
         };
-        
+
         public WebAppExtensionsTests()
         {
             _configSection = GetConfigSection(_configSectionName);
@@ -316,7 +317,7 @@ namespace Microsoft.Identity.Web.Test
 
         private void AddSignIn_TestCommon(IServiceCollection services, ServiceProvider provider)
         {
-            // Assert correct services added           
+            // Assert correct services added
             Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<OpenIdConnectOptions>));
             Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<MicrosoftIdentityOptions>));
             Assert.Contains(services, s => s.ServiceType == typeof(IOpenIdConnectMiddlewareDiagnostics));
@@ -409,7 +410,7 @@ namespace Microsoft.Identity.Web.Test
             // Assert issuer is updated to non-default user flow
             Assert.Contains(TestConstants.B2CEditProfileUserFlow, redirectContext.ProtocolMessage.IssuerAddress);
             Assert.NotNull(redirectContext.ProtocolMessage.Parameters["client_info"]);
-            Assert.Equal("1", redirectContext.ProtocolMessage.Parameters["client_info"].ToString());
+            Assert.Equal("1", redirectContext.ProtocolMessage.Parameters["client_info"].ToString(CultureInfo.InvariantCulture));;
         }
 
         private void AddWebAppCallsProtectedWebApi_TestCommon(IServiceCollection services, ServiceProvider provider, OpenIdConnectOptions oidcOptions, IEnumerable<string> initialScopes)
@@ -433,9 +434,9 @@ namespace Microsoft.Identity.Web.Test
         }
 
         private async Task AddWebAppCallsProtectedWebApi_TestAuthorizationCodeReceivedEvent(
-            IServiceProvider provider, 
-            OpenIdConnectOptions oidcOptions, 
-            Func<AuthorizationCodeReceivedContext, Task> authCodeReceivedFuncMock, 
+            IServiceProvider provider,
+            OpenIdConnectOptions oidcOptions,
+            Func<AuthorizationCodeReceivedContext, Task> authCodeReceivedFuncMock,
             ITokenAcquisition tokenAcquisitionMock)
         {
             var (httpContext, authScheme, authProperties) = CreateContextParameters(provider);
@@ -461,9 +462,9 @@ namespace Microsoft.Identity.Web.Test
         }
 
         private async Task AddWebAppCallsProtectedWebApi_TestRedirectToIdentityProviderForSignOutEvent(
-            IServiceProvider provider, 
-            OpenIdConnectOptions oidcOptions, 
-            Func<RedirectContext, Task> redirectFuncMock, 
+            IServiceProvider provider,
+            OpenIdConnectOptions oidcOptions,
+            Func<RedirectContext, Task> redirectFuncMock,
             ITokenAcquisition tokenAcquisitionMock)
         {
             var (httpContext, authScheme, authProperties) = CreateContextParameters(provider);


### PR DESCRIPTION
- Included rules from MSAL .editorconfig into root .editorconfig.
- Included rules from MSAL SolutionWideAnalyzerConfig.ruleset into root .editorconfig.
- Added some rule suppressions to the tests .editorconfig.
- Added StyleCop analyzers.
- Moved stylecop.json config into solution level and referenced from the projects.
- Also includes Jenny's fixes.

This PR has a lot of files mostly because some warnings had a lot of occurrences (but it's mostly tiny changes). Following PRs should be smaller. Once this one is approved and merged, I will send a PR for the rest of the changes.

Includes fixes for:
- CA1305. Specify IFormatProvider.
- CA2007. Call ConfigureAwait on the awaited Task.
- SA1001. The spacing around a comma is incorrect, within a C# code file.
- SA1003. The spacing around an operator symbol is incorrect, within a C# code file.
- SA1004. A line within a documentation header above a C# element does not begin with a single space.
- SA1005. A single-line comment within a C# code file does not begin with a single space.
- SA1028. A line of code ends with a space, tab, or other whitespace characters before the end of line character(s).
- SA1208. A using directive which declares a member of the System namespace appears after a using directive which declares a member of a different namespace, within a C# code file.
- SA1413. A multi-line initializer should use a comma on the last item.
- SA1503. The opening and closing braces for a C# statement have been omitted.
- SA1600. A C# code element is missing a documentation header.
- SA1629. A section of the Xml header documentation for a C# element does not end with a period (also known as a full stop).