### PR TITLE
Fix the XML documentation for ClaimsPrincipalExtensions.GetNameIdenti…

### DIFF
--- a/src/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
+++ b/src/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
@@ -176,8 +176,8 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Gets the NameIdentifierId associated with the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the sub claim.</param>
-        /// <returns>Name identifier ID (sub) of the identity, or <c>null</c> if it cannot be found.</returns>
+        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the <c>uid</c> claim.</param>
+        /// <returns>Name identifier ID (uid) of the identity, or <c>null</c> if it cannot be found.</returns>
         public static string GetNameIdentifierId(this ClaimsPrincipal claimsPrincipal)
         {
             return claimsPrincipal.FindFirstValue(ClaimConstants.UniqueObjectIdentifier);


### PR DESCRIPTION
…fierId

Fixes the XML documentation for ClaimsPrincipalExtensions.GetNameIdentifierId
therefore addressing https://github.com/AzureAD/microsoft-identity-web/issues/171