### PR TITLE
Removing unused references and updating the ClientSemVer to 0.2.0-preview

### DIFF
--- a/ProjectTemplates/AspNetCoreMicrosoftIdentityWebProjectTemplates.csproj
+++ b/ProjectTemplates/AspNetCoreMicrosoftIdentityWebProjectTemplates.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!--This should be passed from the VSTS build-->
+    <ClientSemVer Condition="'$(ClientSemVer)' == ''">0.2.0-localbuild</ClientSemVer>
+    <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
+    <PackageVersion>$(ClientSemVer)</PackageVersion>
+    
     <PackageType>Template</PackageType>
-    <PackageVersion>0.1.5</PackageVersion>
     <PackageId>Microsoft.Identity.Web.ProjectTemplates</PackageId>
     <Title>ASP.NET Core Web app and Web API templates with Microsoft identity platform</Title>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.csproj
+++ b/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <!--This should be passed from the VSTS build-->
-    <ClientSemVer Condition="'$(ClientSemVer)' == ''">0.1.0-localbuild</ClientSemVer>
+    <ClientSemVer Condition="'$(ClientSemVer)' == ''">0.2.0-localbuild</ClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(ClientSemVer)</Version>
 
@@ -54,7 +54,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.0-preview.5.20279.2" />
   </ItemGroup>
 
@@ -63,7 +63,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <!--This should be passed from the VSTS build-->
-    <ClientSemVer Condition="'$(ClientSemVer)' == ''">0.1.0-localbuild</ClientSemVer>
+    <ClientSemVer Condition="'$(ClientSemVer)' == ''">0.2.0-localbuild</ClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(ClientSemVer)</Version>
 
@@ -73,7 +73,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />   
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.1.1" />
@@ -83,7 +83,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.15.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Improving the project files.
- Removing from Microsoft.Identity.Web/MicrosoftIdentity.Web.UI the references to Microsoft.AspNetCore.Authentication.Cookies and Microsoft.Extensions.DependencyInjection which are already transitively added by ASP.NET Core.
- Updating the ClientSemVer to 0.2.0-preview in MIcrosoft.Identity.Web and Microsoft.Identity.Web.UI
- Using the same mechanism in AspNetCoreMicrosoftIdentityWebProjectTemplates.csproj as in Microsoft.Identity.Web.csproj and MicrosoftIdentity.Web.UI.csproj to align the versions;