### PR TITLE
Minor fixes to samples home page

### DIFF
--- a/tests/B2CWebAppCallsWebApi/Client/Views/Home/Index.cshtml
+++ b/tests/B2CWebAppCallsWebApi/Client/Views/Home/Index.cshtml
@@ -2,11 +2,11 @@
     ViewData["Title"] = "Home Page";
 }
 
-    <h1>
-        How to secure a Web API built with ASP.NET Core using the Microsoft identity platform (formerly Azure Active Directory for developers)
-    </h1>
-    <p>
-        This sample shows how to secure a Web API built with ASP.NET Core using the Microsoft identity platform (formerly Azure Active Directory for developers).The client uses OpenID Connect to sign in users. It leverages the ASP.NET Core OpenID Connect middleware
-        and MSAL.NET.
-    </p>
-<img src="https://raw.githubusercontent.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/master/4-WebApp-your-API/ReadmeFiles/topology.png"/>
+<h1>
+    How to secure a Web API built with ASP.NET Core using the Microsoft identity platform (formerly Azure Active Directory for developers)
+</h1>
+<p>
+    This sample shows how to secure a Web API built with ASP.NET Core using the Microsoft identity platform (formerly Azure Active Directory for developers).The client uses OpenID Connect to sign in users. It leverages the ASP.NET Core OpenID Connect middleware
+    and MSAL.NET.
+</p>
+<img src="https://github.com/AzureAD/microsoft-identity-web/blob/master/tests/B2CWebAppCallsWebApi/ReadmeFiles/topology.png?raw=true" />

--- a/tests/B2CWebAppCallsWebApi/Client/Views/Shared/_CookieConsentPartial.cshtml
+++ b/tests/B2CWebAppCallsWebApi/Client/Views/Shared/_CookieConsentPartial.cshtml
@@ -7,7 +7,7 @@
 
 @if (showBanner)
 {
-    <nav id="cookieConsent" class="navbar navbar-default navbar-fixed-top" role="alert">
+    <nav id="cookieConsent" class="navbar navbar-default navbar-fixed-bottom" role="alert">
         <div class="container">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#cookieConsent .navbar-collapse">

--- a/tests/WebAppCallsWebApiCallsGraph/Client/Views/Home/Index.cshtml
+++ b/tests/WebAppCallsWebApiCallsGraph/Client/Views/Home/Index.cshtml
@@ -2,11 +2,11 @@
     ViewData["Title"] = "Home Page";
 }
 
-    <h1>
-        How to secure a Web API built with ASP.NET Core using the Microsoft identity platform (formerly Azure Active Directory for developers)
-    </h1>
-    <p>
-        This sample shows how to secure a Web API built with ASP.NET Core using the Microsoft identity platform (formerly Azure Active Directory for developers).The client uses OpenID Connect to sign in users. It leverages the ASP.NET Core OpenID Connect middleware
-        and MSAL.NET.
-    </p>
-<img src="https://raw.githubusercontent.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/master/4-WebApp-your-API/ReadmeFiles/topology.png"/>
+<h1>
+    How to secure a Web API built with ASP.NET Core using the Microsoft identity platform (formerly Azure Active Directory for developers)
+</h1>
+<p>
+    This sample shows how to secure a Web API built with ASP.NET Core using the Microsoft identity platform (formerly Azure Active Directory for developers).The client uses OpenID Connect to sign in users. It leverages the ASP.NET Core OpenID Connect middleware
+    and MSAL.NET.
+</p>
+<img src="https://github.com/AzureAD/microsoft-identity-web/blob/master/tests/WebAppCallsWebApiCallsGraph/ReadmeFiles/topology.png?raw=true" />

--- a/tests/WebAppCallsWebApiCallsGraph/Client/Views/Shared/_CookieConsentPartial.cshtml
+++ b/tests/WebAppCallsWebApiCallsGraph/Client/Views/Shared/_CookieConsentPartial.cshtml
@@ -7,7 +7,7 @@
 
 @if (showBanner)
 {
-    <nav id="cookieConsent" class="navbar navbar-default navbar-fixed-top" role="alert">
+    <nav id="cookieConsent" class="navbar navbar-default navbar-fixed-bottom" role="alert">
         <div class="container">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#cookieConsent .navbar-collapse">


### PR DESCRIPTION
In both sample client projects:
- moved the cookie consent bar to bottom. (Currently it completely hides the menu bar, which is a bit confusing.)
**Before:**
![image](https://user-images.githubusercontent.com/34331512/81511526-e02a2c80-92ce-11ea-9bd1-57475a65bf64.png)

- updated images on home pages.
**Before:** 
![image](https://user-images.githubusercontent.com/34331512/81511455-7e69c280-92ce-11ea-9229-d76ce1f6f6f5.png)
**After:**
![image](https://user-images.githubusercontent.com/34331512/81511465-90e3fc00-92ce-11ea-88e8-5fcac64ce69f.png)