### PR TITLE
fix: #154 AddProtectedWebApiCallProtectedWebApi overwrites handler

### DIFF
--- a/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -124,11 +124,15 @@ namespace Microsoft.Identity.Web
             {
                 options.Events ??= new JwtBearerEvents();
 
+                var onTokenValidatedHandler = options.Events.OnTokenValidated;
+
                 options.Events.OnTokenValidated = async context =>
                 {
                     context.HttpContext.StoreTokenUsedToCallWebAPI(context.SecurityToken as JwtSecurityToken);
                     context.Success();
                     await Task.FromResult(0).ConfigureAwait(false);
+
+                    await onTokenValidatedHandler(context).ConfigureAwait(false);
                 };
             });
 

--- a/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -128,11 +128,10 @@ namespace Microsoft.Identity.Web
 
                 options.Events.OnTokenValidated = async context =>
                 {
+                    await onTokenValidatedHandler(context).ConfigureAwait(false);                
                     context.HttpContext.StoreTokenUsedToCallWebAPI(context.SecurityToken as JwtSecurityToken);
                     context.Success();
                     await Task.FromResult(0).ConfigureAwait(false);
-
-                    await onTokenValidatedHandler(context).ConfigureAwait(false);
                 };
             });
 


### PR DESCRIPTION
Code now preserves existing event handler when registering OnTokenValidated event handler in AddProtectedWebApiCallsProtectedWebApi.  Previous code was overwriting existing event handler meaning that logging via JwtBearerMiddlewareDiagnostics would no longer work and perhaps more seriously the OnTokenValidated event handler registered in AddProtectedWebApi (intended to "ensure that the Web API only accepts tokens from tenants where it has been consented and provisioned.")

https://github.com/AzureAD/microsoft-identity-web/issues/154