### PR TITLE
Replaced Newtonsoft.Json with System.Text.Json in projects. Plus minor misc fixes.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -476,9 +476,6 @@ dotnet_diagnostic.CA1303.severity = none
 # SA1004: Documentation lines should begin with single space
 dotnet_diagnostic.SA1004.severity = none
 
-# SA1027: Use tabs correctly
-dotnet_diagnostic.SA1027.severity = none
-
 # SA1118: Parameter should not span multiple lines
 dotnet_diagnostic.SA1118.severity = none
 
@@ -509,17 +506,8 @@ dotnet_diagnostic.SA1308.severity = none
 # SA1311: Static readonly fields should begin with upper-case letter
 dotnet_diagnostic.SA1311.severity = none
 
-# SA1312: Variable names should begin with lower-case letter
-dotnet_diagnostic.SA1312.severity = none
-
-# SA1313: Parameter names should begin with lower-case letter
-dotnet_diagnostic.SA1313.severity = none
-
 # SA1401: Fields should be private
 dotnet_diagnostic.SA1401.severity = none
-
-# SA1502: Element should not be on a single line
-dotnet_diagnostic.SA1502.severity = none
 
 # SA1512: Single-line comments should not be followed by blank line
 dotnet_diagnostic.SA1512.severity = none

--- a/src/Microsoft.Identity.Web/ClientInfo.cs
+++ b/src/Microsoft.Identity.Web/ClientInfo.cs
@@ -2,20 +2,18 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using System.Runtime.Serialization;
-using System.Text;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Identity.Web
 {
-    [DataContract]
     internal class ClientInfo
     {
-        [DataMember(Name = "uid", IsRequired = false)]
+        [JsonPropertyName("uid")]
         public string UniqueObjectIdentifier { get; set; }
 
-        [DataMember(Name = "utid", IsRequired = false)]
+        [JsonPropertyName("utid")]
         public string UniqueTenantIdentifier { get; set; }
 
         public static ClientInfo CreateFromJson(string clientInfo)
@@ -25,19 +23,22 @@ namespace Microsoft.Identity.Web
                 throw new ArgumentNullException(nameof(clientInfo), $"client info returned from the server is null");
             }
 
-            return DeserializeFromJson<ClientInfo>(Base64UrlHelpers.DecodeToBytes(clientInfo));
+            return DeserializeFromJson(Base64UrlHelpers.DecodeToBytes(clientInfo));
         }
 
-        internal static T DeserializeFromJson<T>(byte[] jsonByteArray)
+        internal static ClientInfo DeserializeFromJson(byte[] jsonByteArray)
         {
             if (jsonByteArray == null || jsonByteArray.Length == 0)
             {
                 return default;
             }
 
-            using var stream = new MemoryStream(jsonByteArray);
-            using var reader = new StreamReader(stream, Encoding.UTF8);
-            return (T)JsonSerializer.Create().Deserialize(reader, typeof(T));
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            };
+
+            return JsonSerializer.Deserialize<ClientInfo>(jsonByteArray, options);
         }
     }
 }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerConfigurationRetriever.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerConfigurationRetriever.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols;
-using Newtonsoft.Json;
 
 namespace Microsoft.Identity.Web.InstanceDiscovery
 {
@@ -34,8 +34,13 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
                 throw new ArgumentNullException(nameof(retriever), $"No metadata document retriever is provided");
             }
 
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            };
+
             string doc = await retriever.GetDocumentAsync(address, cancel).ConfigureAwait(false);
-            return JsonConvert.DeserializeObject<IssuerMetadata>(doc);
+            return JsonSerializer.Deserialize<IssuerMetadata>(doc, options);
         }
     }
 }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerMetadata.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerMetadata.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Identity.Web.InstanceDiscovery
 {
@@ -14,19 +14,19 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         /// <summary>
         /// Tenant discovery endpoint.
         /// </summary>
-        [JsonProperty(PropertyName = "tenant_discovery_endpoint")]
+        [JsonPropertyName("tenant_discovery_endpoint")]
         public string TenantDiscoveryEndpoint { get; set; }
 
         /// <summary>
         /// API Version.
         /// </summary>
-        [JsonProperty(PropertyName = "api-version")]
+        [JsonPropertyName("api-version")]
         public string ApiVersion { get; set; }
 
         /// <summary>
         /// List of metadata associated with the endpoint.
         /// </summary>
-        [JsonProperty(PropertyName = "metadata")]
+        [JsonPropertyName("metadata")]
         public List<Metadata> Metadata { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/Metadata.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/Metadata.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Identity.Web.InstanceDiscovery
 {
@@ -14,20 +14,20 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         /// <summary>
         /// Preferred alias.
         /// </summary>
-        [JsonProperty(PropertyName = "preferred_network")]
+        [JsonPropertyName("preferred_network")]
         public string PreferredNetwork { get; set; }
 
         /// <summary>
         /// Preferred alias to cache tokens emitted by one of the aliases (to avoid
         /// SSO islands).
         /// </summary>
-        [JsonProperty(PropertyName = "preferred_cache")]
+        [JsonPropertyName("preferred_cache")]
         public string PreferredCache { get; set; }
 
         /// <summary>
         /// Aliases of issuer URLs which are equivalent.
         /// </summary>
-        [JsonProperty(PropertyName = "aliases")]
+        [JsonPropertyName("aliases")]
         public List<string> Aliases { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -80,7 +80,10 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Is considered B2C if the attribute SignUpSignInPolicyId is defined.
         /// </summary>
-        internal bool IsB2C { get { return !string.IsNullOrWhiteSpace(DefaultUserFlow); } }
+        internal bool IsB2C
+        {
+            get => !string.IsNullOrWhiteSpace(DefaultUserFlow);
+        }
 
         /// <summary>
         /// Description of the certificates used to prove the identity of the Web app or Web API.

--- a/src/Microsoft.Identity.Web/Resource/RegisterValidAudience.cs
+++ b/src/Microsoft.Identity.Web/Resource/RegisterValidAudience.cs
@@ -49,13 +49,13 @@ namespace Microsoft.Identity.Web.Resource
         ///  api://{ClientID}.
         ///
         /// When Web API developers don't provide the "Audience" in the configuration, Microsoft.Identity.Web
-        /// considers that this is the default App ID URI as explained abovce. When developer provide the
-        /// "Audience" member, its available in the TokenValidationParameter.ValidAudience.
+        /// considers that this is the default App ID URI as explained above. When developer provides the
+        /// "Audience" member, it's available in the TokenValidationParameter.ValidAudience.
         /// </summary>
-        /// <param name="audiences">audiences in the security token.</param>
+        /// <param name="audiences">Audiences in the security token.</param>
         /// <param name="securityToken">Security token from which to validate the audiences.</param>
         /// <param name="validationParameters">Token validation parameters.</param>
-        /// <returns>true is the token is valid, and false, otherwise.</returns>
+        /// <returns>True if the token is valid; false, otherwise.</returns>
         internal /*for test only*/ bool ValidateAudience(
             IEnumerable<string> audiences,
             SecurityToken securityToken,

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         private readonly IDistributedCache _distributedCache;
 
         /// <summary>
-        /// Msal memory token cache options.
+        /// MSAL memory token cache options.
         /// </summary>
         private readonly DistributedCacheEntryOptions _cacheOptions;
 

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         private readonly IMemoryCache _memoryCache;
 
         /// <summary>
-        /// Msal memory token cache options.
+        /// MSAL memory token cache options.
         /// </summary>
         private readonly MsalMemoryTokenCacheOptions _cacheOptions;
 

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         protected readonly IOptions<MicrosoftIdentityOptions> _microsoftIdentityOptions;
 
         /// <summary>
-        /// Http accessor.
+        /// HTTP accessor.
         /// </summary>
         protected readonly IHttpContextAccessor _httpContextAccessor;
 

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
@@ -10,15 +10,15 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.Identity.Web.TokenCacheProviders.Session
 {
     /// <summary>
-    /// An implementation of token cache for Confidential clients backed by an Http session.
+    /// An implementation of token cache for Confidential clients backed by an HTTP session.
     /// </summary>
-    /// For this session cache to work effectively the aspnetcore session has to be configured properly.
+    /// For this session cache to work effectively the ASP.NET Core session has to be configured properly.
     /// The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state
     ///
     /// // In the method - public void ConfigureServices(IServiceCollection services) in startup.cs, add the following
     /// services.AddSession(option =>
     /// {
-    ///	    option.Cookie.IsEssential = true;
+    ///     option.Cookie.IsEssential = true;
     /// });
     ///
     /// In the method - public void Configure(IApplicationBuilder app, IHostingEnvironment env) in startup.cs, add the following
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         private ILogger _logger;
 
         /// <summary>
-        /// Msal Token cache provider constructor.
+        /// MSAL Token cache provider constructor.
         /// </summary>
         /// <param name="microsoftIdentityOptions">Configuration options.</param>
         /// <param name="httpContextAccessor">accessor for an HttpContext.</param>
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         }
 
         /// <summary>
-        /// Writes the token cache identitied by its key to the serialization mechanism.
+        /// Writes the token cache identified by its key to the serialization mechanism.
         /// </summary>
         /// <param name="cacheKey">key for the cache (account ID or app ID).</param>
         /// <param name="bytes">blob to write to the cache.</param>

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
@@ -13,28 +13,28 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
     public static class SessionTokenCacheProviderExtension
     {
         /// <summary>Adds both App and per-user session token caches.</summary>
-        /// For this session cache to work effectively the aspnetcore session has to be configured properly.
+        /// For this session cache to work effectively the ASP.NET Core session has to be configured properly.
         /// The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state
         ///
-        /// // In the method - public void ConfigureServices(IServiceCollection services) in startup.cs, add the following
+        /// // In the method - public void ConfigureServices(IServiceCollection services) in Startup.cs, add the following
         /// services.AddSession(option =>
         /// {
-        ///	    option.Cookie.IsEssential = true;
+        ///     option.Cookie.IsEssential = true;
         /// });
         ///
-        /// In the method - public void Configure(IApplicationBuilder app, IHostingEnvironment env) in startup.cs, add the following
+        /// In the method - public void Configure(IApplicationBuilder app, IHostingEnvironment env) in Startup.cs, add the following
         ///
         /// app.UseSession(); // Before UseMvc()
         ///
         /// <param name="services">The services collection to add to.</param>
-        /// <returns></returns>
+        /// <returns>The service collection.</returns>
         public static IServiceCollection AddSessionTokenCaches(this IServiceCollection services)
         {
             // Add session if you are planning to use session based token cache
-            var ISessionStoreservice = services.FirstOrDefault(x => x.ServiceType.Name == "ISessionStore");
+            var sessionStoreService = services.FirstOrDefault(x => x.ServiceType.Name == "ISessionStore");
 
             // If not added already
-            if (ISessionStoreservice == null)
+            if (sessionStoreService == null)
             {
                 services.AddSession(option =>
                 {
@@ -56,22 +56,22 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
             return services;
         }
 
-        /// <summary>Adds the Http session based application token cache to the service collection.</summary>
-        /// For this session cache to work effectively the aspnetcore session has to be configured properly.
+        /// <summary>Adds an HTTP session based application token cache to the service collection.</summary>
+        /// For this session cache to work effectively the ASP.NET Core session has to be configured properly.
         /// The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state
         ///
-        /// // In the method - public void ConfigureServices(IServiceCollection services) in startup.cs, add the following
+        /// // In the method - public void ConfigureServices(IServiceCollection services) in Startup.cs, add the following
         /// services.AddSession(option =>
         /// {
-        ///	    option.Cookie.IsEssential = true;
+        ///     option.Cookie.IsEssential = true;
         /// });
         ///
-        /// In the method - public void Configure(IApplicationBuilder app, IHostingEnvironment env) in startup.cs, add the following
+        /// In the method - public void Configure(IApplicationBuilder app, IHostingEnvironment env) in Startup.cs, add the following
         ///
         /// app.UseSession(); // Before UseMvc()
         ///
         /// <param name="services">The services collection to add to.</param>
-        /// <returns></returns>
+        /// <returns>The service collection.</returns>
         public static IServiceCollection AddSessionAppTokenCache(this IServiceCollection services)
         {
             services.AddHttpContextAccessor();
@@ -79,22 +79,22 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
             return services;
         }
 
-        /// <summary>Adds the http session based per user token cache to the service collection.</summary>
-        /// For this session cache to work effectively the aspnetcore session has to be configured properly.
+        /// <summary>Adds an HTTP session based per user token cache to the service collection.</summary>
+        /// For this session cache to work effectively the ASP.NET Core session has to be configured properly.
         /// The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state
         ///
-        /// // In the method - public void ConfigureServices(IServiceCollection services) in startup.cs, add the following
+        /// // In the method - public void ConfigureServices(IServiceCollection services) in Startup.cs, add the following
         /// services.AddSession(option =>
         /// {
-        ///	    option.Cookie.IsEssential = true;
+        ///     option.Cookie.IsEssential = true;
         /// });
         ///
-        /// In the method - public void Configure(IApplicationBuilder app, IHostingEnvironment env) in startup.cs, add the following
+        /// In the method - public void Configure(IApplicationBuilder app, IHostingEnvironment env) in Startup.cs, add the following
         ///
         /// app.UseSession(); // Before UseMvc()
         ///
         /// <param name="services">The services collection to add to.</param>
-        /// <returns></returns>
+        /// <returns>The service collection.</returns>
         public static IServiceCollection AddSessionPerUserTokenCache(this IServiceCollection services)
         {
             services.AddHttpContextAccessor();

--- a/tests/B2CWebAppCallsWebApi/Client/Services/TodoListService.cs
+++ b/tests/B2CWebAppCallsWebApi/Client/Services/TodoListService.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Identity.Web;
-using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web;
 using TodoListService.Models;
 
 namespace TodoListClient.Services
@@ -35,6 +35,10 @@ namespace TodoListClient.Services
         private readonly string _TodoListScope = string.Empty;
         private readonly string _TodoListBaseAddress = string.Empty;
         private readonly ITokenAcquisition _tokenAcquisition;
+        private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
 
         public TodoListService(ITokenAcquisition tokenAcquisition, HttpClient httpClient, IConfiguration configuration, IHttpContextAccessor contextAccessor)
         {
@@ -49,7 +53,7 @@ namespace TodoListClient.Services
         {
             await PrepareAuthenticatedClient();
 
-            var jsonRequest = JsonConvert.SerializeObject(todo);
+            var jsonRequest = JsonSerializer.Serialize(todo);
             var jsoncontent = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
 
             var response = await this._httpClient.PostAsync($"{ _TodoListBaseAddress}/api/todolist", jsoncontent);
@@ -57,7 +61,7 @@ namespace TodoListClient.Services
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                todo = JsonConvert.DeserializeObject<Todo>(content);
+                todo = JsonSerializer.Deserialize<Todo>(content, _jsonOptions);
 
                 return todo;
             }
@@ -83,7 +87,7 @@ namespace TodoListClient.Services
         {
             await PrepareAuthenticatedClient();
 
-            var jsonRequest = JsonConvert.SerializeObject(todo);
+            var jsonRequest = JsonSerializer.Serialize(todo);
             var jsoncontent = new StringContent(jsonRequest, Encoding.UTF8, "application/json-patch+json");
 
             var response = await _httpClient.PatchAsync($"{ _TodoListBaseAddress}/api/todolist/{todo.Id}", jsoncontent);
@@ -91,7 +95,7 @@ namespace TodoListClient.Services
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                todo = JsonConvert.DeserializeObject<Todo>(content);
+                todo = JsonSerializer.Deserialize<Todo>(content, _jsonOptions);
 
                 return todo;
             }
@@ -107,7 +111,7 @@ namespace TodoListClient.Services
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                IEnumerable<Todo> todolist = JsonConvert.DeserializeObject<IEnumerable<Todo>>(content);
+                IEnumerable<Todo> todolist = JsonSerializer.Deserialize<IEnumerable<Todo>>(content, _jsonOptions);
 
                 return todolist;
             }
@@ -131,7 +135,7 @@ namespace TodoListClient.Services
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                Todo todo = JsonConvert.DeserializeObject<Todo>(content);
+                Todo todo = JsonSerializer.Deserialize<Todo>(content, _jsonOptions);
 
                 return todo;
             }

--- a/tests/B2CWebAppCallsWebApi/TodoListService/Models/TodoItem.cs
+++ b/tests/B2CWebAppCallsWebApi/TodoListService/Models/TodoItem.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 namespace TodoListService.Models
 {
     public class Todo

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -159,14 +159,14 @@ namespace Microsoft.Identity.Web.Test.Integration
 
             services.AddTokenAcquisition();
             services.AddTransient(
-                _provider => Options.Create(new MicrosoftIdentityOptions
+                provider => Options.Create(new MicrosoftIdentityOptions
                 {
                     Authority = TestConstants.AuthorityCommonTenant,
                     ClientId = TestConstants.ConfidentialClientId,
                     CallbackPath = string.Empty,
                 }));
             services.AddTransient(
-                _provider => Options.Create(new ConfidentialClientApplicationOptions
+                provider => Options.Create(new ConfidentialClientApplicationOptions
                 {
                     Instance = TestConstants.AadInstance,
                     TenantId = TestConstants.ConfidentialClientLabTenant,

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabResponse.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabResponse.cs
@@ -1,57 +1,57 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
     public class LabResponse
     {
-        [JsonProperty("app")]
+        [JsonPropertyName("app")]
         public LabApp App { get; set; }
 
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public LabUser User { get; set; }
 
-        [JsonProperty("lab")]
+        [JsonPropertyName("lab")]
         public Lab Lab { get; set; }
     }
 
     public class LabApp
     {
-        [JsonProperty("appid")]
+        [JsonPropertyName("appid")]
         public string AppId { get; set; }
 
         // TODO: this is a list, but lab sends a string. Not used today, discuss with lab to return a list
-        [JsonProperty("redirecturi")]
+        [JsonPropertyName("redirecturi")]
         public string RedirectUri { get; set; }
 
-        [JsonProperty("signinaudience")]
+        [JsonPropertyName("signinaudience")]
         public string Audience { get; set; }
 
         // TODO: this is a list, but lab sends a string. Not used today, discuss with lab to return a list
-        [JsonProperty("authority")]
+        [JsonPropertyName("authority")]
         public string Authority { get; set; }
     }
 
     public class Lab
     {
-        [JsonProperty("tenantid")]
+        [JsonPropertyName("tenantid")]
         public string TenantId { get; set; }
 
-        [JsonProperty("federationprovider")]
+        [JsonPropertyName("federationprovider")]
         public FederationProvider FederationProvider { get; set; }
 
-        [JsonProperty("credentialvaultkeyname")]
+        [JsonPropertyName("credentialvaultkeyname")]
         public string CredentialVaultkeyName { get; set; }
 
-        [JsonProperty("authority")]
+        [JsonPropertyName("authority")]
         public string Authority { get; set; }
     }
 
     public class LabCredentialResponse
     {
-        [JsonProperty("Value")]
+        [JsonPropertyName("Value")]
         public string Secret { get; set; }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabServiceApi.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabServiceApi.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
             };
 
             string result = await SendLabRequestAsync(LabApiConstants.LabUserCredentialEndpoint, queryDict).ConfigureAwait(false);
-            return JsonConvert.DeserializeObject<LabCredentialResponse>(result).Secret;
+            return JsonSerializer.Deserialize<LabCredentialResponse>(result).Secret;
         }
 
         private async Task<LabResponse> GetLabResponseFromApiAsync(UserQuery query)
@@ -65,15 +65,15 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
 
         private async Task<LabResponse> CreateLabResponseFromResultStringAsync(string result)
         {
-            LabUser[] userResponses = JsonConvert.DeserializeObject<LabUser[]>(result);
+            LabUser[] userResponses = JsonSerializer.Deserialize<LabUser[]>(result);
 
             var user = userResponses[0];
 
             var appResponse = await GetLabResponseAsync(LabApiConstants.LabAppEndpoint + user.AppId).ConfigureAwait(false);
-            LabApp[] labApps = JsonConvert.DeserializeObject<LabApp[]>(appResponse);
+            LabApp[] labApps = JsonSerializer.Deserialize<LabApp[]>(appResponse);
 
             var labInfoResponse = await GetLabResponseAsync(LabApiConstants.LabInfoEndpoint + user.LabName).ConfigureAwait(false);
-            Lab[] labs = JsonConvert.DeserializeObject<Lab[]>(labInfoResponse);
+            Lab[] labs = JsonSerializer.Deserialize<Lab[]>(labInfoResponse);
 
             user.TenantId = labs[0].TenantId;
             user.FederationProvider = labs[0].FederationProvider;

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabUser.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/LabUser.cs
@@ -2,40 +2,40 @@
 // Licensed under the MIT License.
 
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
     public class LabUser
     {
-        [JsonProperty("objectId")]
+        [JsonPropertyName("objectId")]
         public Guid ObjectId { get; set; }
 
-        [JsonProperty("userType")]
+        [JsonPropertyName("userType")]
         public UserType UserType { get; set; }
 
-        [JsonProperty("upn")]
+        [JsonPropertyName("upn")]
         public string Upn { get; set; }
 
-        [JsonProperty("displayname")]
+        [JsonPropertyName("displayname")]
         public string DisplayName { get; set; }
 
-        [JsonProperty("mfa")]
+        [JsonPropertyName("mfa")]
         public MFA Mfa { get; set; }
 
-        [JsonProperty("protectionpolicy")]
+        [JsonPropertyName("protectionpolicy")]
         public ProtectionPolicy ProtectionPolicy { get; set; }
 
-        [JsonProperty("homedomain")]
+        [JsonPropertyName("homedomain")]
         public HomeDomain HomeDomain { get; set; }
 
-        [JsonProperty("homeupn")]
+        [JsonPropertyName("homeupn")]
         public string HomeUPN { get; set; }
 
-        [JsonProperty("b2cprovider")]
+        [JsonPropertyName("b2cprovider")]
         public B2CIdentityProvider B2cProvider { get; set; }
 
-        [JsonProperty("labname")]
+        [JsonPropertyName("labname")]
         public string LabName { get; set; }
 
         public FederationProvider FederationProvider { get; set; }
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
 
         private string _password = null;
 
-        [JsonProperty("appid")]
+        [JsonPropertyName("appid")]
         public string AppId { get; set; }
 
         public string GetOrFetchPassword()

--- a/tests/Microsoft.Identity.Web.Test/ClientInfoTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClientInfoTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+using System.Text.Json;
 using Microsoft.Identity.Web.Test.Common;
 using Xunit;
 
@@ -10,8 +11,8 @@ namespace Microsoft.Identity.Web.Test
 {
     public class ClientInfoTests
     {
-        private const string Uid = "Uid";
-        private const string Utid = "Utid";
+        private const string Uid = TestConstants.Uid;
+        private const string Utid = TestConstants.Utid;
         private string _decodedJson = $"{{\"uid\":\"{Uid}\",\"utid\":\"{Utid}\"}}";
         private string _decodedEmptyJson = "{}";
         private string _invalidJson = $"{{\"uid\":\"{Uid}\",\"utid\":\"{Utid}\"";
@@ -46,21 +47,21 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void CreateFromJson_InvalidString_ThrowsException()
         {
-            Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => ClientInfo.CreateFromJson(Base64UrlHelpers.Encode(_invalidJson)));
+            Assert.Throws<JsonException>(() => ClientInfo.CreateFromJson(Base64UrlHelpers.Encode(_invalidJson)));
 
-            Assert.Throws<FormatException>(() => ClientInfo.CreateFromJson(_invalidJson));
+            Assert.Throws<ArgumentException>(() => ClientInfo.CreateFromJson(_invalidJson));
         }
 
         [Fact]
         public void DeserializeFromJson_ValidByteArray_ReturnsClientInfo()
         {
-            var clientInfoResult = ClientInfo.DeserializeFromJson<ClientInfo>(Encoding.UTF8.GetBytes(_decodedJson));
+            var clientInfoResult = ClientInfo.DeserializeFromJson(Encoding.UTF8.GetBytes(_decodedJson));
 
             Assert.NotNull(clientInfoResult);
             Assert.Equal(Uid, clientInfoResult.UniqueObjectIdentifier);
             Assert.Equal(Utid, clientInfoResult.UniqueTenantIdentifier);
 
-            clientInfoResult = ClientInfo.DeserializeFromJson<ClientInfo>(Encoding.UTF8.GetBytes(_decodedEmptyJson));
+            clientInfoResult = ClientInfo.DeserializeFromJson(Encoding.UTF8.GetBytes(_decodedEmptyJson));
             Assert.NotNull(clientInfoResult);
             Assert.Null(clientInfoResult.UniqueObjectIdentifier);
             Assert.Null(clientInfoResult.UniqueTenantIdentifier);
@@ -69,11 +70,11 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void DeserializeFromJson_NullOrEmptyJsonByteArray_ReturnsNull()
         {
-            var actualClientInfo = ClientInfo.DeserializeFromJson<ClientInfo>(Array.Empty<byte>());
+            var actualClientInfo = ClientInfo.DeserializeFromJson(Array.Empty<byte>());
 
             Assert.Null(actualClientInfo);
 
-            actualClientInfo = ClientInfo.DeserializeFromJson<ClientInfo>(null);
+            actualClientInfo = ClientInfo.DeserializeFromJson(null);
 
             Assert.Null(actualClientInfo);
         }
@@ -81,7 +82,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void DeserializeFromJson_InvalidJsonByteArray_ReturnsNull()
         {
-            Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => ClientInfo.DeserializeFromJson<ClientInfo>(Encoding.UTF8.GetBytes(_invalidJson)));
+            Assert.Throws<JsonException>(() => ClientInfo.DeserializeFromJson(Encoding.UTF8.GetBytes(_invalidJson)));
         }
     }
 }

--- a/tests/WebAppCallsWebApiCallsGraph/Client/Services/TodoListService.cs
+++ b/tests/WebAppCallsWebApiCallsGraph/Client/Services/TodoListService.cs
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Identity.Web;
-using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web;
 using TodoListService.Models;
 
 namespace TodoListClient.Services
@@ -35,6 +35,10 @@ namespace TodoListClient.Services
         private readonly string _TodoListScope = string.Empty;
         private readonly string _TodoListBaseAddress = string.Empty;
         private readonly ITokenAcquisition _tokenAcquisition;
+        private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
 
         public TodoListService(ITokenAcquisition tokenAcquisition, HttpClient httpClient, IConfiguration configuration, IHttpContextAccessor contextAccessor)
         {
@@ -49,14 +53,14 @@ namespace TodoListClient.Services
         {
             await PrepareAuthenticatedClient();
 
-            var jsonRequest = JsonConvert.SerializeObject(todo);
+            var jsonRequest = JsonSerializer.Serialize(todo);
             var jsoncontent = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
             var response = await this._httpClient.PostAsync($"{ _TodoListBaseAddress}/api/todolist", jsoncontent);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                todo = JsonConvert.DeserializeObject<Todo>(content);
+                todo = JsonSerializer.Deserialize<Todo>(content, _jsonOptions);
 
                 return todo;
             }
@@ -82,14 +86,14 @@ namespace TodoListClient.Services
         {
             await PrepareAuthenticatedClient();
 
-            var jsonRequest = JsonConvert.SerializeObject(todo);
+            var jsonRequest = JsonSerializer.Serialize(todo);
             var jsoncontent = new StringContent(jsonRequest, Encoding.UTF8, "application/json-patch+json");
             var response = await _httpClient.PatchAsync($"{ _TodoListBaseAddress}/api/todolist/{todo.Id}", jsoncontent);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                todo = JsonConvert.DeserializeObject<Todo>(content);
+                todo = JsonSerializer.Deserialize<Todo>(content, _jsonOptions);
 
                 return todo;
             }
@@ -104,7 +108,7 @@ namespace TodoListClient.Services
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                IEnumerable<Todo> todolist = JsonConvert.DeserializeObject<IEnumerable<Todo>>(content);
+                IEnumerable<Todo> todolist = JsonSerializer.Deserialize<IEnumerable<Todo>>(content, _jsonOptions);
 
                 return todolist;
             }
@@ -127,7 +131,7 @@ namespace TodoListClient.Services
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                Todo todo = JsonConvert.DeserializeObject<Todo>(content);
+                Todo todo = JsonSerializer.Deserialize<Todo>(content, _jsonOptions);
 
                 return todo;
             }

--- a/tests/WebAppCallsWebApiCallsGraph/TodoListService/Models/TodoItem.cs
+++ b/tests/WebAppCallsWebApiCallsGraph/TodoListService/Models/TodoItem.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 namespace TodoListService.Models
 {
     public class Todo


### PR DESCRIPTION
Replaced Newtonsoft.Json with System.Text.Json in projects (including samples). Plus minor spelling, warning fixes.

**Note:** Newtonsoft.Json by default does case-**insensitive** deserializaton, while System.Text.Json is case-**sensitive** by default to improve performance. In order to make it case-insensitive, we have to pass it options object to the deserializer.

Related resources:
[Try the new System.Text.Json APIs](https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-apis/)
[How to serialize and deserialize (marshal and unmarshal) JSON in .NET](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-how-to)
[How to migrate from Newtonsoft.Json to System.Text.Json](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to)