### PR TITLE
Adding the capability of calling a Web API to the mvc2 template

### DIFF
--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -69,9 +69,17 @@
       "shortName": ""
     },
     "RazorRuntimeCompilation": {
-      "longName": "razor-runtime-compilation",
-      "shortName": "rrc"
-    }
+        "longName": "razor-runtime-compilation",
+        "shortName": "rrc"
+    },
+    "CalledApiUrl": {
+        "longName": "called-api-url",
+        "shortName": ""
+    },
+    "CalledApiScopes": {
+        "longName": "called-api-scopes",
+        "shortName": ""
+    }  
   },
   "usageExamples": [
     "--auth Individual"

--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
@@ -86,16 +86,16 @@
           "condition": "(IndividualLocalAuth && !UseLocalDB)",
           "rename": {
             "Data/SqlLite/": "Data/Migrations/"
-           },
-           "exclude": [
+          },
+          "exclude": [
             "Data/SqlServer/**"
-           ]
+          ]
         },
         {
-            "condition": "(!GenerateApi)",
-            "exclude": [
-                "Services/**"
-            ]
+          "condition": "(!GenerateApi)",
+          "exclude": [
+            "Services/**"
+          ]
         }
       ]
     }
@@ -213,9 +213,9 @@
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
     "HttpPort": {
-        "type": "parameter",
-        "datatype": "integer",
-        "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
     "HttpPortGenerated": {
       "type": "generated",
@@ -312,12 +312,12 @@
       "datatype": "choice",
       "choices": [
         {
-            "choice": "netcoreapp5.0",
-            "description": "Target netcoreapp5.0"
+          "choice": "netcoreapp5.0",
+          "description": "Target netcoreapp5.0"
         },
         {
-            "choice": "netcoreapp3.1",
-            "description": "Target netcoreapp3.1"
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
         }
       ],
       "replaces": "netcoreapp5.0",
@@ -332,22 +332,22 @@
       }
     },
     "skipRestore": {
-        "type": "parameter",
-        "datatype": "bool",
-        "description": "If specified, skips the automatic restore of the project on create.",
-        "defaultValue": "false"
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     },
     "CalledApiUrl": {
-        "type": "parameter",
-        "datatype": "string",
-        "replaces": "https://graph.microsoft.com/v1.0",
-        "description": "URL of the API to call from the web app."
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "https://graph.microsoft.com/v1.0/me",
+      "description": "URL of the API to call from the web app."
     },
     "CalledApiScopes": {
-        "type": "parameter",
-        "datatype": "string",
-        "replaces" :  "user.read",
-        "description": "Scopes to request to call the API from the web app."
+      "type": "parameter",
+      "datatype": "string",
+      "replaces" :  "user.read",
+      "description": "Scopes to request to call the API from the web app."
     },
     "TokenCacheSerialization": {
       "type": "parameter",

--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
@@ -349,30 +349,6 @@
       "replaces" :  "user.read",
       "description": "Scopes to request to call the API from the web app."
     },
-    "TokenCacheSerialization": {
-      "type": "parameter",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "InMemory",
-          "description": "In memory implementation of the token cache serialization."
-        },
-        {
-          "choice": "Session",
-          "description": "Session based implementation of the token cache serialization."
-        },
-        {
-          "choice": "DistributedMemory",
-          "description": "Distributed memory cache implementation."
-        },
-        {
-            "choice": "SQL",
-            "description": "SQL implementation for the token cache serialization."
-        }
-      ],
-      "defaultValue": "InMemory",
-      "description": "The token cache serialization technology to use"
-    },
     "GenerateApi": {
       "type": "computed",
       "value": "(CalledApiUrl != \"\" && CalledApiScopes != \"\")"

--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
@@ -86,10 +86,16 @@
           "condition": "(IndividualLocalAuth && !UseLocalDB)",
           "rename": {
             "Data/SqlLite/": "Data/Migrations/"
-          },
-          "exclude": [
+           },
+           "exclude": [
             "Data/SqlServer/**"
-          ]
+           ]
+        },
+        {
+            "condition": "(!GenerateApi)",
+            "exclude": [
+                "Services/**"
+            ]
         }
       ]
     }
@@ -207,9 +213,9 @@
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
     "HttpPort": {
-      "type": "parameter",
-      "datatype": "integer",
-      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+        "type": "parameter",
+        "datatype": "integer",
+        "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
     "HttpPortGenerated": {
       "type": "generated",
@@ -306,8 +312,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+            "choice": "netcoreapp5.0",
+            "description": "Target netcoreapp5.0"
+        },
+        {
+            "choice": "netcoreapp3.1",
+            "description": "Target netcoreapp3.1"
         }
       ],
       "replaces": "netcoreapp5.0",
@@ -322,10 +332,50 @@
       }
     },
     "skipRestore": {
+        "type": "parameter",
+        "datatype": "bool",
+        "description": "If specified, skips the automatic restore of the project on create.",
+        "defaultValue": "false"
+    },
+    "CalledApiUrl": {
+        "type": "parameter",
+        "datatype": "string",
+        "replaces": "https://graph.microsoft.com/v1.0",
+        "description": "URL of the API to call from the web app."
+    },
+    "CalledApiScopes": {
+        "type": "parameter",
+        "datatype": "string",
+        "replaces" :  "user.read",
+        "description": "Scopes to request to call the API from the web app."
+    },
+    "TokenCacheSerialization": {
       "type": "parameter",
-      "datatype": "bool",
-      "description": "If specified, skips the automatic restore of the project on create.",
-      "defaultValue": "false"
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "InMemory",
+          "description": "In memory implementation of the token cache serialization."
+        },
+        {
+          "choice": "Session",
+          "description": "Session based implementation of the token cache serialization."
+        },
+        {
+          "choice": "DistributedMemory",
+          "description": "Distributed memory cache implementation."
+        },
+        {
+            "choice": "SQL",
+            "description": "SQL implementation for the token cache serialization."
+        }
+      ],
+      "defaultValue": "InMemory",
+      "description": "The token cache serialization technology to use"
+    },
+    "GenerateApi": {
+      "type": "computed",
+      "value": "(CalledApiUrl != \"\" && CalledApiScopes != \"\")"
     }
   },
   "primaryOutputs": [

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
@@ -12,15 +12,16 @@ using Microsoft.Identity.Web;
 using System.Net;
 using System.Net.Http;
 #endif
-
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Company.WebApplication1.Models;
 
 namespace Company.WebApplication1.Controllers
 {
+#if (GenerateApi)
     using Services;
 
+#endif 
 #if (OrganizationalAuth)
     [Authorize]
 #endif
@@ -42,6 +43,10 @@ namespace Company.WebApplication1.Controllers
         public async Task<IActionResult> Index()
         {
             ViewData["ApiResult"] = await _downstreamWebApi.CallWebApi();
+
+            // You can also specify the relative endpoint and the scopes
+            // ViewData["ApiResult"] = await _downstreamWebApi.CallWebApi("me", new string[] {"user.read"});
+            
             return View();
         }
 #else

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
@@ -6,12 +6,21 @@ using System.Threading.Tasks;
 #if (OrganizationalAuth)
 using Microsoft.AspNetCore.Authorization;
 #endif
+#if (GenerateApi)
+using Microsoft.Extensions.Configuration;
+using Microsoft.Identity.Web;
+using System.Net;
+using System.Net.Http;
+#endif
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Company.WebApplication1.Models;
 
 namespace Company.WebApplication1.Controllers
 {
+    using Services;
+
 #if (OrganizationalAuth)
     [Authorize]
 #endif
@@ -19,6 +28,23 @@ namespace Company.WebApplication1.Controllers
     {
         private readonly ILogger<HomeController> _logger;
 
+#if (GenerateApi)
+        private readonly IDownstreamWebApi _downstreamWebApi;
+
+        public HomeController(ILogger<HomeController> logger,
+                              IDownstreamWebApi downstreamWebApi)
+        {
+             _logger = logger;
+            _downstreamWebApi = downstreamWebApi;
+       }
+
+        [AuthorizeForScopes(ScopeKeySection = "CalledApi:CalledApiScopes")]
+        public async Task<IActionResult> Index()
+        {
+            ViewData["ApiResult"] = await _downstreamWebApi.CallWebApi();
+            return View();
+        }
+#else
         public HomeController(ILogger<HomeController> logger)
         {
             _logger = logger;
@@ -29,6 +55,7 @@ namespace Company.WebApplication1.Controllers
             return View();
         }
 
+#endif
         public IActionResult Privacy()
         {
             return View();

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Services/DownstreamWebApi.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Services/DownstreamWebApi.cs
@@ -1,0 +1,65 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web;
+
+namespace test.Services
+{
+    public interface IDownstreamWebApi
+    {
+        Task<string> CallWebApi();
+    }
+
+    public static class DownstreamWebApiExtensions
+    {
+        public static void AddDownstreamWebApiService(this IServiceCollection services, IConfiguration configuration)
+        {
+            // https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
+            services.AddHttpClient<IDownstreamWebApi, DownstreamWebApi>();
+        }
+    }
+
+    public class DownstreamWebApi : IDownstreamWebApi
+    {
+        private readonly ITokenAcquisition _tokenAcquisition;
+
+        private readonly IConfiguration _configuration;
+
+        private readonly HttpClient _httpClient;
+
+        public DownstreamWebApi(
+            ITokenAcquisition tokenAcquisition,
+            IConfiguration configuration,
+            HttpClient httpClient)
+        {
+            _tokenAcquisition = tokenAcquisition;
+            _configuration = configuration;
+            _httpClient = httpClient;
+        }
+
+
+        public async Task<string> CallWebApi()
+        {
+            string[] scopes = _configuration["CalledApi:CalledApiScopes"]?.Split(' ');
+            string apiUrl = _configuration["CalledApi:CalledApiUrl"];
+
+            string accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync(scopes);
+            _httpClient.DefaultRequestHeaders.Add("Authorization", $"bearer {accessToken}");
+
+            string apiResult;
+            var response = await _httpClient.GetAsync($"{apiUrl}");
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                apiResult = await response.Content.ReadAsStringAsync();
+            }
+            else
+            {
+                apiResult = $"Error calling the API '{apiUrl}'";
+            }
+
+            return apiResult;
+        }
+    }
+}

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Services/DownstreamWebApi.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Services/DownstreamWebApi.cs
@@ -39,11 +39,17 @@ namespace test.Services
             _httpClient = httpClient;
         }
 
-
-        public async Task<string> CallWebApi()
+        /// <summary>
+        /// Calls the Web API with the required scopes
+        /// </summary>
+        /// <param name="requireScopes">[Optional] Scopes required to call the Web API. If
+        /// not specified, uses scopes from the configuration</param>
+        /// <param name="relativeEndpoint">Endpoint relative to the CalledApiUrl configuration</param>
+        /// <returns>A Json string representing the result of calling the Web API</returns>
+        public async Task<string> CallWebApi(string relativeEndpoint = "", string[] requireScopes = null)
         {
-            string[] scopes = _configuration["CalledApi:CalledApiScopes"]?.Split(' ');
-            string apiUrl = _configuration["CalledApi:CalledApiUrl"];
+            string[] scopes = requiredScopes ?? _configuration["CalledApi:CalledApiScopes"]?.Split(' ');
+            string apiUrl = (_configuration["CalledApi:CalledApiUrl"] as string)?.TrimEnd('/') + $"/{relativeEndpoint}";
 
             string accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync(scopes);
             _httpClient.DefaultRequestHeaders.Add("Authorization", $"bearer {accessToken}");

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Startup.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Startup.cs
@@ -44,6 +44,10 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Company.WebApplication1
 {
+#if (GenerateApi)
+    using Services;
+#endif
+
     public class Startup
     {
         public Startup(IConfiguration configuration)
@@ -69,14 +73,22 @@ namespace Company.WebApplication1
                 .AddEntityFrameworkStores<ApplicationDbContext>();
 #elif (OrganizationalAuth)
             services.AddSignIn(Configuration, "AzureAd");
-            // Uncomment the following lines if you want your Web app to call a downstream API
-            // services.AddWebAppCallsProtectedWebApi(Configuration, 
-            //                                        new string[] { "user.read" }, 
-            //                                        "AzureAd")
-            //         .AddInMemoryTokenCaches();
+#if (GenerateApi)
+            services.AddWebAppCallsProtectedWebApi(Configuration, 
+                                                  "AzureAd")
+                    .AddInMemoryTokenCaches();
 
+            services.AddDownstreamWebApiService(Configuration);
+#endif
 #elif (IndividualB2CAuth)
             services.AddSignIn(Configuration, "AzureAdB2C");
+#if (GenerateApi)
+            services.AddWebAppCallsProtectedWebApi(Configuration, 
+                                                  "AzureAdB2C")
+                    .AddInMemoryTokenCaches();
+
+            services.AddDownstreamWebApiService(Configuration);
+#endif
 #endif
 #if (OrganizationalAuth)
 

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Views/Home/Index.cshtml
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Views/Home/Index.cshtml
@@ -6,3 +6,7 @@
     <h1 class="display-4">Welcome</h1>
     <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>
+
+<div>Api result</div>
+
+<div>@ViewData["ApiResult"]</div>

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -36,7 +36,7 @@
 //      Applications are registered in the https://portal.azure.com portal.
 //    */
 //    "CalledApiScopes": "user.read",
-//    "CalledApiUrl": "https://graph.microsoft.com/v1.0/me"
+//    "CalledApiUrl": "https://graph.microsoft.com/v1.0"
 //   },
 ////#endif
 //#endif

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -1,60 +1,60 @@
 {
-    ////#if (IndividualB2CAuth)
-    //  "AzureAdB2C": {
-    //    "Instance": "https:////login.microsoftonline.com/tfp/",
-    //    "ClientId": "11111111-1111-1111-11111111111111111",
-    //    "CallbackPath": "/signin-oidc",
-    //    "Domain": "qualified.domain.name",
-    //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
-    //    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
-    //    "EditProfilePolicyId": "MyEditProfilePolicyId"
-    //  },
-    ////#elseif (OrganizationalAuth)
-    //  "AzureAd": {
-    //#if (MultiOrgAuth)
-    //    "Instance": "https:////login.microsoftonline.com/common",
-    //#elseif (SingleOrgAuth)
-    //    "Instance": "https:////login.microsoftonline.com/",
-    //    "Domain": "qualified.domain.name",
-    //    "TenantId": "22222222-2222-2222-2222-222222222222",
-    //#endif
-    //    "ClientId": "11111111-1111-1111-11111111111111111",
-    ////#if (GenerateApi)
-    //    "ClientSecret": "secret-from-app-registration",
-    //    "ClientCertificates" : [
-    //    ]
-    ////#endif
-    //    "CallbackPath": "/signin-oidc"
-    //  },
-    ////#if (GenerateApi)
-    //    "CalledApi": {
-    //    /*
-    //     'CalledApiScope' is the scope of the Web API you want to call. This can be:
-    //      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
-    //      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
-    //        App ID URI of a legacy v1 Web application
-    //      Applications are registered in the https://portal.azure.com portal.
-    //    */
-    //    "CalledApiScopes": "user.read",
-    //    "CalledApiUrl": "https://graph.microsoft.com/v1.0/me"
-    //   },
-    ////#endif
-    //#endif
-    ////#if (IndividualLocalAuth)
-    //  "ConnectionStrings": {
-    ////#if (UseLocalDB)
-    //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
-    ////#else
-    //    "DefaultConnection": "DataSource=app.db"
-    //#endif
-    //  },
-    //#endif
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
-        }
-    },
-    "AllowedHosts": "*"
+////#if (IndividualB2CAuth)
+//  "AzureAdB2C": {
+//    "Instance": "https:////login.microsoftonline.com/tfp/",
+//    "ClientId": "11111111-1111-1111-11111111111111111",
+//    "CallbackPath": "/signin-oidc",
+//    "Domain": "qualified.domain.name",
+//    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
+//    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
+//    "EditProfilePolicyId": "MyEditProfilePolicyId"
+//  },
+////#elseif (OrganizationalAuth)
+//  "AzureAd": {
+//#if (MultiOrgAuth)
+//    "Instance": "https:////login.microsoftonline.com/common",
+//#elseif (SingleOrgAuth)
+//    "Instance": "https:////login.microsoftonline.com/",
+//    "Domain": "qualified.domain.name",
+//    "TenantId": "22222222-2222-2222-2222-222222222222",
+//#endif
+//    "ClientId": "11111111-1111-1111-11111111111111111",
+////#if (GenerateApi)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ]
+////#endif
+//    "CallbackPath": "/signin-oidc"
+//  },
+////#if (GenerateApi)
+//    "CalledApi": {
+//    /*
+//     'CalledApiScope' is the scope of the Web API you want to call. This can be:
+//      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
+//      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
+//        App ID URI of a legacy v1 Web application
+//      Applications are registered in the https://portal.azure.com portal.
+//    */
+//    "CalledApiScopes": "user.read",
+//    "CalledApiUrl": "https://graph.microsoft.com/v1.0/me"
+//   },
+////#endif
+//#endif
+////#if (IndividualLocalAuth)
+//  "ConnectionStrings": {
+////#if (UseLocalDB)
+//    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
+////#else
+//    "DefaultConnection": "DataSource=app.db"
+//#endif
+//  },
+//#endif
+"Logging": {
+    "LogLevel": {
+        "Default": "Information",
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+    }
+},
+"AllowedHosts": "*"
 }

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -55,6 +55,6 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-},
-"AllowedHosts": "*"
+  },
+  "AllowedHosts": "*"
 }

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -1,42 +1,60 @@
 {
-////#if (IndividualB2CAuth)
-//  "AzureAdB2C": {
-//    "Instance": "https:////login.microsoftonline.com/tfp/",
-//    "ClientId": "11111111-1111-1111-11111111111111111",
-//    "CallbackPath": "/signin-oidc",
-//    "Domain": "qualified.domain.name",
-//    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
-//    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
-//    "EditProfilePolicyId": "MyEditProfilePolicyId"
-//  },
-////#elseif (OrganizationalAuth)
-//  "AzureAd": {
-//#if (MultiOrgAuth)
-//    "Instance": "https:////login.microsoftonline.com/common",
-//#elseif (SingleOrgAuth)
-//    "Instance": "https:////login.microsoftonline.com/",
-//    "Domain": "qualified.domain.name",
-//    "TenantId": "22222222-2222-2222-2222-222222222222",
-//#endif
-//    "ClientId": "11111111-1111-1111-11111111111111111",
-//    "CallbackPath": "/signin-oidc"
-//  },
-//#endif
-////#if (IndividualLocalAuth)
-//  "ConnectionStrings": {
-////#if (UseLocalDB)
-//    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
-////#else
-//    "DefaultConnection": "DataSource=app.db"
-//#endif
-//  },
-//#endif
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  },
-  "AllowedHosts": "*"
+    ////#if (IndividualB2CAuth)
+    //  "AzureAdB2C": {
+    //    "Instance": "https:////login.microsoftonline.com/tfp/",
+    //    "ClientId": "11111111-1111-1111-11111111111111111",
+    //    "CallbackPath": "/signin-oidc",
+    //    "Domain": "qualified.domain.name",
+    //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
+    //    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
+    //    "EditProfilePolicyId": "MyEditProfilePolicyId"
+    //  },
+    ////#elseif (OrganizationalAuth)
+    //  "AzureAd": {
+    //#if (MultiOrgAuth)
+    //    "Instance": "https:////login.microsoftonline.com/common",
+    //#elseif (SingleOrgAuth)
+    //    "Instance": "https:////login.microsoftonline.com/",
+    //    "Domain": "qualified.domain.name",
+    //    "TenantId": "22222222-2222-2222-2222-222222222222",
+    //#endif
+    //    "ClientId": "11111111-1111-1111-11111111111111111",
+    ////#if (GenerateApi)
+    //    "ClientSecret": "secret-from-app-registration",
+    //    "ClientCertificates" : [
+    //    ]
+    ////#endif
+    //    "CallbackPath": "/signin-oidc"
+    //  },
+    ////#if (GenerateApi)
+    //    "CalledApi": {
+    //    /*
+    //     'CalledApiScope' is the scope of the Web API you want to call. This can be:
+    //      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
+    //      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
+    //        App ID URI of a legacy v1 Web application
+    //      Applications are registered in the https://portal.azure.com portal.
+    //    */
+    //    "CalledApiScopes": "user.read",
+    //    "CalledApiUrl": "https://graph.microsoft.com/v1.0/me"
+    //   },
+    ////#endif
+    //#endif
+    ////#if (IndividualLocalAuth)
+    //  "ConnectionStrings": {
+    ////#if (UseLocalDB)
+    //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
+    ////#else
+    //    "DefaultConnection": "DataSource=app.db"
+    //#endif
+    //  },
+    //#endif
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*"
 }

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -49,11 +49,11 @@
 //#endif
 //  },
 //#endif
-"Logging": {
+  "Logging": {
     "LogLevel": {
-        "Default": "Information",
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
 },
 "AllowedHosts": "*"


### PR DESCRIPTION
Adding the capability of calling a Web API to the mvc2 template

To test it:

```sh
msbuild /t:pack
cd bin\Debug
dotnet new -i Microsoft.Identity.Web.ProjectTemplates.0.1.4.nupkg
mkdir test
dotnet new mvc2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta" --called-api-scopes "user.read"
```

to un-install the templates

```
cd bin\Debug
dotnet new -u Microsoft.Identity.Web.ProjectTemplates.0.1.4.nupkg
```