### PR TITLE
Nullable partial work

### DIFF
--- a/src/Microsoft.Identity.Web/AccountExtensions.cs
+++ b/src/Microsoft.Identity.Web/AccountExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="account">The IAccount instance.</param>
         /// <returns>A <see cref="ClaimsPrincipal"/> built from IAccount.</returns>
-        public static ClaimsPrincipal ToClaimsPrincipal(this IAccount account)
+        public static ClaimsPrincipal? ToClaimsPrincipal(this IAccount? account)
         {
             if (account != null)
             {

--- a/src/Microsoft.Identity.Web/Base64UrlHelpers.cs
+++ b/src/Microsoft.Identity.Web/Base64UrlHelpers.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Web
         // * the 62nd and 63rd regular base64 encoding characters ('+' and '/') are replace with ('-' and '_')
         // The changes make the encoding alphabet file and URL safe
         // See RFC4648, section 5 for more info
-        public static string Encode(string arg)
+        public static string? Encode(string? arg)
         {
             if (arg == null)
             {
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Web
             return Convert.FromBase64String(s); // Standard base64 decoder
         }
 
-        internal static string Encode(byte[] arg)
+        internal static string? Encode(byte[]? arg)
         {
             if (arg == null)
             {

--- a/src/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
+++ b/src/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="claimsPrincipal">Claims principal.</param>
         /// <returns>A string corresponding to an account identifier as defined in <see cref="Microsoft.Identity.Client.AccountId.Identifier"/>.</returns>
-        public static string GetMsalAccountId(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetMsalAccountId(this ClaimsPrincipal claimsPrincipal)
         {
             if (claimsPrincipal == null)
             {
@@ -85,13 +85,13 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="claimsPrincipal">Identity for which to compute the domain-hint.</param>
         /// <returns>domain-hint for the identity, or <c>null</c> if it cannot be found.</returns>
-        public static string GetDomainHint(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetDomainHint(this ClaimsPrincipal claimsPrincipal)
         {
             // Tenant for MSA accounts
             const string msaTenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
 
             var tenantId = GetTenantId(claimsPrincipal);
-            string domainHint = string.IsNullOrWhiteSpace(tenantId)
+            string? domainHint = string.IsNullOrWhiteSpace(tenantId)
                 ? null
                 : tenantId.Equals(msaTenantId, StringComparison.OrdinalIgnoreCase) ? "consumers" : "organizations";
 
@@ -154,7 +154,7 @@ namespace Microsoft.Identity.Web
             {
                 throw new ArgumentNullException(nameof(claimsPrincipal));
             }
-            
+
             return claimsPrincipal.FindFirstValue(ClaimConstants.UniqueObjectIdentifier);
         }
 

--- a/src/Microsoft.Identity.Web/ClientInfo.cs
+++ b/src/Microsoft.Identity.Web/ClientInfo.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Identity.Web
     internal class ClientInfo
     {
         [DataMember(Name = "uid", IsRequired = false)]
-        public string UniqueObjectIdentifier { get; set; }
+        public string? UniqueObjectIdentifier { get; set; }
 
         [DataMember(Name = "utid", IsRequired = false)]
-        public string UniqueTenantIdentifier { get; set; }
+        public string? UniqueTenantIdentifier { get; set; }
 
         public static ClientInfo CreateFromJson(string clientInfo)
         {
@@ -25,19 +25,11 @@ namespace Microsoft.Identity.Web
                 throw new ArgumentNullException(nameof(clientInfo), $"client info returned from the server is null");
             }
 
-            return DeserializeFromJson<ClientInfo>(Base64UrlHelpers.DecodeToBytes(clientInfo));
-        }
+            var jsonByteArray = Base64UrlHelpers.DecodeToBytes(clientInfo);
 
-        internal static T DeserializeFromJson<T>(byte[] jsonByteArray)
-        {
-            if (jsonByteArray == null || jsonByteArray.Length == 0)
-            {
-                return default;
-            }
-
-            using var stream = new MemoryStream(jsonByteArray);
-            using var reader = new StreamReader(stream, Encoding.UTF8);
-            return (T)JsonSerializer.Create().Deserialize(reader, typeof(T));
+            using MemoryStream stream = new MemoryStream(jsonByteArray);
+            using StreamReader reader = new StreamReader(stream, Encoding.UTF8);
+            return (ClientInfo)JsonSerializer.Create().Deserialize(reader, typeof(ClientInfo));
         }
     }
 }

--- a/src/Microsoft.Identity.Web/HttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/HttpContextExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="httpContext">Http context associated with the current request.</param>
         /// <returns><see cref="JwtSecurityToken"/> used to call the Web API.</returns>
-        internal static JwtSecurityToken GetTokenUsedToCallWebAPI(this HttpContext httpContext)
+        internal static JwtSecurityToken? GetTokenUsedToCallWebAPI(this HttpContext httpContext)
         {
             return httpContext.Items["JwtSecurityTokenUsedToCallWebAPI"] as JwtSecurityToken;
         }

--- a/src/Microsoft.Identity.Web/ITokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/ITokenAcquisition.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Identity.Web
         /// <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the
         /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant.</param>
         /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes.</returns>
-        Task<string> GetAccessTokenForUserAsync(IEnumerable<string> scopes, string tenantId = null);
+        Task<string> GetAccessTokenForUserAsync(IEnumerable<string> scopes, string? tenantId = null);
 
         /// <summary>
         /// Acquires a token from the authority configured in the app, for the confidential client itself (not on behalf of a user)

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerMetadata.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerMetadata.cs
@@ -15,18 +15,18 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         /// Tenant discovery endpoint.
         /// </summary>
         [JsonProperty(PropertyName = "tenant_discovery_endpoint")]
-        public string TenantDiscoveryEndpoint { get; set; }
+        public string? TenantDiscoveryEndpoint { get; set; }
 
         /// <summary>
         /// API Version.
         /// </summary>
         [JsonProperty(PropertyName = "api-version")]
-        public string ApiVersion { get; set; }
+        public string? ApiVersion { get; set; }
 
         /// <summary>
         /// List of metadata associated with the endpoint.
         /// </summary>
         [JsonProperty(PropertyName = "metadata")]
-        public List<Metadata> Metadata { get; set; }
+        public List<Metadata>? Metadata { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/Metadata.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/Metadata.cs
@@ -15,19 +15,19 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         /// Preferred alias.
         /// </summary>
         [JsonProperty(PropertyName = "preferred_network")]
-        public string PreferredNetwork { get; set; }
+        public string? PreferredNetwork { get; set; }
 
         /// <summary>
         /// Preferred alias to cache tokens emitted by one of the aliases (to avoid
         /// SSO islands).
         /// </summary>
         [JsonProperty(PropertyName = "preferred_cache")]
-        public string PreferredCache { get; set; }
+        public string? PreferredCache { get; set; }
 
         /// <summary>
         /// Aliases of issuer URLs which are equivalent.
         /// </summary>
         [JsonProperty(PropertyName = "aliases")]
-        public List<string> Aliases { get; set; }
+        public List<string>? Aliases { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -1,6 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
 
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <PropertyGroup Label="Package Metadat">
     <!--This should be passed from the VSTS build-->
     <ClientSemVer Condition="'$(ClientSemVer)' == ''">0.1.0-localbuild</ClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
@@ -24,6 +32,7 @@
     <PackageReleaseNotes>The changelog is available at https://github.com/AzureAD/microsoft-identity-web/blob/master/changelog.txt and the roadmap at https://github.com/AzureAD/microsoft-identity-web/wiki#roadmap </PackageReleaseNotes>
     <PackageTags>Microsoft Identity Web .NET ASP.NET Core Web App Web API B2C</PackageTags>
   </PropertyGroup>
+  
   <PropertyGroup Label="Source Link">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -34,9 +43,6 @@
 
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
@@ -46,23 +52,6 @@
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
-
-  
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- The MSAL.snk has both private and public keys -->
-    <DelaySign>false</DelaySign>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\gh\microsoft-identity-web\src\Microsoft.Identity.Web\Microsoft.Identity.Web.xml</DocumentationFile>
-  </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.1" />

--- a/src/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
+++ b/src/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Identity.Web.Resource
                 throw new ArgumentNullException(nameof(aadAuthority));
             }
 
-            Uri.TryCreate(aadAuthority, UriKind.Absolute, out Uri authorityUri);
+            Uri.TryCreate(aadAuthority, UriKind.Absolute, out Uri? authorityUri);
             string authorityHost = authorityUri?.Authority ?? new Uri(FallbackAuthority).Authority;
 
-            if (s_issuerValidators.TryGetValue(authorityHost, out AadIssuerValidator aadIssuerValidator))
+            if (s_issuerValidators.TryGetValue(authorityHost, out AadIssuerValidator? aadIssuerValidator))
             {
                 return aadIssuerValidator;
             }
@@ -173,9 +173,9 @@ namespace Microsoft.Identity.Web.Resource
         {
             if (securityToken is JwtSecurityToken jwtSecurityToken)
             {
-                if (jwtSecurityToken.Payload.TryGetValue(ClaimConstants.Tid, out object tenantId))
+                if (jwtSecurityToken.Payload.TryGetValue(ClaimConstants.Tid, out object? tenantId))
                 {
-                    return tenantId as string;
+                    return (string)tenantId;
                 }
 
                 // Since B2C doesn't have "tid" as default, get it from issuer

--- a/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Identity.Web.Resource
         {
             foreach (var property in message.GetType().GetProperties())
             {
-                object value = property.GetValue(message);
+                object? value = property.GetValue(message);
                 if (value != null)
                 {
                     _logger.LogDebug($"   - {property.Name}={value}");

--- a/src/Microsoft.Identity.Web/Resource/RegisterValidAudience.cs
+++ b/src/Microsoft.Identity.Web/Resource/RegisterValidAudience.cs
@@ -61,7 +61,12 @@ namespace Microsoft.Identity.Web.Resource
             SecurityToken securityToken,
             TokenValidationParameters validationParameters)
         {
-            JwtSecurityToken token = securityToken as JwtSecurityToken;
+            JwtSecurityToken? token = securityToken as JwtSecurityToken;
+            if (token == null)
+            {
+                throw new SecurityTokenValidationException("Token is not JWT token.");
+            }
+
             string validAudience;
 
             // Case of a default App ID URI (the developer did not provide explicit valid audience(s)

--- a/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Identity.Web.Resource
                 throw new ArgumentNullException(nameof(acceptedScopes));
             }
 
-            Claim scopeClaim = context?.User?.FindFirst("http://schemas.microsoft.com/identity/claims/scope");
+            Claim? scopeClaim = context?.User?.FindFirst("http://schemas.microsoft.com/identity/claims/scope");
 
             if (scopeClaim == null || !scopeClaim.Value.Split(' ').Intersect(acceptedScopes).Any())
             {

--- a/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Web
             IConfiguration configuration,
             string configSectionName = "AzureAd",
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
-            X509Certificate2 tokenDecryptionCertificate = null,
+            X509Certificate2? tokenDecryptionCertificate = null,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {
             return builder.AddProtectedWebApi(
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Web
             this AuthenticationBuilder builder,
             Action<JwtBearerOptions> configureJwtBearerOptions,
             Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions,
-            X509Certificate2 tokenDecryptionCertificate = null,
+            X509Certificate2? tokenDecryptionCertificate = null,
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {

--- a/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
@@ -36,7 +35,7 @@ namespace Microsoft.Identity.Web
             IConfiguration configuration,
             string configSectionName = "AzureAd",
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
-            X509Certificate2 tokenDecryptionCertificate = null,
+            X509Certificate2? tokenDecryptionCertificate = null,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {
             AuthenticationBuilder builder = services.AddAuthentication(jwtBearerScheme);
@@ -66,7 +65,7 @@ namespace Microsoft.Identity.Web
             this IServiceCollection services,
             Action<JwtBearerOptions> configureJwtBearerOptions,
             Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions,
-            X509Certificate2 tokenDecryptionCertificate = null,
+            X509Certificate2? tokenDecryptionCertificate = null,
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {

--- a/src/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
@@ -158,7 +159,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The service collection for chaining.</returns>
         public static IServiceCollection AddWebAppCallsProtectedWebApi(
             this IServiceCollection services,
-            IEnumerable<string> initialScopes,
+            IEnumerable<string>? initialScopes,
             Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions,
             Action<ConfidentialClientApplicationOptions> configureConfidentialClientApplicationOptions,
             string openIdConnectScheme = OpenIdConnectDefaults.AuthenticationScheme)
@@ -198,7 +199,7 @@ namespace Microsoft.Identity.Web
                 var codeReceivedHandler = options.Events.OnAuthorizationCodeReceived;
                 options.Events.OnAuthorizationCodeReceived = async context =>
                 {
-                    var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>() as ITokenAcquisitionInternal;
+                    var tokenAcquisition = (ITokenAcquisitionInternal)context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
                     await tokenAcquisition.AddAccountToCacheFromAuthorizationCodeAsync(context, options.Scope).ConfigureAwait(false);
                     await codeReceivedHandler(context).ConfigureAwait(false);
                 };
@@ -232,7 +233,7 @@ namespace Microsoft.Identity.Web
                 options.Events.OnRedirectToIdentityProviderForSignOut = async context =>
                 {
                     // Remove the account from MSAL.NET token cache
-                    var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>() as ITokenAcquisitionInternal;
+                    var tokenAcquisition = (ITokenAcquisitionInternal)context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
                     await tokenAcquisition.RemoveAccountAsync(context).ConfigureAwait(false);
                     await signOutHandler(context).ConfigureAwait(false);
                 };

--- a/tests/Microsoft.Identity.Web.Test/ClientInfoTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClientInfoTests.cs
@@ -54,13 +54,13 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void DeserializeFromJson_ValidByteArray_ReturnsClientInfo()
         {
-            var clientInfoResult = ClientInfo.DeserializeFromJson<ClientInfo>(Encoding.UTF8.GetBytes(_decodedJson));
+            var clientInfoResult = ClientInfo.CreateFromJson(_decodedJson);
 
             Assert.NotNull(clientInfoResult);
             Assert.Equal(Uid, clientInfoResult.UniqueObjectIdentifier);
             Assert.Equal(Utid, clientInfoResult.UniqueTenantIdentifier);
 
-            clientInfoResult = ClientInfo.DeserializeFromJson<ClientInfo>(Encoding.UTF8.GetBytes(_decodedEmptyJson));
+            clientInfoResult = ClientInfo.CreateFromJson(_decodedEmptyJson);
             Assert.NotNull(clientInfoResult);
             Assert.Null(clientInfoResult.UniqueObjectIdentifier);
             Assert.Null(clientInfoResult.UniqueTenantIdentifier);
@@ -69,11 +69,11 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void DeserializeFromJson_NullOrEmptyJsonByteArray_ReturnsNull()
         {
-            var actualClientInfo = ClientInfo.DeserializeFromJson<ClientInfo>(Array.Empty<byte>());
+            var actualClientInfo = ClientInfo.CreateFromJson("");
 
             Assert.Null(actualClientInfo);
 
-            actualClientInfo = ClientInfo.DeserializeFromJson<ClientInfo>(null);
+            actualClientInfo = ClientInfo.CreateFromJson(null);
 
             Assert.Null(actualClientInfo);
         }
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void DeserializeFromJson_InvalidJsonByteArray_ReturnsNull()
         {
-            Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => ClientInfo.DeserializeFromJson<ClientInfo>(Encoding.UTF8.GetBytes(_invalidJson)));
+            Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => ClientInfo.CreateFromJson(_invalidJson));
         }
     }
 }


### PR DESCRIPTION
This is most of the work needed to conform to the nullable reference types. This makes the API more expressive, by showing which input / output types can be null or not. 

https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references

This is NOT a breaking change. 

Please read through my PR comments and decide if this is an avenue you wish to pursue. To sum up:

PROs: 

- better semantics (you know when to pass null or not)
- will help us discover bugs
- much less chances of NULL refs
- better for customers who also use this feature, as it will help the compiler analyze NULLs as well

CONs: 

- you still have to program defensively
- about ~2h more of work (I am happy to finish it if)
- one more things to understand