### PR TITLE
fix for honoring valid audiences provided by the developer in JwtBearerOptions

### DIFF
--- a/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Identity.Web
                 // This is a Microsoft identity platform Web API
                 options.Authority = AuthorityHelpers.EnsureAuthorityIsV2(options.Authority);
 
-                if (options.TokenValidationParameters.AudienceValidator == null)
+                if (options.TokenValidationParameters.AudienceValidator == null
+                && options.TokenValidationParameters.ValidAudiences == null)
                 {
                     RegisterValidAudience registerAudience = new RegisterValidAudience();
                     registerAudience.RegisterAudienceValidation(


### PR DESCRIPTION
see [issue](https://github.com/AzureAD/microsoft-identity-web/issues/211)