### PR TITLE
Removing a useless instruction and generating XML comments

### DIFF
--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
                  {
                      RedirectUri = callbackUrl,
                  },
-                CookieAuthenticationDefaults.AuthenticationScheme,
-                scheme);
+                 CookieAuthenticationDefaults.AuthenticationScheme,
+                 scheme);
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
+++ b/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
@@ -6,93 +6,99 @@
     <members>
         <member name="T:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController">
             <summary>
-            Controller used in web apps to manage accounts
+            Controller used in web apps to manage accounts.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.#ctor(Microsoft.Extensions.Options.IOptionsMonitor{Microsoft.Identity.Web.MicrosoftIdentityOptions})">
             <summary>
             Constructor of <see cref="T:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController"/> from <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/>
-            This constructor is used by dependency injection
+            This constructor is used by dependency injection.
             </summary>
-            <param name="microsoftIdentityOptions">Configuration options</param>
+            <param name="microsoftIdentityOptions">Configuration options.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.SignIn(System.String)">
             <summary>
-            Handles user sign in
+            Handles user sign in.
             </summary>
-            <param name="scheme">Authentication scheme</param>
-            <returns>Challenge generating a redirect to Azure AD to sign in the user</returns>
+            <param name="scheme">Authentication scheme.</param>
+            <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.SignOut(System.String)">
             <summary>
-            Handles the user sign-out
+            Handles the user sign-out.
             </summary>
-            <param name="scheme">Authentication scheme</param>
-            <returns>Sign out result</returns>
+            <param name="scheme">Authentication scheme.</param>
+            <returns>Sign out result.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.ResetPassword(System.String)">
             <summary>
-            In B2C applications handles the Reset password policy
+            In B2C applications handles the Reset password policy.
             </summary>
-            <param name="scheme">Authentication scheme</param>
-            <returns>Challenge generating a redirect to Azure AD B2C</returns>
+            <param name="scheme">Authentication scheme.</param>
+            <returns>Challenge generating a redirect to Azure AD B2C.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.EditProfile(System.String)">
             <summary>
-            In B2C applications, handles the Edit Profile policy
+            In B2C applications, handles the Edit Profile policy.
             </summary>
-            <param name="scheme">Authentication scheme</param>
-            <returns>Challenge generating a redirect to Azure AD B2C</returns>
+            <param name="scheme">Authentication scheme.</param>
+            <returns>Challenge generating a redirect to Azure AD B2C.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.AccessDeniedModel">
             <summary>
-            Page presenting the Access denied error
+            Page presenting the Access denied error.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.AccessDeniedModel.OnGet">
             <summary>
-            Method handling the Get Http verb
+            Method handling the HTTP GET method.
             </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel">
             <summary>
-            Model for the Error page
+            Model for the Error page.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.RequestId">
             <summary>
             This API supports infrastructure and is not intended to be used
-            directly from your code.This API may change or be removed in future releases
+            directly from your code.This API may change or be removed in future releases.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.ShowRequestId">
             <summary>
             This API supports infrastructure and is not intended to be used
-            directly from your code.This API may change or be removed in future releases
+            directly from your code.This API may change or be removed in future releases.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.OnGet">
             <summary>
             This API supports infrastructure and is not intended to be used
-            directly from your code.This API may change or be removed in future releases
+            directly from your code.This API may change or be removed in future releases.
             </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.SignedOutModel">
             <summary>
-            Model for the SignOut page
+            Model for the SignOut page.
             </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.SignedOutModel.OnGet">
+            <summary>
+            Method handling the HTTP GET method.
+            </summary>
+            <returns></returns>
         </member>
         <member name="T:Microsoft.Identity.Web.UI.ServiceCollectionExtensions">
             <summary>
             Extension method on <see cref="T:Microsoft.Extensions.DependencyInjection.IMvcBuilder"/> to add UI
-            for Microsoft.Identity.Web
+            for Microsoft.Identity.Web.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.ServiceCollectionExtensions.AddMicrosoftIdentityUI(Microsoft.Extensions.DependencyInjection.IMvcBuilder)">
             <summary>
             Adds a controller and Razor pages for the accounts management.
             </summary>
-            <param name="builder">MVC Builder</param>
+            <param name="builder">MVC Builder.</param>
         </member>
     </members>
 </doc>

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -11,18 +11,18 @@
         </member>
         <member name="M:Microsoft.Identity.Web.AccountExtensions.ToClaimsPrincipal(Microsoft.Identity.Client.IAccount)">
             <summary>
-            Creates the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from the values found 
-            in an <see cref="T:Microsoft.Identity.Client.IAccount"/>
+            Creates the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from the values found
+            in an <see cref="T:Microsoft.Identity.Client.IAccount"/>.
             </summary>
-            <param name="account">The IAccount instance</param>
-            <returns>A <see cref="T:System.Security.Claims.ClaimsPrincipal"/> built from IAccount</returns>
+            <param name="account">The IAccount instance.</param>
+            <returns>A <see cref="T:System.Security.Claims.ClaimsPrincipal"/> built from IAccount.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.AuthorizeForScopesAttribute">
             <summary>
             Filter used on a controller action to trigger incremental consent.
             </summary>
             <example>
-            The following controller action will trigger
+            The following controller action will trigger.
             <code>
             [AuthorizeForScopes(Scopes = new[] {"Mail.Send"})]
             public async Task&lt;IActionResult&gt; SendEmail()
@@ -33,28 +33,28 @@
         </member>
         <member name="P:Microsoft.Identity.Web.AuthorizeForScopesAttribute.Scopes">
             <summary>
-            Scopes to request
+            Scopes to request.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.AuthorizeForScopesAttribute.ScopeKeySection">
             <summary>
-            Key section on the configuration file that holds the scope value
+            Key section on the configuration file that holds the scope value.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.AuthorizeForScopesAttribute.OnException(Microsoft.AspNetCore.Mvc.Filters.ExceptionContext)">
             <summary>
-            Handles the MsalUiRequiredException
+            Handles the MsalUiRequiredException.
             </summary>
-            <param name="context">Context provided by ASP.NET Core</param>
+            <param name="context">Context provided by ASP.NET Core.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.AuthorizeForScopesAttribute.BuildAuthenticationPropertiesForIncrementalConsent(System.String[],Microsoft.Identity.Client.MsalUiRequiredException,Microsoft.AspNetCore.Http.HttpContext)">
             <summary>
             Build Authentication properties needed for incremental consent.
             </summary>
-            <param name="scopes">Scopes to request</param>
-            <param name="ex">MsalUiRequiredException instance</param>
-            <param name="context">current http context in the pipeline</param>
-            <returns>AuthenticationProperties</returns>
+            <param name="scopes">Scopes to request.</param>
+            <param name="ex">MsalUiRequiredException instance.</param>
+            <param name="context">current HTTP context in the pipeline.</param>
+            <returns>AuthenticationProperties.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.ClaimConstants">
             <summary>
@@ -63,82 +63,82 @@
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Name">
             <summary>
-            Name claim: "name"
+            Name claim: "name".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.ObjectId">
             <summary>
-            Old Object Id claim: http://schemas.microsoft.com/identity/claims/objectidentifier
+            Old Object Id claim: http://schemas.microsoft.com/identity/claims/objectidentifier.
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Oid">
             <summary>
-            New Object id claim: "oid"
+            New Object id claim: "oid".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.PreferredUserName">
             <summary>
-            PreferredUserName: "preferred_username"
+            PreferredUserName: "preferred_username".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.TenantId">
             <summary>
-            Old TenantId claim: "http://schemas.microsoft.com/identity/claims/tenantid"
+            Old TenantId claim: "http://schemas.microsoft.com/identity/claims/tenantid".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Tid">
             <summary>
-            New Tenant Id claim: "tid"
+            New Tenant Id claim: "tid".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.ClientInfo">
             <summary>
-            ClientInfo claim: "client_info"
+            ClientInfo claim: "client_info".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.UniqueObjectIdentifier">
             <summary>
-            UniqueObjectIdentifier: "utid"
+            UniqueObjectIdentifier: "utid".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Scope">
             <summary>
-            Older scope claim: "http://schemas.microsoft.com/identity/claims/scope"
+            Older scope claim: "http://schemas.microsoft.com/identity/claims/scope".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Scp">
             <summary>
-            Newer scope claim: "scp"
+            Newer scope claim: "scp".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Roles">
             <summary>
-            New Roles claim = "roles"
+            New Roles claim = "roles".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Role">
             <summary>
-            Old Role claim: "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+            Old Role claim: "http://schemas.microsoft.com/ws/2008/06/identity/claims/role".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Sub">
             <summary>
-            Subject claim: "sub"
+            Subject claim: "sub".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Acr">
             <summary>
-            Acr claim: "acr"
+            Acr claim: "acr".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.UserFlow">
             <summary>
-            UserFlow claim: "http://schemas.microsoft.com/claims/authnclassreference"
+            UserFlow claim: "http://schemas.microsoft.com/claims/authnclassreference".
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.ClaimConstants.Tfp">
             <summary>
-            Tfp claim: "tfp"
+            Tfp claim: "tfp".
             </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.ClaimsPrincipalExtensions">
@@ -148,63 +148,63 @@
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetMsalAccountId(System.Security.Claims.ClaimsPrincipal)">
             <summary>
-            Gets the Account identifier for an MSAL.NET account from a <see cref="T:System.Security.Claims.ClaimsPrincipal"/>
+            Gets the Account identifier for an MSAL.NET account from a <see cref="T:System.Security.Claims.ClaimsPrincipal"/>.
             </summary>
-            <param name="claimsPrincipal">Claims principal</param>
-            <returns>A string corresponding to an account identifier as defined in <see cref="P:Microsoft.Identity.Client.AccountId.Identifier"/></returns>
+            <param name="claimsPrincipal">Claims principal.</param>
+            <returns>A string corresponding to an account identifier as defined in <see cref="P:Microsoft.Identity.Client.AccountId.Identifier"/>.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetObjectId(System.Security.Claims.ClaimsPrincipal)">
             <summary>
-            Gets the unique object ID associated with the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>
+            Gets the unique object ID associated with the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>.
             </summary>
-            <param name="claimsPrincipal">the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from which to retrieve the unique object ID</param>
-            <remarks>This method returns the object ID both in case the developer has enabled or not claims mapping</remarks>
-            <returns>Unique object ID of the identity, or <c>null</c> if it cannot be found</returns>
+            <param name="claimsPrincipal">the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from which to retrieve the unique object ID.</param>
+            <remarks>This method returns the object ID both in case the developer has enabled or not claims mapping.</remarks>
+            <returns>Unique object ID of the identity, or <c>null</c> if it cannot be found.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetTenantId(System.Security.Claims.ClaimsPrincipal)">
             <summary>
-            Gets the Tenant ID associated with the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>
+            Gets the Tenant ID associated with the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>.
             </summary>
-            <param name="claimsPrincipal">the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from which to retrieve the tenant ID</param>
-            <returns>Tenant ID of the identity, or <c>null</c> if it cannot be found</returns>
-            <remarks>This method returns the tenant ID both in case the developer has enabled or not claims mapping</remarks>
+            <param name="claimsPrincipal">the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from which to retrieve the tenant ID.</param>
+            <returns>Tenant ID of the identity, or <c>null</c> if it cannot be found.</returns>
+            <remarks>This method returns the tenant ID both in case the developer has enabled or not claims mapping.</remarks>
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetLoginHint(System.Security.Claims.ClaimsPrincipal)">
             <summary>
-            Gets the login-hint associated with a <see cref="T:System.Security.Claims.ClaimsPrincipal"/>
+            Gets the login-hint associated with a <see cref="T:System.Security.Claims.ClaimsPrincipal"/>.
             </summary>
-            <param name="claimsPrincipal">Identity for which to complete the login-hint</param>
-            <returns>login-hint for the identity, or <c>null</c> if it cannot be found</returns>
+            <param name="claimsPrincipal">Identity for which to complete the login-hint.</param>
+            <returns>login-hint for the identity, or <c>null</c> if it cannot be found.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetDomainHint(System.Security.Claims.ClaimsPrincipal)">
             <summary>
-            Gets the domain-hint associated with an identity
+            Gets the domain-hint associated with an identity.
             </summary>
-            <param name="claimsPrincipal">Identity for which to compute the domain-hint</param>
-            <returns>domain-hint for the identity, or <c>null</c> if it cannot be found</returns>
+            <param name="claimsPrincipal">Identity for which to compute the domain-hint.</param>
+            <returns>domain-hint for the identity, or <c>null</c> if it cannot be found.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetDisplayName(System.Security.Claims.ClaimsPrincipal)">
             <summary>
-            Get the display name for the signed-in user, from the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>
+            Get the display name for the signed-in user, from the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>.
             </summary>
-            <param name="claimsPrincipal">Claims about the user/account</param>
+            <param name="claimsPrincipal">Claims about the user/account.</param>
             <returns>A string containing the display name for the user, as determined by Azure AD (v1.0) and Microsoft identity platform (v2.0) tokens,
-            or <c>null</c> if the claims cannot be found</returns>
-            <remarks>See https://docs.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims </remarks>
+            or <c>null</c> if the claims cannot be found.</returns>
+            <remarks>See https://docs.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims. </remarks>
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetUserFlowId(System.Security.Claims.ClaimsPrincipal)">
             <summary>
-            Gets the user flow id associated with the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>
+            Gets the user flow id associated with the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>.
             </summary>
-            <param name="claimsPrincipal">the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from which to retrieve the user flow id</param>
-            <returns>User Flow Id of the identity, or <c>null</c> if it cannot be found</returns>
+            <param name="claimsPrincipal">the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from which to retrieve the user flow id.</param>
+            <returns>User Flow Id of the identity, or <c>null</c> if it cannot be found.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetNameIdentifierId(System.Security.Claims.ClaimsPrincipal)">
             <summary>
-            Gets the NameIdentifierId associated with the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>
+            Gets the NameIdentifierId associated with the <see cref="T:System.Security.Claims.ClaimsPrincipal"/>.
             </summary>
-            <param name="claimsPrincipal">the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from which to retrieve the sub claim</param>
-            <returns>Name identifier ID (sub) of the identity, or <c>null</c> if it cannot be found</returns>
+            <param name="claimsPrincipal">the <see cref="T:System.Security.Claims.ClaimsPrincipal"/> from which to retrieve the sub claim.</param>
+            <returns>Name identifier ID (sub) of the identity, or <c>null</c> if it cannot be found.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.ClaimsPrincipalFactory">
             <summary>
@@ -216,11 +216,11 @@
              Instantiate a ClaimsPrincipal from an account objectId and tenantId. This can
              be useful when the Web app subscribes to another service on behalf of the user
              and then is called back by a notification where the user is identified by his tenant
-             id and object id (like in Microsoft Graph Web Hooks)
+             id and object id (like in Microsoft Graph Web Hooks).
              </summary>
-             <param name="tenantId">Tenant Id of the account</param>
-             <param name="objectId">Object Id of the account in this tenant ID</param>
-             <returns>A ClaimsPrincipal containing these two claims</returns>
+             <param name="tenantId">Tenant Id of the account.</param>
+             <param name="objectId">Object Id of the account in this tenant ID.</param>
+             <returns>A ClaimsPrincipal containing these two claims.</returns>
             
              <example>
              <code>
@@ -238,13 +238,13 @@
         </member>
         <member name="T:Microsoft.Identity.Web.CookiePolicyOptionsExtensions">
             <summary>
-            Extension class containing cookie policies (work around for same site)
+            Extension class containing cookie policies (work around for same site).
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.CookiePolicyOptionsExtensions.HandleSameSiteCookieCompatibility(Microsoft.AspNetCore.Builder.CookiePolicyOptions)">
             <summary>
             Handles SameSite cookie issue according to the https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1.
-            The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+            The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
             </summary>
             <param name="options"></param>
             <returns></returns>
@@ -252,23 +252,23 @@
         <member name="M:Microsoft.Identity.Web.CookiePolicyOptionsExtensions.HandleSameSiteCookieCompatibility(Microsoft.AspNetCore.Builder.CookiePolicyOptions,System.Func{System.String,System.Boolean})">
             <summary>
             Handles SameSite cookie issue according to the docs: https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
-            The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+            The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
             </summary>
             <param name="options"></param>
-            <param name="disallowsSameSiteNone">If you dont want to use the default user-agent list implementation, the method sent in this parameter will be run against the user-agent and if returned true, SameSite value will be set to Unspecified. The default user-agent list used can be found at: https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/</param>
+            <param name="disallowsSameSiteNone">If you dont want to use the default user-agent list implementation, the method sent in this parameter will be run against the user-agent and if returned true, SameSite value will be set to Unspecified. The default user-agent list used can be found at: https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.</param>
             <returns></returns>
         </member>
         <member name="M:Microsoft.Identity.Web.CookiePolicyOptionsExtensions.DisallowsSameSiteNone(System.String)">
-            <summary>
+             <summary>
             
-            </summary>
-            <param name="userAgent"></param>
-            <remarks>Method taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/</remarks>
-            <returns></returns>
+             </summary>
+             <param name="userAgent"></param>
+             <remarks>Method taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.</remarks>
+             <returns></returns>
         </member>
         <member name="T:Microsoft.Identity.Web.Extensions">
             <summary>
-            Extension methods
+            Extension methods.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.Extensions.ContainsAny(System.String,System.String[])">
@@ -280,22 +280,22 @@
         </member>
         <member name="M:Microsoft.Identity.Web.HttpContextExtensions.StoreTokenUsedToCallWebAPI(Microsoft.AspNetCore.Http.HttpContext,System.IdentityModel.Tokens.Jwt.JwtSecurityToken)">
             <summary>
-            Keep the validated token associated with the Http request
+            Keep the validated token associated with the Http request.
             </summary>
-            <param name="httpContext">Http context</param>
+            <param name="httpContext">Http context.</param>
             <param name="token">Token to preserve after the token is validated so that
-            it can be used in the actions</param>
+            it can be used in the actions.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.HttpContextExtensions.GetTokenUsedToCallWebAPI(Microsoft.AspNetCore.Http.HttpContext)">
             <summary>
-            Get the parsed information about the token used to call the Web API
+            Get the parsed information about the token used to call the Web API.
             </summary>
-            <param name="httpContext">Http context associated with the current request</param>
-            <returns><see cref="T:System.IdentityModel.Tokens.Jwt.JwtSecurityToken"/> used to call the Web API</returns>
+            <param name="httpContext">Http context associated with the current request.</param>
+            <returns><see cref="T:System.IdentityModel.Tokens.Jwt.JwtSecurityToken"/> used to call the Web API.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.InstanceDiscovery.IssuerConfigurationRetriever">
             <summary>
-            An implementation of IConfigurationRetriever geared towards Azure AD issuers metadata />
+            An implementation of IConfigurationRetriever geared towards Azure AD issuers metadata />.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.InstanceDiscovery.IssuerConfigurationRetriever.GetConfigurationAsync(System.String,Microsoft.IdentityModel.Protocols.IDocumentRetriever,System.Threading.CancellationToken)">
@@ -306,26 +306,26 @@
             <returns></returns>
             <exception cref="T:System.ArgumentNullException">address - Azure AD Issuer metadata address url is required
             or
-            retriever - No metadata document retriever is provided</exception>
+            retriever - No metadata document retriever is provided.</exception>
         </member>
         <member name="T:Microsoft.Identity.Web.InstanceDiscovery.IssuerMetadata">
             <summary>
-            Model class to hold information parsed from the Azure AD issuer endpoint
+            Model class to hold information parsed from the Azure AD issuer endpoint.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.InstanceDiscovery.IssuerMetadata.TenantDiscoveryEndpoint">
             <summary>
-            Tenant discovery endpoint
+            Tenant discovery endpoint.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.InstanceDiscovery.IssuerMetadata.ApiVersion">
             <summary>
-            API Version
+            API Version.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.InstanceDiscovery.IssuerMetadata.Metadata">
             <summary>
-            List of metadata associated with the endpoint
+            List of metadata associated with the endpoint.
             </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.InstanceDiscovery.Metadata">
@@ -335,35 +335,35 @@
         </member>
         <member name="P:Microsoft.Identity.Web.InstanceDiscovery.Metadata.PreferredNetwork">
             <summary>
-            Preferred alias
+            Preferred alias.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.InstanceDiscovery.Metadata.PreferredCache">
             <summary>
             Preferred alias to cache tokens emitted by one of the aliases (to avoid
-            SSO islands)
+            SSO islands).
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.InstanceDiscovery.Metadata.Aliases">
             <summary>
-            Aliases of issuer URLs which are equivalent
+            Aliases of issuer URLs which are equivalent.
             </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.ITokenAcquisition">
             <summary>
-            Interface for the token acquisition service (encapsultating MSAL.NET)
+            Interface for the token acquisition service (encapsulating MSAL.NET).
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.ITokenAcquisition.GetAccessTokenForUserAsync(System.Collections.Generic.IEnumerable{System.String},System.String)">
             <summary>
-            Typically used from an ASP.NET Core Web App or Web API controller, this method gets an access token 
+            Typically used from an ASP.NET Core Web App or Web API controller, this method gets an access token
             for a downstream API on behalf of the user account which claims are provided in the <see cref="P:Microsoft.AspNetCore.Http.HttpContext.User"/>
-            member of the controller's <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> parameter
+            member of the controller's <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/> parameter.
             </summary>
-            <param name="scopes">Scopes to request for the downstream API to call</param>
-            <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the 
-            cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant</param>
-            <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes</returns>
+            <param name="scopes">Scopes to request for the downstream API to call.</param>
+            <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the
+            cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant.</param>
+            <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ITokenAcquisition.GetAccessTokenForAppAsync(System.Collections.Generic.IEnumerable{System.String})">
             <summary>
@@ -374,58 +374,63 @@
             should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
             Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
             in the portal, and cannot be overriden in the application.</param>
-            <returns>An access token for the app itself, based on its scopes</returns>
+            <returns>An access token for the app itself, based on its scopes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ITokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeader(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException)">
             <summary>
-            Used in Web APIs (which therefore cannot have an interaction with the user). 
+            Used in Web APIs (which therefore cannot have an interaction with the user).
             Replies to the client through the HttpResponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
-            the client can trigger an interaction with the user so the user can consent to more scopes
+            the client can trigger an interaction with the user so the user can consent to more scopes.
             </summary>
-            <param name="scopes">Scopes to consent to</param>
-            <param name="msalSeviceException"><see cref="T:Microsoft.Identity.Client.MsalUiRequiredException"/> triggering the challenge</param>
+            <param name="scopes">Scopes to consent to.</param>
+            <param name="msalSeviceException"><see cref="T:Microsoft.Identity.Client.MsalUiRequiredException"/> triggering the challenge.</param>
+        </member>
+        <member name="T:Microsoft.Identity.Web.ITokenAcquisitionInternal">
+            <summary>
+            Interface for the internal operations of token acquisition service (encapsulating MSAL.NET).
+            </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.ITokenAcquisitionInternal.AddAccountToCacheFromAuthorizationCodeAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.AuthorizationCodeReceivedContext,System.Collections.Generic.IEnumerable{System.String})">
-            <summary>
-            In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App, when the authorization code is received (after the user
-            signed-in and consented)
-            An On-behalf-of token contained in the <see cref="T:Microsoft.AspNetCore.Authentication.OpenIdConnect.AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the 
-            same user in order to call to downstream APIs.
-            </summary>
-            <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
-            <param name="scopes">Scopes to request</param>
-            <example>
-            From the configuration of the Authentication of the ASP.NET Core Web API: 
-            <code>OpenIdConnectOptions options;</code>
+             <summary>
+             In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App, when the authorization code is received (after the user
+             signed-in and consented)
+             An On-behalf-of token contained in the <see cref="T:Microsoft.AspNetCore.Authentication.OpenIdConnect.AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the
+             same user in order to call to downstream APIs.
+             </summary>
+             <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
+             <param name="scopes">Scopes to request.</param>
+             <example>
+             From the configuration of the Authentication of the ASP.NET Core Web API:
+             <code>OpenIdConnectOptions options;</code>
             
-            Subscribe to the authorization code received event:
-            <code>
-             options.Events = new OpenIdConnectEvents();
-             options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
-            }
-            </code>
+             Subscribe to the authorization code received event:
+             <code>
+              options.Events = new OpenIdConnectEvents();
+              options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
+             }
+             </code>
             
-            And then in the OnAuthorizationCodeRecieved method, call <see cref="M:Microsoft.Identity.Web.ITokenAcquisitionInternal.AddAccountToCacheFromAuthorizationCodeAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.AuthorizationCodeReceivedContext,System.Collections.Generic.IEnumerable{System.String})"/>:
-            <code>
-            private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
-            {
-              var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService&lt;ITokenAcquisition&gt;();
-               await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, new string[] { "user.read" });
-            }
-            </code>
-            </example>
+             And then in the OnAuthorizationCodeRecieved method, call <see cref="M:Microsoft.Identity.Web.ITokenAcquisitionInternal.AddAccountToCacheFromAuthorizationCodeAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.AuthorizationCodeReceivedContext,System.Collections.Generic.IEnumerable{System.String})"/>:
+             <code>
+             private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
+             {
+               var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService&lt;ITokenAcquisition&gt;();
+                await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, new string[] { "user.read" });
+             }
+             </code>
+             </example>
         </member>
         <member name="M:Microsoft.Identity.Web.ITokenAcquisitionInternal.RemoveAccountAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.RedirectContext)">
             <summary>
-            Removes the account associated with context.HttpContext.User from the MSAL.NET cache
+            Removes the account associated with context.HttpContext.User from the MSAL.NET cache.
             </summary>
-            <param name="context">RedirectContext passed-in to a <see cref="P:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/> 
-            Openidconnect event</param>
+            <param name="context">RedirectContext passed-in to a <see cref="P:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/>
+            Openidconnect event.</param>
             <returns></returns>
         </member>
         <member name="T:Microsoft.Identity.Web.MicrosoftIdentityOptions">
             <summary>
-            Options for configuring authentication using Azure Active Directory. It has both AAD and B2C configuration attributes
+            Options for configuring authentication using Azure Active Directory. It has both AAD and B2C configuration attributes.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.Instance">
@@ -445,15 +450,26 @@
         </member>
         <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.RedirectUri">
             <summary>
-            In a Web app, gets or sets the RedirectUri (URI where the token will be sent back by
+            In a web app, gets or sets the RedirectUri (URI where the token will be sent back by
             Azure Active Directory or Azure Active Directory B2C)
             This property is exclusive with <see cref="P:Microsoft.AspNetCore.Authentication.RemoteAuthenticationOptions.CallbackPath"/> which should be used preferably if you don't want
-            to have a different deployed configuration from your developper configuration.
-            There are cases where RedirectUri is needed, for instance when you use a reverse proxy that transforms https
-            URLs (external world) to http URLs (inside the protected area). This can also be useful for Web apps running
+            to have a different deployed configuration from your developer configuration.
+            There are cases where RedirectUri is needed, for instance when you use a reverse proxy that transforms HTTPS
+            URLs (external world) to HTTP URLs (inside the protected area). This can also be useful for web apps running
             in containers (for the same reasons)
-            If you don't specify the RedirectUri, the redirect URI will be computed from the URL on which the app is
+            If you don't specify the redirect URI, the redirect URI will be computed from the URL on which the app is
             deployed and the CallbackPath.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.PostLogoutRedirectUri">
+            <summary>
+            In a web app, gets or sets the PostLogoutRedirectUri 
+            This property is exclusive with <see cref="!:RemoteAuthenticationOptions.SignedOutCallbackPath"/> which should be used preferably if you don't want
+            to have a different deployed configuration from your developer configuration.
+            There are cases where PostLogoutRedirectUri is needed, for instance when you use a reverse proxy that transforms HTTPS
+            URLs (external world) to HTTP URLs (inside the protected area). This can also be useful for web apps running
+            in containers (for the same reasons)
+            If you don't specify the PostLogoutRedirectUri, it will be computed by ASP.NET Core using the SignedOutCallbackPath.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.EditProfilePolicyId">
@@ -478,7 +494,7 @@
         </member>
         <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.IsB2C">
             <summary>
-            Is considered B2C if the attribute SignUpSignInPolicyId is defined
+            Is considered B2C if the attribute SignUpSignInPolicyId is defined.
             </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.Resource.AadIssuerValidator">
@@ -488,33 +504,33 @@
         </member>
         <member name="F:Microsoft.Identity.Web.Resource.AadIssuerValidator._issuerAliases">
             <summary>
-            A list of all Issuers across the various Azure AD instances
+            A list of all Issuers across the various Azure AD instances.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.Resource.AadIssuerValidator.GetIssuerValidator(System.String)">
             <summary>
             Gets an <see cref="T:Microsoft.Identity.Web.Resource.AadIssuerValidator"/> for an authority.
             </summary>
-            <param name="aadAuthority">The authority to create the validator for, e.g. https://login.microsoftonline.com/ </param>
+            <param name="aadAuthority">The authority to create the validator for, e.g. https://login.microsoftonline.com/. </param>
             <returns>A <see cref="T:Microsoft.Identity.Web.Resource.AadIssuerValidator"/> for the aadAuthority.</returns>
             <exception cref="T:System.ArgumentNullException">if <paramref name="aadAuthority"/> is null or empty.</exception>
         </member>
         <member name="M:Microsoft.Identity.Web.Resource.AadIssuerValidator.Validate(System.String,Microsoft.IdentityModel.Tokens.SecurityToken,Microsoft.IdentityModel.Tokens.TokenValidationParameters)">
             <summary>
             Validate the issuer for multi-tenant applications of various audience (Work and School account, or Work and School accounts +
-            Personal accounts)
+            Personal accounts).
             </summary>
-            <param name="actualIssuer">Issuer to validate (will be tenanted)</param>
-            <param name="securityToken">Received Security Token</param>
-            <param name="validationParameters">Token Validation parameters</param>
+            <param name="actualIssuer">Issuer to validate (will be tenanted).</param>
+            <param name="securityToken">Received Security Token.</param>
+            <param name="validationParameters">Token Validation parameters.</param>
             <remarks>The issuer is considered as valid if it has the same HTTP scheme and authority as the
             authority from the configuration file, has a tenant ID, and optionally v2.0 (this web API
             accepts both V1 and V2 tokens).
-            Authority aliasing is also taken into account</remarks>
-            <returns>The <c>issuer</c> if it's valid, or otherwise <c>SecurityTokenInvalidIssuerException</c> is thrown</returns>
+            Authority aliasing is also taken into account.</remarks>
+            <returns>The <c>issuer</c> if it's valid, or otherwise <c>SecurityTokenInvalidIssuerException</c> is thrown.</returns>
             <exception cref="T:System.ArgumentNullException"> if <paramref name="securityToken"/> is null.</exception>
             <exception cref="T:System.ArgumentNullException"> if <paramref name="validationParameters"/> is null.</exception>
-            <exception cref="T:Microsoft.IdentityModel.Tokens.SecurityTokenInvalidIssuerException">if the issuer </exception>
+            <exception cref="T:Microsoft.IdentityModel.Tokens.SecurityTokenInvalidIssuerException">if the issuer. </exception>
         </member>
         <member name="M:Microsoft.Identity.Web.Resource.AadIssuerValidator.GetTenantIdFromToken(Microsoft.IdentityModel.Tokens.SecurityToken)">
             <summary>Gets the tenant ID from a token.</summary>
@@ -524,31 +540,31 @@
         </member>
         <member name="T:Microsoft.Identity.Web.Resource.IJwtBearerMiddlewareDiagnostics">
             <summary>
-            Interface implemented by diagnostics for the JwtBearer middleware
+            Interface implemented by diagnostics for the JwtBearer middleware.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.Resource.IJwtBearerMiddlewareDiagnostics.Subscribe(Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents)">
             <summary>
-            Called to subscribe to JwtBearerEvents
+            Called to subscribe to JwtBearerEvents.
             </summary>
-            <param name="events">JwtBearer events</param>
-            <returns>the events (for chaining)</returns>
+            <param name="events">JwtBearer events.</param>
+            <returns>the events (for chaining).</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.Resource.IOpenIdConnectMiddlewareDiagnostics">
             <summary>
             Diagnostics used in the Open Id Connect middleware
-            (used in Web Apps)
+            (used in Web Apps).
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.Resource.IOpenIdConnectMiddlewareDiagnostics.Subscribe(Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents)">
             <summary>
-            Method to subscribe to OpenIDConnect events
+            Method to subscribe to OpenIDConnect events.
             </summary>
-            <param name="events">Open Id connect events</param>
+            <param name="events">Open Id connect events.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.Resource.JwtBearerMiddlewareDiagnostics">
             <summary>
-            Diagnostics for the JwtBearer middleware (used in Web APIs)
+            Diagnostics for the JwtBearer middleware (used in Web APIs).
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.Resource.JwtBearerMiddlewareDiagnostics.#ctor(Microsoft.Extensions.Logging.ILogger{Microsoft.Identity.Web.Resource.JwtBearerMiddlewareDiagnostics})">
@@ -556,7 +572,7 @@
             Constructor for a <see cref="T:Microsoft.Identity.Web.Resource.JwtBearerMiddlewareDiagnostics"/>. This constructor
             is used by dependency injection.
             </summary>
-            <param name="logger">Logger</param>
+            <param name="logger">Logger.</param>
         </member>
         <member name="F:Microsoft.Identity.Web.Resource.JwtBearerMiddlewareDiagnostics.s_onAuthenticationFailed">
             <summary>
@@ -581,29 +597,29 @@
         <member name="M:Microsoft.Identity.Web.Resource.JwtBearerMiddlewareDiagnostics.Subscribe(Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents)">
             <summary>
             Subscribes to all the JwtBearer events, to help debugging, while
-            preserving the previous handlers (which are called)
+            preserving the previous handlers (which are called).
             </summary>
-            <param name="events">Events to subscribe to</param>
+            <param name="events">Events to subscribe to.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.Resource.OpenIdConnectMiddlewareDiagnostics">
             <summary>
             Diagnostics used in the Open Id Connect middleware
-            (used in Web Apps)
+            (used in Web Apps).
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.Resource.OpenIdConnectMiddlewareDiagnostics.#ctor(Microsoft.Extensions.Logging.ILogger{Microsoft.Identity.Web.Resource.OpenIdConnectMiddlewareDiagnostics})">
             <summary>
             Constructor of the <see cref="T:Microsoft.Identity.Web.Resource.OpenIdConnectMiddlewareDiagnostics"/>, used
-            by dependency injection
+            by dependency injection.
             </summary>
-            <param name="logger">Logger used to log the diagnostics</param>
+            <param name="logger">Logger used to log the diagnostics.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.Resource.OpenIdConnectMiddlewareDiagnostics.Subscribe(Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents)">
             <summary>
             Subscribes to all the OpenIdConnect events, to help debugging, while
-            preserving the previous handlers (which are called)
+            preserving the previous handlers (which are called).
             </summary>
-            <param name="events">Events to subscribe to</param>
+            <param name="events">Events to subscribe to.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.Resource.ScopesRequiredHttpContextExtensions">
             <summary>
@@ -614,13 +630,13 @@
         <member name="M:Microsoft.Identity.Web.Resource.ScopesRequiredHttpContextExtensions.VerifyUserHasAnyAcceptedScope(Microsoft.AspNetCore.Http.HttpContext,System.String[])">
             <summary>
             When applied to an <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/>, verifies that the user authenticated in the
-            web API has any of the accepted scopes. 
+            web API has any of the accepted scopes.
             If the authenticated user does not have any of these <paramref name="acceptedScopes"/>, the
-            method throws an HTTP Unauthorized with the message telling which scopes are expected in the token
+            method throws an HTTP Unauthorized with the message telling which scopes are expected in the token.
             </summary>
-            <param name="context">HttpContext (from the controller)</param>
-            <param name="acceptedScopes">Scopes accepted by this web API</param>
-            <exception cref="T:System.Net.Http.HttpRequestException"/> with a <see cref="P:Microsoft.AspNetCore.Http.HttpResponse.StatusCode"/> set to 
+            <param name="context">HttpContext (from the controller).</param>
+            <param name="acceptedScopes">Scopes accepted by this web API.</param>
+            <exception cref="T:System.Net.Http.HttpRequestException"/> with a <see cref="P:Microsoft.AspNetCore.Http.HttpResponse.StatusCode"/> set to
             <see cref="F:System.Net.HttpStatusCode.Unauthorized"/>
         </member>
         <member name="T:Microsoft.Identity.Web.ServiceCollectionExtensions">
@@ -632,8 +648,8 @@
              <summary>
              Add the token acquisition service.
              </summary>
-             <param name="services">Service collection</param>
-             <returns>the service collection</returns>
+             <param name="services">Service collection.</param>
+             <returns>the service collection.</returns>
              <example>
              This method is typically called from the Startup.ConfigureServices(IServiceCollection services)
              Note that the implementation of the token cache can be chosen separately.
@@ -650,25 +666,25 @@
         </member>
         <member name="T:Microsoft.Identity.Web.TokenAcquisition">
             <summary>
-            Token acquisition service
+            Token acquisition service.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.#ctor(Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider,Microsoft.AspNetCore.Http.IHttpContextAccessor,Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.MicrosoftIdentityOptions},Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Client.ConfidentialClientApplicationOptions},System.Net.Http.IHttpClientFactory,Microsoft.Extensions.Logging.ILogger{Microsoft.Identity.Web.TokenAcquisition})">
             <summary>
             Constructor of the TokenAcquisition service. This requires the Azure AD Options to
             configure the confidential client application and a token cache provider.
-            This constructor is called by ASP.NET Core dependency injection
+            This constructor is called by ASP.NET Core dependency injection.
             </summary>
-            <param name="tokenCacheProvider">The App token cache provider</param>
-            <param name="httpContextAccessor">Access to the HttpContext of the request</param>
-            <param name="microsoftIdentityOptions">Configuration options</param>
-            <param name="applicationOptions">MSAL.NET configuration options</param>
-            <param name="httpClientFactory">Http client factory</param>
-            <param name="logger">Logger</param>
+            <param name="tokenCacheProvider">The App token cache provider.</param>
+            <param name="httpContextAccessor">Access to the HttpContext of the request.</param>
+            <param name="microsoftIdentityOptions">Configuration options.</param>
+            <param name="applicationOptions">MSAL.NET configuration options.</param>
+            <param name="httpClientFactory">Http client factory.</param>
+            <param name="logger">Logger.</param>
         </member>
         <member name="F:Microsoft.Identity.Web.TokenAcquisition._scopesRequestedByMsal">
             <summary>
-            Scopes which are already requested by MSAL.NET. They should not be re-requested;
+            Scopes which are already requested by MSAL.NET. They should not be re-requested;.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.AddAccountToCacheFromAuthorizationCodeAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.AuthorizationCodeReceivedContext,System.Collections.Generic.IEnumerable{System.String})">
@@ -681,7 +697,7 @@
              in order to call to downstream APIs.
              </summary>
              <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
-             <param name="scopes">scopes to request access to</param>
+             <param name="scopes">scopes to request access to.</param>
              <example>
              From the configuration of the Authentication of the ASP.NET Core Web API:
              <code>OpenIdConnectOptions options;</code>
@@ -709,18 +725,18 @@
             for a downstream API using;
             1) the token cache (for Web Apps and Web APIs) if a token exists in the cache
             2) or the <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a>
-            in Web APIs, for the user account that is ascertained from claims are provided in the <see cref="P:Microsoft.AspNetCore.Http.HttpContext.User"/> 
-            instance of the current HttpContext
+            in Web APIs, for the user account that is ascertained from claims are provided in the <see cref="P:Microsoft.AspNetCore.Http.HttpContext.User"/>
+            instance of the current HttpContext.
             </summary>
-            <param name="scopes">Scopes to request for the downstream API to call</param>
+            <param name="scopes">Scopes to request for the downstream API to call.</param>
             <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
-            cases where a given account is a guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in</param>
-            <returns>An access token to call the downstream API and populated with this downstream Api's scopes</returns>
-            <remarks>Calling this method from a Web API supposes that you have previously called, 
+            cases where a given account is a guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
+            <returns>An access token to call the downstream API and populated with this downstream Api's scopes.</returns>
+            <remarks>Calling this method from a Web API supposes that you have previously called,
             in a method called by JwtBearerOptions.Events.OnTokenValidated, the HttpContextExtensions.StoreTokenUsedToCallWebAPI method
             passing the validated token (as a JwtSecurityToken). Calling it from a Web App supposes that
             you have previously called AddAccountToCacheFromAuthorizationCodeAsync from a method called by
-            OpenIdConnectOptions.Events.OnAuthorizationCodeReceived</remarks>
+            OpenIdConnectOptions.Events.OnAuthorizationCodeReceived.</remarks>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetAccessTokenForUserAsync(System.Collections.Generic.IEnumerable{System.String},System.String)">
             <summary>
@@ -728,18 +744,18 @@
             for a downstream API using;
             1) the token cache (for Web Apps and Web APis) if a token exists in the cache
             2) or the <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a>
-            in Web APIs, for the user account that is ascertained from claims are provided in the <see cref="P:Microsoft.AspNetCore.Http.HttpContext.User"/> 
-            instance of the current HttpContext
+            in Web APIs, for the user account that is ascertained from claims are provided in the <see cref="P:Microsoft.AspNetCore.Http.HttpContext.User"/>
+            instance of the current HttpContext.
             </summary>
-            <param name="scopes">Scopes to request for the downstream API to call</param>
+            <param name="scopes">Scopes to request for the downstream API to call.</param>
             <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
-            cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in</param>
-            <returns>An access token to call the downstream API and populated with this downstream Api's scopes</returns>
-            <remarks>Calling this method from a Web API supposes that you have previously called, 
+            cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
+            <returns>An access token to call the downstream API and populated with this downstream Api's scopes.</returns>
+            <remarks>Calling this method from a Web API supposes that you have previously called,
             in a method called by JwtBearerOptions.Events.OnTokenValidated, the HttpContextExtensions.StoreTokenUsedToCallWebAPI method
             passing the validated token (as a JwtSecurityToken). Calling it from a Web App supposes that
             you have previously called AddAccountToCacheFromAuthorizationCodeAsync from a method called by
-            OpenIdConnectOptions.Events.OnAuthorizationCodeReceived</remarks>
+            OpenIdConnectOptions.Events.OnAuthorizationCodeReceived.</remarks>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetAccessTokenForAppAsync(System.Collections.Generic.IEnumerable{System.String})">
             <summary>
@@ -750,59 +766,59 @@
             should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
             Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
             in the portal, and cannot be overriden in the application.</param>
-            <returns>An access token for the app itself, based on its scopes</returns>
+            <returns>An access token for the app itself, based on its scopes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.RemoveAccountAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.RedirectContext)">
             <summary>
-            Removes the account associated with context.HttpContext.User from the MSAL.NET cache
+            Removes the account associated with context.HttpContext.User from the MSAL.NET cache.
             </summary>
             <param name="context">RedirectContext passed-in to a <see cref="P:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/>
-            Openidconnect event</param>
+            Openidconnect event.</param>
             <returns></returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetOrBuildConfidentialClientApplicationAsync">
             <summary>
-            Creates an MSAL Confidential client application if needed
+            Creates an MSAL Confidential client application if needed.
             </summary>
             <returns></returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.BuildConfidentialClientApplicationAsync">
             <summary>
-            Creates an MSAL Confidential client application
+            Creates an MSAL Confidential client application.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetAccessTokenOnBehalfOfUserFromCacheAsync(Microsoft.Identity.Client.IConfidentialClientApplication,System.Security.Claims.ClaimsPrincipal,System.Collections.Generic.IEnumerable{System.String},System.String)">
             <summary>
-            Gets an access token for a downstream API on behalf of the user described by its claimsPrincipal
+            Gets an access token for a downstream API on behalf of the user described by its claimsPrincipal.
             </summary>
             <param name="application"></param>
-            <param name="claimsPrincipal">Claims principal for the user on behalf of whom to get a token</param>
-            <param name="scopes">Scopes for the downstream API to call</param>
+            <param name="claimsPrincipal">Claims principal for the user on behalf of whom to get a token.</param>
+            <param name="scopes">Scopes for the downstream API to call.</param>
             <param name="tenant">(optional) Specific tenant for which to acquire a token to access the scopes
-            on behalf of the user described in the claimsPrincipal</param>
+            on behalf of the user described in the claimsPrincipal.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetAccessTokenOnBehalfOfUserFromCacheAsync(Microsoft.Identity.Client.IConfidentialClientApplication,Microsoft.Identity.Client.IAccount,System.Collections.Generic.IEnumerable{System.String},System.String)">
             <summary>
-            Gets an access token for a downstream API on behalf of the user which account is passed as an argument
+            Gets an access token for a downstream API on behalf of the user which account is passed as an argument.
             </summary>
             <param name="application"></param>
             <param name="account">User IAccount for which to acquire a token.
-            See <see cref="P:Microsoft.Identity.Client.AccountId.Identifier"/></param>
-            <param name="scopes">Scopes for the downstream API to call</param>
+            See <see cref="P:Microsoft.Identity.Client.AccountId.Identifier"/>.</param>
+            <param name="scopes">Scopes for the downstream API to call.</param>
             <param name="tenant"></param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeader(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException)">
             <summary>
             Used in Web APIs (which therefore cannot have an interaction with the user).
             Replies to the client through the HttpResponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
-            the client can trigger an interaction with the user so that the user consents to more scopes
+            the client can trigger an interaction with the user so that the user consents to more scopes.
             </summary>
-            <param name="scopes">Scopes to consent to</param>
-            <param name="msalServiceException"><see cref="T:Microsoft.Identity.Client.MsalUiRequiredException"/> triggering the challenge</param>
+            <param name="scopes">Scopes to consent to.</param>
+            <param name="msalServiceException"><see cref="T:Microsoft.Identity.Client.MsalUiRequiredException"/> triggering the challenge.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetAccountByUserFlow(System.Collections.Generic.IEnumerable{Microsoft.Identity.Client.IAccount},System.String)">
             <summary>
-            Gets an IAccount for the current B2C user flow in the user claims
+            Gets an IAccount for the current B2C user flow in the user claims.
             </summary>
             <param name="accounts"></param>
             <param name="userFlow"></param>
@@ -810,7 +826,7 @@
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.Distributed.DistributedTokenCacheAdapterExtension">
             <summary>
-            Extension class used to add an in-memory token cache serializer to MSAL
+            Extension class used to add an in-memory token cache serializer to MSAL.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.DistributedTokenCacheAdapterExtension.AddDistributedTokenCaches(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
@@ -834,17 +850,17 @@
         </member>
         <member name="F:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter._distributedCache">
             <summary>
-            .NET Core Memory cache
+            .NET Core Memory cache.
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter._cacheOptions">
             <summary>
-            Msal memory token cache options
+            Msal memory token cache options.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.MicrosoftIdentityOptions},Microsoft.AspNetCore.Http.IHttpContextAccessor,Microsoft.Extensions.Caching.Distributed.IDistributedCache,Microsoft.Extensions.Options.IOptions{Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions})">
             <summary>
-            Constructor
+            Initializes a new instance of the <see cref="T:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter"/> class.
             </summary>
             <param name="microsoftIdentityOptions"></param>
             <param name="httpContextAccessor"></param>
@@ -854,25 +870,25 @@
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.RemoveKeyAsync(System.String)">
             <summary>
             Removes a specific token cache, described by its cache key
-            from the distributed cache
+            from the distributed cache.
             </summary>
-            <param name="cacheKey">Key of the cache to remove</param>
+            <param name="cacheKey">Key of the cache to remove.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.ReadCacheBytesAsync(System.String)">
             <summary>
-            Read a specific token cache, described by its cache key, from the 
-            distributed cache
+            Read a specific token cache, described by its cache key, from the
+            distributed cache.
             </summary>
             <param name="cacheKey"></param>
             <returns>Read blob representing a token cache for the cache key
-            (account or app)</returns>
+            (account or app).</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.WriteCacheBytesAsync(System.String,System.Byte[])">
             <summary>
-            Writes a token cache blob to the serialization cache (by key)
+            Writes a token cache blob to the serialization cache (by key).
             </summary>
-            <param name="cacheKey">Cache key</param>
-            <param name="bytes">blob to write</param>
+            <param name="cacheKey">Cache key.</param>
+            <param name="bytes">blob to write.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider">
             <summary>
@@ -881,31 +897,35 @@
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider.InitializeAsync(Microsoft.Identity.Client.ITokenCache)">
             <summary>
-            Initializes a token cache (which can be a user token cache or an app token cache)
+            Initializes a token cache (which can be a user token cache or an app token cache).
             </summary>
-            <param name="tokenCache">Token cache for which to initialize the serialization</param>
+            <param name="tokenCache">Token cache for which to initialize the serialization.</param>
             <returns></returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider.ClearAsync">
             <summary>
-            Clear the cache
+            Clear the cache.
             </summary>
             <returns></returns>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.InMemory.InMemoryTokenCacheProviderExtension">
             <summary>
-            Extension class used to add an in-memory token cache serializer to MSAL
+            Extension class used to add an in-memory token cache serializer to MSAL.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.InMemory.InMemoryTokenCacheProviderExtension.AddInMemoryTokenCaches(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
             <summary>Adds both the app and per-user in-memory token caches.</summary>
             <param name="services">The services collection to add to.</param>
-            <returns>the services (for chaining)</returns>
+            <returns>the services (for chaining).</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions">
             <summary>
-            MSAL's in-memory token cache options
+            MSAL's in-memory token cache options.
             </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions.#ctor">
+            <summary>Initializes a new instance of the <see cref="T:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions"/> class.
+            By default, the sliding expiration is set for 14 days.</summary>
         </member>
         <member name="P:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions.SlidingExpiration">
             <summary>
@@ -917,10 +937,6 @@
             The SlidingExpiration value.
             </value>
         </member>
-        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions.#ctor">
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions"/> class.
-            By default, the sliding expiration is set for 14 days.</summary>
-        </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheProvider">
             <summary>
             An implementation of token cache for both Confidential and Public clients backed by MemoryCache.
@@ -929,43 +945,43 @@
         </member>
         <member name="F:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheProvider._memoryCache">
             <summary>
-            .NET Core Memory cache
+            .NET Core Memory cache.
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheProvider._cacheOptions">
             <summary>
-            Msal memory token cache options
+            Msal memory token cache options.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheProvider.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.MicrosoftIdentityOptions},Microsoft.AspNetCore.Http.IHttpContextAccessor,Microsoft.Extensions.Caching.Memory.IMemoryCache,Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions})">
             <summary>
-            Constructor
+            Constructor.
             </summary>
-            <param name="microsoftIdentityOptions">Configuration options</param>
-            <param name="httpContextAccessor">Accessor to the HttpContext</param>
-            <param name="memoryCache">serialization cache</param>
-            <param name="cacheOptions">Memory cache options</param>
+            <param name="microsoftIdentityOptions">Configuration options.</param>
+            <param name="httpContextAccessor">Accessor to the HttpContext.</param>
+            <param name="memoryCache">serialization cache.</param>
+            <param name="cacheOptions">Memory cache options.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheProvider.RemoveKeyAsync(System.String)">
             <summary>
-            Removes a token cache identitied by its key, from the serialization
-            cache
+            Removes a token cache identified by its key, from the serialization
+            cache.
             </summary>
-            <param name="cacheKey">token cache key</param>
+            <param name="cacheKey">token cache key.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheProvider.ReadCacheBytesAsync(System.String)">
             <summary>
-            Reads a blob from the serialization cache (identitied by its key)
+            Reads a blob from the serialization cache (identified by its key).
             </summary>
-            <param name="cacheKey">Token cache key</param>
-            <returns>Read Bytes</returns>
+            <param name="cacheKey">Token cache key.</param>
+            <returns>Read Bytes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheProvider.WriteCacheBytesAsync(System.String,System.Byte[])">
             <summary>
-            Writes a token cache blob to the serialization cache (identitied by its key)
+            Writes a token cache blob to the serialization cache (identified by its key).
             </summary>
-            <param name="cacheKey">Token cache key</param>
-            <param name="bytes">Bytes to write</param>
+            <param name="cacheKey">Token cache key.</param>
+            <param name="bytes">Bytes to write.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider">
             <summary></summary>
@@ -973,31 +989,31 @@
         </member>
         <member name="F:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider._microsoftIdentityOptions">
             <summary>
-            Azure AD options
+            Azure AD options.
             </summary>
         </member>
         <member name="F:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider._httpContextAccessor">
             <summary>
-            Http accessor
+            Http accessor.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.MicrosoftIdentityOptions},Microsoft.AspNetCore.Http.IHttpContextAccessor)">
             <summary>
-            Constructor of the abstract token cache provider
+            Constructor of the abstract token cache provider.
             </summary>
-            <param name="microsoftIdentityOptions">Configuration options</param>
-            <param name="httpContextAccessor">Accessor for the HttpContext</param>
+            <param name="microsoftIdentityOptions">Configuration options.</param>
+            <param name="httpContextAccessor">Accessor for the HttpContext.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.InitializeAsync(Microsoft.Identity.Client.ITokenCache)">
             <summary>
             Initializes the token cache serialization.
             </summary>
-            <param name="tokenCache">Token cache to serialize/deserialize</param>
+            <param name="tokenCache">Token cache to serialize/deserialize.</param>
             <returns></returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.GetCacheKey(System.Boolean)">
             <summary>
-            Cache key
+            Cache key.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.OnAfterAccessAsync(Microsoft.Identity.Client.TokenCacheNotificationArgs)">
@@ -1011,36 +1027,36 @@
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.OnBeforeWriteAsync(Microsoft.Identity.Client.TokenCacheNotificationArgs)">
             <summary>
-            if you want to ensure that no concurrent write takes place, use this notification to place a lock on the entry
+            if you want to ensure that no concurrent write takes place, use this notification to place a lock on the entry.
             </summary>
-            <param name="args">Token cache notification arguments</param>
+            <param name="args">Token cache notification arguments.</param>
             <returns></returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.ClearAsync">
             <summary>
-            Clear the cache
+            Clear the cache.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.WriteCacheBytesAsync(System.String,System.Byte[])">
             <summary>
-            Method to be implemented by concrete cache serializers to write the cache bytes
+            Method to be implemented by concrete cache serializers to write the cache bytes.
             </summary>
-            <param name="cacheKey">Cache key</param>
-            <param name="bytes">Bytes to write</param>
+            <param name="cacheKey">Cache key.</param>
+            <param name="bytes">Bytes to write.</param>
             <returns></returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.ReadCacheBytesAsync(System.String)">
             <summary>
-            Method to be implemented by concrete cache serializers to Read the cache bytes
+            Method to be implemented by concrete cache serializers to Read the cache bytes.
             </summary>
-            <param name="cacheKey">Cache key</param>
-            <returns>Read bytes</returns>
+            <param name="cacheKey">Cache key.</param>
+            <returns>Read bytes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.RemoveKeyAsync(System.String)">
             <summary>
-            Method to be implemented by concrete cache serializers to remove an entry from the cache
+            Method to be implemented by concrete cache serializers to remove an entry from the cache.
             </summary>
-            <param name="cacheKey">Cache key</param>
+            <param name="cacheKey">Cache key.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.Session.MsalSessionTokenCacheProvider">
              <summary>
@@ -1063,36 +1079,36 @@
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Session.MsalSessionTokenCacheProvider.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.MicrosoftIdentityOptions},Microsoft.AspNetCore.Http.IHttpContextAccessor,Microsoft.Extensions.Logging.ILogger{Microsoft.Identity.Web.TokenCacheProviders.Session.MsalSessionTokenCacheProvider})">
             <summary>
-            Msal Token cache provider constructor
+            Msal Token cache provider constructor.
             </summary>
-            <param name="microsoftIdentityOptions">Configuration options</param>
-            <param name="httpContextAccessor">accessor for an HttpContext</param>
-            <param name="logger">Logger</param>
+            <param name="microsoftIdentityOptions">Configuration options.</param>
+            <param name="httpContextAccessor">accessor for an HttpContext.</param>
+            <param name="logger">Logger.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Session.MsalSessionTokenCacheProvider.ReadCacheBytesAsync(System.String)">
             <summary>
-            Read a blob representing the token cache from its key
+            Read a blob representing the token cache from its key.
             </summary>
             <param name="cacheKey">Key representing the token cache
-            (account or app)</param>
-            <returns>Read blob</returns>
+            (account or app).</param>
+            <returns>Read blob.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Session.MsalSessionTokenCacheProvider.WriteCacheBytesAsync(System.String,System.Byte[])">
             <summary>
-            Writes the token cache identitied by its key to the serialization mechanism
+            Writes the token cache identitied by its key to the serialization mechanism.
             </summary>
-            <param name="cacheKey">key for the cache (account ID or app ID)</param>
-            <param name="bytes">blob to write to the cache</param>
+            <param name="cacheKey">key for the cache (account ID or app ID).</param>
+            <param name="bytes">blob to write to the cache.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Session.MsalSessionTokenCacheProvider.RemoveKeyAsync(System.String)">
             <summary>
-            Removes a cache described from its key
+            Removes a cache described from its key.
             </summary>
-            <param name="cacheKey">key of the token cache (user account or app ID)</param>
+            <param name="cacheKey">key of the token cache (user account or app ID).</param>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.Session.SessionTokenCacheProviderExtension">
             <summary>
-            Extension class to add a session token cache serializer to MSAL
+            Extension class to add a session token cache serializer to MSAL.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Session.SessionTokenCacheProviderExtension.AddSessionTokenCaches(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
@@ -1159,41 +1175,41 @@
             Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
             This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
             </summary>
-            <param name="builder">AuthenticationBuilder to which to add this configuration</param>
-            <param name="configuration">The Configuration object</param>
-            <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options</param>
-            <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer"</param>
-            <param name="tokenDecryptionCertificate">Token decryption certificate (null by default)</param>
+            <param name="builder">AuthenticationBuilder to which to add this configuration.</param>
+            <param name="configuration">The Configuration object.</param>
+            <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options.</param>
+            <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer".</param>
+            <param name="tokenDecryptionCertificate">Token decryption certificate (null by default).</param>
             <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
             Set to true if you want to debug, or just understand the JwtBearer events.
             </param>
-            <returns>The authentication builder to chain</returns>
+            <returns>The authentication builder to chain.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebApiAuthenticationBuilderExtensions.AddProtectedWebApi(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.Action{Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions},System.Action{Microsoft.Identity.Web.MicrosoftIdentityOptions},System.Security.Cryptography.X509Certificates.X509Certificate2,System.String,System.Boolean)">
             <summary>
             Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
             This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
             </summary>
-            <param name="builder">AuthenticationBuilder to which to add this configuration</param>
-            <param name="configureJwtBearerOptions">The action to configure <see cref="T:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions"/></param>
+            <param name="builder">AuthenticationBuilder to which to add this configuration.</param>
+            <param name="configureJwtBearerOptions">The action to configure <see cref="T:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions"/>.</param>
             <param name="configureMicrosoftIdentityOptions">The action to configure the <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/>
-            configuration options</param>
-            <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer"</param>
-            <param name="tokenDecryptionCertificate">Token decryption certificate</param>
+            configuration options.</param>
+            <param name="tokenDecryptionCertificate">Token decryption certificate.</param>
+            <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer".</param>
             <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
             Set to true if you want to debug, or just understand the JwtBearer events.
             </param>
-            <returns>The authentication builder to chain</returns>
+            <returns>The authentication builder to chain.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebApiAuthenticationBuilderExtensions.EnsureValidAudiencesContainsApiGuidIfGuidProvided(Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions,Microsoft.Identity.Web.MicrosoftIdentityOptions)">
             <summary>
             Ensure that if the audience is a GUID, api://{audience} is also added
             as a valid audience (this is the default App ID URL in the app registration
-            portal)
+            portal).
             </summary>
             <param name="options"><see cref="T:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions"/> for which to ensure that
-            api://GUID is a valid audience</param>
-            <param name="msIdentityOptions">Configuration options</param>
+            api://GUID is a valid audience.</param>
+            <param name="msIdentityOptions">Configuration options.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.WebApiServiceCollectionExtensions">
             <summary>
@@ -1205,52 +1221,52 @@
             Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
             This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
             </summary>
-            <param name="services">Service collection to which to add authentication</param>
-            <param name="configuration">The Configuration object</param>
-            <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options</param>
-            <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer"</param>
-            <param name="tokenDecryptionCertificate">Token decryption certificate (null by default)</param>
+            <param name="services">Service collection to which to add authentication.</param>
+            <param name="configuration">The Configuration object.</param>
+            <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options.</param>
+            <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer".</param>
+            <param name="tokenDecryptionCertificate">Token decryption certificate (null by default).</param>
             <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
             Set to true if you want to debug, or just understand the JwtBearer events.
             </param>
-            <returns>The service collection to chain</returns>
+            <returns>The service collection to chain.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebApiServiceCollectionExtensions.AddProtectedWebApi(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions},System.Action{Microsoft.Identity.Web.MicrosoftIdentityOptions},System.Security.Cryptography.X509Certificates.X509Certificate2,System.String,System.Boolean)">
             <summary>
             Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
             This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
             </summary>
-            <param name="services">Service collection to which to add authentication</param>
-            <param name="configureJwtBearerOptions">The action to configure <see cref="T:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions"/></param>
-            <param name="configureMicrosoftIdentityOptions">The action to configure <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/></param>
-            <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer"</param>
-            <param name="tokenDecryptionCertificate">Token decryption certificate (null by default)</param>
+            <param name="services">Service collection to which to add authentication.</param>
+            <param name="configureJwtBearerOptions">The action to configure <see cref="T:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions"/>.</param>
+            <param name="configureMicrosoftIdentityOptions">The action to configure <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/>.</param>
+            <param name="tokenDecryptionCertificate">Token decryption certificate (null by default).</param>
+            <param name="jwtBearerScheme">The JwtBearer scheme name to be used. By default it uses "Bearer".</param>
             <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
             Set to true if you want to debug, or just understand the JwtBearer events.
             </param>
-            <returns>The service collection to chain</returns>
+            <returns>The service collection to chain.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebApiServiceCollectionExtensions.AddProtectedWebApiCallsProtectedWebApi(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration,System.String,System.String)">
             <summary>
             Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
-            This supposes that the configuration files have a section named configSectionName (typically "AzureAD")
+            This supposes that the configuration files have a section named configSectionName (typically "AzureAD").
             </summary>
-            <param name="services">Service collection to which to add authentication</param>
-            <param name="configuration">Configuration</param>
-            <param name="configSectionName">Section name in the config file (by default "AzureAD")</param>
-            <param name="jwtBearerScheme">Scheme for the JwtBearer token</param>
-            <returns>The service collection to chain</returns>
+            <param name="services">Service collection to which to add authentication.</param>
+            <param name="configuration">Configuration.</param>
+            <param name="configSectionName">Section name in the config file (by default "AzureAD").</param>
+            <param name="jwtBearerScheme">Scheme for the JwtBearer token.</param>
+            <returns>The service collection to chain.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebApiServiceCollectionExtensions.AddProtectedWebApiCallsProtectedWebApi(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.Identity.Client.ConfidentialClientApplicationOptions},System.Action{Microsoft.Identity.Web.MicrosoftIdentityOptions},System.String)">
             <summary>
             Protects the Web API with Microsoft identity platform (formerly Azure AD v2.0)
-            This supposes that the configuration files have a section named configSectionName (typically "AzureAD")
+            This supposes that the configuration files have a section named configSectionName (typically "AzureAD").
             </summary>
-            <param name="services">Service collection to which to add authentication</param>
-            <param name="configureConfidentialClientApplicationOptions">The action to configure <see cref="T:Microsoft.Identity.Client.ConfidentialClientApplicationOptions"/></param>
-            <param name="configureMicrosoftIdentityOptions">The action to configure <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/></param>
-            <param name="jwtBearerScheme">Scheme for the JwtBearer token</param>
-            <returns>The service collection to chain</returns>
+            <param name="services">Service collection to which to add authentication.</param>
+            <param name="configureConfidentialClientApplicationOptions">The action to configure <see cref="T:Microsoft.Identity.Client.ConfidentialClientApplicationOptions"/>.</param>
+            <param name="configureMicrosoftIdentityOptions">The action to configure <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/>.</param>
+            <param name="jwtBearerScheme">Scheme for the JwtBearer token.</param>
+            <returns>The service collection to chain.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.WebAppAuthenticationBuilderExtensions">
             <summary>
@@ -1262,30 +1278,30 @@
             Add authentication with Microsoft identity platform.
             This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
             </summary>
-            <param name="builder">AuthenticationBuilder to which to add this configuration</param>
-            <param name="configuration">The IConfiguration object</param>
-            <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options</param>
-            <param name="openIdConnectScheme">The OpenIdConnect scheme name to be used. By default it uses "OpenIdConnect"</param>
-            <param name="cookieScheme">The Cookies scheme name to be used. By default it uses "Cookies"</param>
+            <param name="builder">AuthenticationBuilder to which to add this configuration.</param>
+            <param name="configuration">The IConfiguration object.</param>
+            <param name="configSectionName">The configuration section with the necessary settings to initialize authentication options.</param>
+            <param name="openIdConnectScheme">The OpenIdConnect scheme name to be used. By default it uses "OpenIdConnect".</param>
+            <param name="cookieScheme">The Cookies scheme name to be used. By default it uses "Cookies".</param>
             <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
             Set to true if you want to debug, or just understand the OpenIdConnect events.
             </param>
-            <returns>The authentication builder for chaining</returns>
+            <returns>The authentication builder for chaining.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebAppAuthenticationBuilderExtensions.AddSignIn(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.Action{Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions},System.Action{Microsoft.Identity.Web.MicrosoftIdentityOptions},System.String,System.String,System.Boolean)">
             <summary>
             Add authentication with Microsoft identity platform.
             This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
             </summary>
-            <param name="builder">AuthenticationBuilder to which to add this configuration</param>
-            <param name="configureOpenIdConnectOptions">The IConfiguration object</param>
-            <param name="configureMicrosoftIdentityOptions">The configuration section with the necessary settings to initialize authentication options</param>
-            <param name="openIdConnectScheme">The OpenIdConnect scheme name to be used. By default it uses "OpenIdConnect"</param>
-            <param name="cookieScheme">The Cookies scheme name to be used. By default it uses "Cookies"</param>
+            <param name="builder">AuthenticationBuilder to which to add this configuration.</param>
+            <param name="configureOpenIdConnectOptions">The IConfiguration object.</param>
+            <param name="configureMicrosoftIdentityOptions">The configuration section with the necessary settings to initialize authentication options.</param>
+            <param name="openIdConnectScheme">The OpenIdConnect scheme name to be used. By default it uses "OpenIdConnect".</param>
+            <param name="cookieScheme">The Cookies scheme name to be used. By default it uses "Cookies".</param>
             <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
             Set to true if you want to debug, or just understand the OpenIdConnect events.
             </param>
-            <returns>The authentication builder for chaining</returns>
+            <returns>The authentication builder for chaining.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.WebAppServiceCollectionExtensions">
             <summary>
@@ -1295,67 +1311,67 @@
         <member name="M:Microsoft.Identity.Web.WebAppServiceCollectionExtensions.AddSignIn(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration,System.String,System.String,System.String,System.Boolean)">
             <summary>
             Add authentication with Microsoft identity platform.
-            This method expects the configuration file will have a section, (by default named "AzureAd"), with the necessary settings to 
+            This method expects the configuration file will have a section, (by default named "AzureAd"), with the necessary settings to
             initialize the authentication options.
             </summary>
-            <param name="services">Service collection to which to add authentication</param>
-            <param name="configuration">The IConfiguration object</param>
+            <param name="services">Service collection to which to add authentication.</param>
+            <param name="configuration">The IConfiguration object.</param>
             <param name="configSectionName">The name of the configuration section with the necessary
-            settings to initialize authentication options</param>
-            <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme 
+            settings to initialize authentication options.</param>
+            <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
             (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
             several OpenIdConnect identity providers.</param>
-            <param name="cookieScheme">Optional name for the acookie uthentication scheme 
-            (by default OpenIdConnectDefaults.AuthenticationScheme) </param>
+            <param name="cookieScheme">Optional name for the acookie uthentication scheme
+            (by default OpenIdConnectDefaults.AuthenticationScheme). </param>
             <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
             Set to true if you want to debug, or just understand the OpenIdConnect events.
             </param>
-            <returns>The service collection for chaining</returns>
+            <returns>The service collection for chaining.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebAppServiceCollectionExtensions.AddSignIn(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions},System.Action{Microsoft.Identity.Web.MicrosoftIdentityOptions},System.String,System.String,System.Boolean)">
             <summary>
             Add authentication with Microsoft identity platform.
             This method expects the configuration file will have a section, named "AzureAd" as default, with the necessary settings to initialize authentication options.
             </summary>
-            <param name="services">Service collection to which to add authentication</param>
-            <param name="configureOpenIdConnectOptions">the action to configure the <see cref="T:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions"/></param>
-            <param name="configureMicrosoftIdentityOptions">the action to configure the <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/></param>
-            <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme 
+            <param name="services">Service collection to which to add authentication.</param>
+            <param name="configureOpenIdConnectOptions">the action to configure the <see cref="T:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions"/>.</param>
+            <param name="configureMicrosoftIdentityOptions">the action to configure the <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/>.</param>
+            <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
             (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
             several OpenIdConnect identity providers.</param>
-            <param name="cookieScheme">Optional name for the acookie uthentication scheme 
-            (by default OpenIdConnectDefaults.AuthenticationScheme) </param>
+            <param name="cookieScheme">Optional name for the acookie uthentication scheme
+            (by default OpenIdConnectDefaults.AuthenticationScheme). </param>
             <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
             Set to true if you want to debug, or just understand the OpenIdConnect events.
             </param>
-            <returns>Yhe service collection for chaining</returns>
+            <returns>Yhe service collection for chaining.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebAppServiceCollectionExtensions.AddWebAppCallsProtectedWebApi(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration,System.Collections.Generic.IEnumerable{System.String},System.String,System.String)">
             <summary>
-            Add MSAL support to the Web App or Web API
+            Add MSAL support to the Web App or Web API.
             </summary>
-            <param name="services">Service collection to which to add authentication</param>
-            <param name="configuration">Configuration</param>
-            <param name="initialScopes">Initial scopes to request at sign-in</param>
+            <param name="services">Service collection to which to add authentication.</param>
+            <param name="configuration">Configuration.</param>
+            <param name="initialScopes">Initial scopes to request at sign-in.</param>
             <param name="configSectionName">The name of the configuration section with the necessary
-            settings to initialize authentication options</param>
-            <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme 
+            settings to initialize authentication options.</param>
+            <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
             (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
             several OpenIdConnect identity providers.</param>
-            <returns>Yhe service collection for chaining</returns>
+            <returns>Yhe service collection for chaining.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.WebAppServiceCollectionExtensions.AddWebAppCallsProtectedWebApi(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Collections.Generic.IEnumerable{System.String},System.Action{Microsoft.Identity.Web.MicrosoftIdentityOptions},System.Action{Microsoft.Identity.Client.ConfidentialClientApplicationOptions},System.String)">
             <summary>
-            Add MSAL support to the Web App or Web API
+            Add MSAL support to the Web App or Web API.
             </summary>
-            <param name="services">Service collection to which to add authentication</param>
-            <param name="initialScopes">Initial scopes to request at sign-in</param>
-            <param name="configureMicrosoftIdentityOptions">The action to set the <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/></param>
-            <param name="configureConfidentialClientApplicationOptions">The action to set the <see cref="T:Microsoft.Identity.Client.ConfidentialClientApplicationOptions"/></param>
-            <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme 
+            <param name="services">Service collection to which to add authentication.</param>
+            <param name="initialScopes">Initial scopes to request at sign-in.</param>
+            <param name="configureMicrosoftIdentityOptions">The action to set the <see cref="T:Microsoft.Identity.Web.MicrosoftIdentityOptions"/>.</param>
+            <param name="configureConfidentialClientApplicationOptions">The action to set the <see cref="T:Microsoft.Identity.Client.ConfidentialClientApplicationOptions"/>.</param>
+            <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
             (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
             several OpenIdConnect identity providers.</param>
-            <returns>The service collection for chaining</returns>
+            <returns>The service collection for chaining.</returns>
         </member>
     </members>
 </doc>

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Identity.Web
         public string RedirectUri { get; set; }
 
         /// <summary>
-        /// In a web app, gets or sets the PostLogoutRedirectUri 
-        /// This property is exclusive with <see cref="RemoteAuthenticationOptions.SignedOutCallbackPath"/> which should be used preferably if you don't want
+        /// In a web app, gets or sets the PostLogoutRedirectUri
+        /// This property is exclusive with <see cref="OpenIdConnectOptions.SignedOutCallbackPath"/> which should be used preferably if you don't want
         /// to have a different deployed configuration from your developer configuration.
         /// There are cases where PostLogoutRedirectUri is needed, for instance when you use a reverse proxy that transforms HTTPS
         /// URLs (external world) to HTTP URLs (inside the protected area). This can also be useful for web apps running

--- a/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -129,10 +129,9 @@ namespace Microsoft.Identity.Web
 
                 options.Events.OnTokenValidated = async context =>
                 {
-                    await onTokenValidatedHandler(context).ConfigureAwait(false);                
+                    await onTokenValidatedHandler(context).ConfigureAwait(false);
                     context.HttpContext.StoreTokenUsedToCallWebAPI(context.SecurityToken as JwtSecurityToken);
                     context.Success();
-                    await Task.FromResult(0).ConfigureAwait(false);
                 };
             });
 


### PR DESCRIPTION
- Removing a useless instruction (as pointed to by @jg11jg in https://github.com/AzureAD/microsoft-identity-web/issues/154)
- Regenerating the XML comments.
- Fixing a couple of static analysis warnings