### PR TITLE
Implemented C# 8 Nullable Reference Type standard.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -467,9 +467,6 @@ dotnet_diagnostic.SA1309.severity = none
 # CA1031: Do not catch general exception types
 dotnet_diagnostic.CA1031.severity = none
 
-# CA1062: Validate arguments of public methods
-dotnet_diagnostic.CA1062.severity = none
-
 # CA1303: Do not pass literals as localized parameters
 dotnet_diagnostic.CA1303.severity = none
 
@@ -527,19 +524,22 @@ dotnet_diagnostic.SA1614.severity = none
 # SA1615: Element return value should be documented
 dotnet_diagnostic.SA1615.severity = none
 
-# SA1616: Element return value documentation should have text
-dotnet_diagnostic.SA1616.severity = none
-
 # SA1623: Property summary documentation should match accessors
 dotnet_diagnostic.SA1623.severity = none
 
 # SA1642: Constructor summary documentation should begin with standard text
 dotnet_diagnostic.SA1642.severity = none
 
-# SA1649: File name should match first type name
+## SA1649: File name should match first type name
 dotnet_diagnostic.SA1649.severity = none
 #########################################################
 #########################################################
+
+# SA1011: Closing square brackets should be spaced correctly
+dotnet_diagnostic.SA1011.severity = none
+
+# SA1009: Closing parenthesis should be spaced correctly
+dotnet_diagnostic.SA1009.severity = none
 
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
     {
         /// <summary>
         /// This API supports infrastructure and is not intended to be used
-        /// directly from your code.This API may change or be removed in future releases.
+        /// directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public string RequestId { get; set; }
+        public string? RequestId { get; set; }
 
         /// <summary>
         /// This API supports infrastructure and is not intended to be used

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/SignedOut.cshtml.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/SignedOut.cshtml.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
         /// <summary>
         /// Method handling the HTTP GET method.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A Sign Out page or Home page.</returns>
         public IActionResult OnGet()
         {
-            if (User.Identity.IsAuthenticated)
+            if (User?.Identity?.IsAuthenticated ?? false)
             {
                 return LocalRedirect("~/");
             }

--- a/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.csproj
+++ b/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.csproj
@@ -42,9 +42,10 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
-     <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>C:\gh\microsoft-identity-web\src\Microsoft.Identity.Web.UI\Microsoft.Identity.Web.UI.xml</DocumentationFile>

--- a/src/Microsoft.Identity.Web/AccountExtensions.cs
+++ b/src/Microsoft.Identity.Web/AccountExtensions.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Security.Claims;
 using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web
 {
     /// <summary>
-    /// Extension methods dealing with IAccount instances.
+    /// Extension methods for <see cref="IAccount"/>.
     /// </summary>
     public static class AccountExtensions
     {
@@ -15,22 +16,31 @@ namespace Microsoft.Identity.Web
         /// Creates the <see cref="ClaimsPrincipal"/> from the values found
         /// in an <see cref="IAccount"/>.
         /// </summary>
-        /// <param name="account">The IAccount instance.</param>
-        /// <returns>A <see cref="ClaimsPrincipal"/> built from IAccount.</returns>
+        /// <param name="account">The <see cref="IAccount"/> instance.</param>
+        /// <returns>A <see cref="ClaimsPrincipal"/> built from <see cref="IAccount"/>.</returns>
         public static ClaimsPrincipal ToClaimsPrincipal(this IAccount account)
         {
-            if (account != null)
+            if (account == null)
             {
-                return new ClaimsPrincipal(
-                    new ClaimsIdentity(new Claim[]
-                    {
-                        new Claim(ClaimConstants.Oid, account.HomeAccountId?.ObjectId),
-                        new Claim(ClaimConstants.Tid, account.HomeAccountId?.TenantId),
-                        new Claim(ClaimTypes.Upn, account.Username),
-                    }));
+                throw new ArgumentNullException(nameof(account));
             }
 
-            return null;
+            ClaimsIdentity identity = new ClaimsIdentity(new Claim[]
+                {
+                    new Claim(ClaimTypes.Upn, account.Username),
+                });
+
+            if (!string.IsNullOrEmpty(account.HomeAccountId?.ObjectId))
+            {
+                identity.AddClaim(new Claim(ClaimConstants.Oid, account.HomeAccountId.ObjectId));
+            }
+
+            if (!string.IsNullOrEmpty(account.HomeAccountId?.TenantId))
+            {
+                identity.AddClaim(new Claim(ClaimConstants.Tid, account.HomeAccountId.TenantId));
+            }
+
+            return new ClaimsPrincipal(identity);
         }
     }
 }

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Identity.Web
     {
         internal static string BuildAuthority(MicrosoftIdentityOptions options)
         {
-            var baseUri = new Uri(options.Instance);
-            var pathBase = baseUri.PathAndQuery.TrimEnd('/');
+            Uri baseUri = new Uri(options.Instance);
+            string pathBase = baseUri.PathAndQuery.TrimEnd('/');
             var domain = options.Domain;
             var tenantId = options.TenantId;
 

--- a/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
+++ b/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
@@ -76,12 +76,12 @@ namespace Microsoft.Identity.Web
             return Task.CompletedTask;
         }
 
-        private string BuildIssuerAddress(RedirectContext context, string defaultUserFlow, string userFlow)
+        private string BuildIssuerAddress(RedirectContext context, string? defaultUserFlow, string userFlow)
         {
             if (!_userFlowToIssuerAddress.TryGetValue(userFlow, out var issuerAddress))
             {
                 _userFlowToIssuerAddress[userFlow] = context.ProtocolMessage.IssuerAddress.ToLowerInvariant()
-                    .Replace($"/{defaultUserFlow.ToLowerInvariant()}/", $"/{userFlow.ToLowerInvariant()}/");
+                    .Replace($"/{defaultUserFlow?.ToLowerInvariant()}/", $"/{userFlow.ToLowerInvariant()}/");
             }
 
             return _userFlowToIssuerAddress[userFlow];

--- a/src/Microsoft.Identity.Web/Base64UrlHelpers.cs
+++ b/src/Microsoft.Identity.Web/Base64UrlHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
@@ -23,7 +24,7 @@ namespace Microsoft.Identity.Web
         // * the 62nd and 63rd regular base64 encoding characters ('+' and '/') are replace with ('-' and '_')
         // The changes make the encoding alphabet file and URL safe
         // See RFC4648, section 5 for more info
-        public static string Encode(string arg)
+        public static string? Encode(string arg)
         {
             if (arg == null)
             {
@@ -68,7 +69,7 @@ namespace Microsoft.Identity.Web
             return Convert.FromBase64String(s); // Standard base64 decoder
         }
 
-        internal static string Encode(byte[] arg)
+        internal static string? Encode(byte[] arg)
         {
             if (arg == null)
             {

--- a/src/Microsoft.Identity.Web/CertificateManagement/CertificateDescription.cs
+++ b/src/Microsoft.Identity.Web/CertificateManagement/CertificateDescription.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Web
         /// <param name="path">Path were to find the certificate file.</param>
         /// <param name="password">Certificate password.</param>
         /// <returns>A certificate description.</returns>
-        public static CertificateDescription FromPath(string path, string password = null)
+        public static CertificateDescription FromPath(string path, string? password = null)
         {
             return new CertificateDescription
             {
@@ -131,7 +131,7 @@ namespace Microsoft.Identity.Web
         /// this value is the path to the certificate in the cert store, for instance <c>CurrentUser/My</c>.</item>
         /// </list>
         /// </summary>
-        internal string Container
+        internal string? Container
         {
             get
             {
@@ -179,43 +179,43 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// URL of the Key Vault for instance https://msidentitywebsamples.vault.azure.net.
         /// </summary>
-        public string KeyVaultUrl { get; set; }
+        public string? KeyVaultUrl { get; set; }
 
         /// <summary>
         /// Certificate store path, for instance "CurrentUser/My".
         /// </summary>
         /// <remarks>This property should only be used in conjunction with DistinguishName or Thumbprint.</remarks>
-        public string CertificateStorePath { get; set; }
+        public string? CertificateStorePath { get; set; }
 
         /// <summary>
         /// Certificate distinguished name.
         /// </summary>
-        public string CertificateDistinguishedName { get; set; }
+        public string? CertificateDistinguishedName { get; set; }
 
         /// <summary>
         /// Name of the certificate in Key Vault.
         /// </summary>
-        public string KeyVaultCertificateName { get; set; }
+        public string? KeyVaultCertificateName { get; set; }
 
         /// <summary>
         /// Certificate thumbprint.
         /// </summary>
-        public string CertificateThumbprint { get; set; }
+        public string? CertificateThumbprint { get; set; }
 
         /// <summary>
         /// Path on disk to the certificate.
         /// </summary>
-        public string CertificateDiskPath { get; set; }
+        public string? CertificateDiskPath { get; set; }
 
         /// <summary>
         /// Path on disk to the certificate password.
         /// </summary>
-        public string CertificatePassword { get; set; }
+        public string? CertificatePassword { get; set; }
 
         /// <summary>
         /// Base64 encoded certificate value.
         /// </summary>
-        public string Base64EncodedValue { get; set; }
+        public string? Base64EncodedValue { get; set; }
 
         /// <summary>
         /// Reference to the certificate or value.
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Web
         /// <item>If <see cref="SourceType"/> equals <see cref="CertificateSource.StoreWithThumbprint"/>,
         /// this value is the thumbprint.</item>
         /// </list>
-        internal string ReferenceOrValue
+        internal string? ReferenceOrValue
         {
             get
             {
@@ -284,6 +284,6 @@ namespace Microsoft.Identity.Web
         /// The certificate, either provided directly in code
         /// or loaded from the description.
         /// </summary>
-        public X509Certificate2 Certificate { get; internal set; }
+        public X509Certificate2? Certificate { get; internal set; }
     }
 }

--- a/src/Microsoft.Identity.Web/CertificateManagement/DefaultCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web/CertificateManagement/DefaultCertificateLoader.cs
@@ -27,19 +27,19 @@ namespace Microsoft.Identity.Web
                 switch (certificateDescription.SourceType)
                 {
                     case CertificateSource.KeyVault:
-                        certificateDescription.Certificate = LoadFromKeyVault(certificateDescription.Container, certificateDescription.ReferenceOrValue);
+                        certificateDescription.Certificate = LoadFromKeyVault(certificateDescription.Container!, certificateDescription.ReferenceOrValue!);
                         break;
                     case CertificateSource.Base64Encoded:
-                        certificateDescription.Certificate = LoadFromBase64Encoded(certificateDescription.ReferenceOrValue);
+                        certificateDescription.Certificate = LoadFromBase64Encoded(certificateDescription.ReferenceOrValue!);
                         break;
                     case CertificateSource.Path:
-                        certificateDescription.Certificate = LoadFromPath(certificateDescription.Container, certificateDescription.ReferenceOrValue);
+                        certificateDescription.Certificate = LoadFromPath(certificateDescription.Container!, certificateDescription.ReferenceOrValue!);
                         break;
                     case CertificateSource.StoreWithThumbprint:
-                        certificateDescription.Certificate = LoadFromStoreWithThumbprint(certificateDescription.ReferenceOrValue, certificateDescription.Container);
+                        certificateDescription.Certificate = LoadFromStoreWithThumbprint(certificateDescription.ReferenceOrValue!, certificateDescription.Container!);
                         break;
                     case CertificateSource.StoreWithDistinguishedName:
-                        certificateDescription.Certificate = LoadFromStoreWithDistinguishedName(certificateDescription.ReferenceOrValue, certificateDescription.Container);
+                        certificateDescription.Certificate = LoadFromStoreWithDistinguishedName(certificateDescription.ReferenceOrValue!, certificateDescription.Container!);
                         break;
                     default:
                         break;
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Web
             byte[] decoded = Convert.FromBase64String(certificateBase64);
             return new X509Certificate2(
                 decoded,
-                (string)null,
+                (string?)null,
                 X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet);
         }
 
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Web
             {
                 return new X509Certificate2(
                     certificate.Cer,
-                    (string)null,
+                    (string?)null,
                     X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet);
             }
 
@@ -106,7 +106,7 @@ namespace Microsoft.Identity.Web
             throw new NotSupportedException($"Only PKCS#12 is supported. Found Content-Type: {secret.Properties.ContentType}");
         }
 
-        private static X509Certificate2 LoadFromStoreWithThumbprint(
+        private static X509Certificate2? LoadFromStoreWithThumbprint(
             string certificateThumbprint,
             string storeDescription = "CurrentUser/My")
         {
@@ -114,7 +114,7 @@ namespace Microsoft.Identity.Web
             StoreName certificateStoreName = StoreName.My;
             ParseStoreLocationAndName(storeDescription, ref certificateStoreLocation, ref certificateStoreName);
 
-            X509Certificate2 cert;
+            X509Certificate2? cert;
             using (X509Store x509Store = new X509Store(
                 certificateStoreName,
                 certificateStoreLocation))
@@ -128,13 +128,13 @@ namespace Microsoft.Identity.Web
             return cert;
         }
 
-        private static X509Certificate2 LoadFromStoreWithDistinguishedName(string certificateSubjectDistinguishedName, string storeDescription = "CurrentUser/My")
+        private static X509Certificate2? LoadFromStoreWithDistinguishedName(string certificateSubjectDistinguishedName, string storeDescription = "CurrentUser/My")
         {
             StoreLocation certificateStoreLocation = StoreLocation.CurrentUser;
             StoreName certificateStoreName = StoreName.My;
             ParseStoreLocationAndName(storeDescription, ref certificateStoreLocation, ref certificateStoreName);
 
-            X509Certificate2 cert;
+            X509Certificate2? cert;
             using (X509Store x509Store = new X509Store(
                  certificateStoreName,
                  certificateStoreLocation))
@@ -150,7 +150,7 @@ namespace Microsoft.Identity.Web
 
         private static X509Certificate2 LoadFromPath(
             string certificateFileName,
-            string password = null)
+            string? password = null)
         {
             return new X509Certificate2(
                 certificateFileName,
@@ -174,11 +174,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Find a certificate by criteria.
         /// </summary>
-        /// <param name="x509Store"></param>
-        /// <param name="identifierCriterium"></param>
-        /// <param name="certificateIdentifier"></param>
-        /// <returns></returns>
-        private static X509Certificate2 FindCertificateByCriterium(
+        private static X509Certificate2? FindCertificateByCriterium(
             X509Store x509Store,
             X509FindType identifierCriterium,
             string certificateIdentifier)
@@ -198,12 +194,12 @@ namespace Microsoft.Identity.Web
             return cert;
         }
 
-        internal /*for test only*/ static X509Certificate2 LoadFirstCertificate(IEnumerable<CertificateDescription> certificateDescription)
+        internal /*for test only*/ static X509Certificate2? LoadFirstCertificate(IEnumerable<CertificateDescription> certificateDescription)
         {
             DefaultCertificateLoader defaultCertificateLoader = new DefaultCertificateLoader();
             CertificateDescription certDescription = certificateDescription.First();
             defaultCertificateLoader.LoadIfNeeded(certDescription);
-            return certDescription?.Certificate;
+            return certDescription.Certificate;
         }
     }
 }

--- a/src/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
+++ b/src/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
@@ -7,24 +7,24 @@ using System.Security.Claims;
 namespace Microsoft.Identity.Web
 {
     /// <summary>
-    /// Extensions around ClaimsPrincipal.
+    /// Extensions for <see cref="ClaimsPrincipal"/>.
     /// </summary>
     public static class ClaimsPrincipalExtensions
     {
         /// <summary>
-        /// Gets the Account identifier for an MSAL.NET account from a <see cref="ClaimsPrincipal"/>.
+        /// Gets the account identifier for an MSAL.NET account from a <see cref="ClaimsPrincipal"/>.
         /// </summary>
         /// <param name="claimsPrincipal">Claims principal.</param>
         /// <returns>A string corresponding to an account identifier as defined in <see cref="Microsoft.Identity.Client.AccountId.Identifier"/>.</returns>
-        public static string GetMsalAccountId(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetMsalAccountId(this ClaimsPrincipal claimsPrincipal)
         {
             if (claimsPrincipal == null)
             {
                 throw new ArgumentNullException(nameof(claimsPrincipal));
             }
 
-            string uniqueObjectIdentifier = claimsPrincipal.GetHomeObjectId();
-            string uniqueTenantIdentifier = claimsPrincipal.GetHomeTenantId();
+            string? uniqueObjectIdentifier = claimsPrincipal.GetHomeObjectId();
+            string? uniqueTenantIdentifier = claimsPrincipal.GetHomeTenantId();
 
             if (!string.IsNullOrWhiteSpace(uniqueObjectIdentifier) && !string.IsNullOrWhiteSpace(uniqueTenantIdentifier))
             {
@@ -39,12 +39,17 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Gets the unique object ID associated with the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the unique object ID.</param>
+        /// <param name="claimsPrincipal">The <see cref="ClaimsPrincipal"/> from which to retrieve the unique object ID.</param>
         /// <remarks>This method returns the object ID both in case the developer has enabled or not claims mapping.</remarks>
         /// <returns>Unique object ID of the identity, or <c>null</c> if it cannot be found.</returns>
-        public static string GetObjectId(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetObjectId(this ClaimsPrincipal claimsPrincipal)
         {
-            string userObjectId = claimsPrincipal.FindFirstValue(ClaimConstants.Oid);
+            if (claimsPrincipal == null)
+            {
+                throw new ArgumentNullException(nameof(claimsPrincipal));
+            }
+
+            string? userObjectId = claimsPrincipal.FindFirstValue(ClaimConstants.Oid);
             if (string.IsNullOrEmpty(userObjectId))
             {
                 userObjectId = claimsPrincipal.FindFirstValue(ClaimConstants.ObjectId);
@@ -56,12 +61,17 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Gets the Tenant ID associated with the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the tenant ID.</param>
+        /// <param name="claimsPrincipal">The <see cref="ClaimsPrincipal"/> from which to retrieve the tenant ID.</param>
         /// <returns>Tenant ID of the identity, or <c>null</c> if it cannot be found.</returns>
         /// <remarks>This method returns the tenant ID both in case the developer has enabled or not claims mapping.</remarks>
-        public static string GetTenantId(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetTenantId(this ClaimsPrincipal claimsPrincipal)
         {
-            string tenantId = claimsPrincipal.FindFirstValue(ClaimConstants.Tid);
+            if (claimsPrincipal == null)
+            {
+                throw new ArgumentNullException(nameof(claimsPrincipal));
+            }
+
+            string? tenantId = claimsPrincipal.FindFirstValue(ClaimConstants.Tid);
             if (string.IsNullOrEmpty(tenantId))
             {
                 return claimsPrincipal.FindFirstValue(ClaimConstants.TenantId);
@@ -74,8 +84,8 @@ namespace Microsoft.Identity.Web
         /// Gets the login-hint associated with a <see cref="ClaimsPrincipal"/>.
         /// </summary>
         /// <param name="claimsPrincipal">Identity for which to complete the login-hint.</param>
-        /// <returns>login-hint for the identity, or <c>null</c> if it cannot be found.</returns>
-        public static string GetLoginHint(this ClaimsPrincipal claimsPrincipal)
+        /// <returns>The login hint for the identity, or <c>null</c> if it cannot be found.</returns>
+        public static string? GetLoginHint(this ClaimsPrincipal claimsPrincipal)
         {
             return GetDisplayName(claimsPrincipal);
         }
@@ -84,14 +94,19 @@ namespace Microsoft.Identity.Web
         /// Gets the domain-hint associated with an identity.
         /// </summary>
         /// <param name="claimsPrincipal">Identity for which to compute the domain-hint.</param>
-        /// <returns>domain-hint for the identity, or <c>null</c> if it cannot be found.</returns>
-        public static string GetDomainHint(this ClaimsPrincipal claimsPrincipal)
+        /// <returns> The domain hint for the identity, or <c>null</c> if it cannot be found.</returns>
+        public static string? GetDomainHint(this ClaimsPrincipal claimsPrincipal)
         {
+            if (claimsPrincipal == null)
+            {
+                throw new ArgumentNullException(nameof(claimsPrincipal));
+            }
+
             // Tenant for MSA accounts
             const string msaTenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
 
             var tenantId = GetTenantId(claimsPrincipal);
-            string domainHint = string.IsNullOrWhiteSpace(tenantId)
+            string? domainHint = string.IsNullOrWhiteSpace(tenantId)
                 ? null
                 : tenantId.Equals(msaTenantId, StringComparison.OrdinalIgnoreCase) ? "consumers" : "organizations";
 
@@ -105,10 +120,15 @@ namespace Microsoft.Identity.Web
         /// <returns>A string containing the display name for the user, as determined by Azure AD (v1.0) and Microsoft identity platform (v2.0) tokens,
         /// or <c>null</c> if the claims cannot be found.</returns>
         /// <remarks>See https://docs.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims. </remarks>
-        public static string GetDisplayName(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetDisplayName(this ClaimsPrincipal claimsPrincipal)
         {
+            if (claimsPrincipal == null)
+            {
+                throw new ArgumentNullException(nameof(claimsPrincipal));
+            }
+
             // Use the claims in a Microsoft identity platform token first
-            string displayName = claimsPrincipal.FindFirstValue(ClaimConstants.PreferredUserName);
+            string? displayName = claimsPrincipal.FindFirstValue(ClaimConstants.PreferredUserName);
 
             if (!string.IsNullOrWhiteSpace(displayName))
             {
@@ -128,13 +148,18 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Gets the user flow id associated with the <see cref="ClaimsPrincipal"/>.
+        /// Gets the user flow ID associated with the <see cref="ClaimsPrincipal"/>.
         /// </summary>
-        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the user flow id.</param>
-        /// <returns>User Flow Id of the identity, or <c>null</c> if it cannot be found.</returns>
-        public static string GetUserFlowId(this ClaimsPrincipal claimsPrincipal)
+        /// <param name="claimsPrincipal">The <see cref="ClaimsPrincipal"/> from which to retrieve the user flow ID.</param>
+        /// <returns>User Flow ID of the identity, or <c>null</c> if it cannot be found.</returns>
+        public static string? GetUserFlowId(this ClaimsPrincipal claimsPrincipal)
         {
-            string userFlowId = claimsPrincipal.FindFirstValue(ClaimConstants.Tfp);
+            if (claimsPrincipal == null)
+            {
+                throw new ArgumentNullException(nameof(claimsPrincipal));
+            }
+
+            string? userFlowId = claimsPrincipal.FindFirstValue(ClaimConstants.Tfp);
             if (string.IsNullOrEmpty(userFlowId))
             {
                 return claimsPrincipal.FindFirstValue(ClaimConstants.UserFlow);
@@ -148,7 +173,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="claimsPrincipal">The <see cref="ClaimsPrincipal"/> from which to retrieve the sub claim.</param>
         /// <returns>Home Object ID (sub) of the identity, or <c>null</c> if it cannot be found.</returns>
-        public static string GetHomeObjectId(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetHomeObjectId(this ClaimsPrincipal claimsPrincipal)
         {
             if (claimsPrincipal == null)
             {
@@ -163,7 +188,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="claimsPrincipal">The <see cref="ClaimsPrincipal"/> from which to retrieve the sub claim.</param>
         /// <returns>Home Tenant ID (sub) of the identity, or <c>null</c> if it cannot be found.</returns>
-        public static string GetHomeTenantId(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetHomeTenantId(this ClaimsPrincipal claimsPrincipal)
         {
             if (claimsPrincipal == null)
             {
@@ -178,8 +203,13 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="claimsPrincipal">The <see cref="ClaimsPrincipal"/> from which to retrieve the <c>uid</c> claim.</param>
         /// <returns>Name identifier ID (uid) of the identity, or <c>null</c> if it cannot be found.</returns>
-        public static string GetNameIdentifierId(this ClaimsPrincipal claimsPrincipal)
+        public static string? GetNameIdentifierId(this ClaimsPrincipal claimsPrincipal)
         {
+            if (claimsPrincipal == null)
+            {
+                throw new ArgumentNullException(nameof(claimsPrincipal));
+            }
+
             return claimsPrincipal.FindFirstValue(ClaimConstants.UniqueObjectIdentifier);
         }
     }

--- a/src/Microsoft.Identity.Web/ClaimsPrincipalFactory.cs
+++ b/src/Microsoft.Identity.Web/ClaimsPrincipalFactory.cs
@@ -6,19 +6,19 @@ using System.Security.Claims;
 namespace Microsoft.Identity.Web
 {
     /// <summary>
-    /// Factory class to create ClaimsPrincipal objects.
+    /// Factory class to create <see cref="ClaimsPrincipal"/> objects.
     /// </summary>
     public static class ClaimsPrincipalFactory
     {
         /// <summary>
-        /// Instantiate a ClaimsPrincipal from an account objectId and tenantId. This can
-        /// be useful when the Web app subscribes to another service on behalf of the user
-        /// and then is called back by a notification where the user is identified by his tenant
-        /// id and object id (like in Microsoft Graph Web Hooks).
+        /// Instantiate a <see cref="ClaimsPrincipal"/> from an account object ID and tenant ID. This can
+        /// be useful when the web app subscribes to another service on behalf of the user
+        /// and then is called back by a notification where the user is identified by their tenant
+        /// ID and object ID (like in Microsoft Graph Web Hooks).
         /// </summary>
-        /// <param name="tenantId">Tenant Id of the account.</param>
-        /// <param name="objectId">Object Id of the account in this tenant ID.</param>
-        /// <returns>A ClaimsPrincipal containing these two claims.</returns>
+        /// <param name="tenantId">Tenant ID of the account.</param>
+        /// <param name="objectId">Object ID of the account in this tenant ID.</param>
+        /// <returns>A <see cref="ClaimsPrincipal"/> containing these two claims.</returns>
         ///
         /// <example>
         /// <code>

--- a/src/Microsoft.Identity.Web/ClientInfo.cs
+++ b/src/Microsoft.Identity.Web/ClientInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -11,12 +10,12 @@ namespace Microsoft.Identity.Web
     internal class ClientInfo
     {
         [JsonPropertyName("uid")]
-        public string UniqueObjectIdentifier { get; set; }
+        public string UniqueObjectIdentifier { get; set; } = null!;
 
         [JsonPropertyName("utid")]
-        public string UniqueTenantIdentifier { get; set; }
+        public string UniqueTenantIdentifier { get; set; } = null!;
 
-        public static ClientInfo CreateFromJson(string clientInfo)
+        public static ClientInfo? CreateFromJson(string clientInfo)
         {
             if (string.IsNullOrEmpty(clientInfo))
             {
@@ -26,7 +25,7 @@ namespace Microsoft.Identity.Web
             return DeserializeFromJson(Base64UrlHelpers.DecodeToBytes(clientInfo));
         }
 
-        internal static ClientInfo DeserializeFromJson(byte[] jsonByteArray)
+        internal static ClientInfo? DeserializeFromJson(byte[] jsonByteArray)
         {
             if (jsonByteArray == null || jsonByteArray.Length == 0)
             {

--- a/src/Microsoft.Identity.Web/CookiePolicyOptionsExtensions.cs
+++ b/src/Microsoft.Identity.Web/CookiePolicyOptionsExtensions.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Identity.Web
         /// Handles SameSite cookie issue according to the https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1.
         /// The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
         /// </summary>
-        /// <param name="options"></param>
-        /// <returns></returns>
+        /// <param name="options"><see cref="CookiePolicyOptions"/>to update.</param>
+        /// <returns><see cref="CookiePolicyOptions"/> to chain.</returns>
         public static CookiePolicyOptions HandleSameSiteCookieCompatibility(this CookiePolicyOptions options)
         {
             return HandleSameSiteCookieCompatibility(options, DisallowsSameSiteNone);
@@ -27,16 +27,22 @@ namespace Microsoft.Identity.Web
         /// Handles SameSite cookie issue according to the docs: https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
         /// The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="disallowsSameSiteNone">If you dont want to use the default user-agent list implementation, the method sent in this parameter will be run against the user-agent and if returned true, SameSite value will be set to Unspecified. The default user-agent list used can be found at: https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.</param>
-        /// <returns></returns>
+        /// <param name="options"><see cref="CookiePolicyOptions"/>to update.</param>
+        /// <param name="disallowsSameSiteNone">If you don't want to use the default user-agent list implementation, the method sent in this parameter will be run against the user-agent and if returned true, SameSite value will be set to Unspecified. The default user-agent list used can be found at: https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/. </param>
+        /// <returns><see cref="CookiePolicyOptions"/> to chain.</returns>
         public static CookiePolicyOptions HandleSameSiteCookieCompatibility(this CookiePolicyOptions options, Func<string, bool> disallowsSameSiteNone)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
             options.OnAppendCookie = cookieContext =>
                 CheckSameSite(cookieContext.Context, cookieContext.CookieOptions, disallowsSameSiteNone);
             options.OnDeleteCookie = cookieContext =>
                 CheckSameSite(cookieContext.Context, cookieContext.CookieOptions, disallowsSameSiteNone);
+
             return options;
         }
 
@@ -53,44 +59,47 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        ///
+        /// Checks if the specified user agent supports SameSite None cookies.
         /// </summary>
-        /// <param name="userAgent"></param>
+        /// <param name="userAgent">Browser user agent.</param>
         /// <remarks>Method taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.</remarks>
-        /// <returns></returns>
+        /// <returns>True, if the user agent does not allow SameSite None cookie; otherwise, false.</returns>
         public static bool DisallowsSameSiteNone(string userAgent)
         {
-            // Cover all iOS based browsers here. This includes:
-            // - Safari on iOS 12 for iPhone, iPod Touch, iPad
-            // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
-            // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
-            // All of which are broken by SameSite=None, because they use the iOS networking
-            // stack.
-            if (userAgent.Contains("CPU iPhone OS 12") ||
-                userAgent.Contains("iPad; CPU OS 12"))
+            if (!string.IsNullOrEmpty(userAgent))
             {
-                return true;
-            }
+                // Cover all iOS based browsers here. This includes:
+                // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+                // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+                // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+                // All of which are broken by SameSite=None, because they use the iOS networking
+                // stack.
+                if (userAgent.Contains("CPU iPhone OS 12") ||
+                    userAgent.Contains("iPad; CPU OS 12"))
+                {
+                    return true;
+                }
 
-            // Cover Mac OS X based browsers that use the Mac OS networking stack.
-            // This includes:
-            // - Safari on Mac OS X.
-            // This does not include:
-            // - Chrome on Mac OS X
-            // Because they do not use the Mac OS networking stack.
-            if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
-                userAgent.Contains("Version/") && userAgent.Contains("Safari"))
-            {
-                return true;
-            }
+                // Cover Mac OS X based browsers that use the Mac OS networking stack.
+                // This includes:
+                // - Safari on Mac OS X.
+                // This does not include:
+                // - Chrome on Mac OS X
+                // Because they do not use the Mac OS networking stack.
+                if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+                    userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+                {
+                    return true;
+                }
 
-            // Cover Chrome 50-69, because some versions are broken by SameSite=None,
-            // and none in this range require it.
-            // Note: this covers some pre-Chromium Edge versions,
-            // but pre-Chromium Edge does not require SameSite=None.
-            if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
-            {
-                return true;
+                // Cover Chrome 50-69, because some versions are broken by SameSite=None,
+                // and none in this range require it.
+                // Note: this covers some pre-Chromium Edge versions,
+                // but pre-Chromium Edge does not require SameSite=None.
+                if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/src/Microsoft.Identity.Web/HttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/HttpContextExtensions.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Identity.Web
     internal static class HttpContextExtensions
     {
         /// <summary>
-        /// Keep the validated token associated with the Http request.
+        /// Keep the validated token associated with the HTTP request.
         /// </summary>
-        /// <param name="httpContext">Http context.</param>
+        /// <param name="httpContext">HTTP context.</param>
         /// <param name="token">Token to preserve after the token is validated so that
         /// it can be used in the actions.</param>
-        internal static void StoreTokenUsedToCallWebAPI(this HttpContext httpContext, JwtSecurityToken token)
+        internal static void StoreTokenUsedToCallWebAPI(this HttpContext httpContext, JwtSecurityToken? token)
         {
             httpContext.Items.Add("JwtSecurityTokenUsedToCallWebAPI", token);
         }
@@ -22,9 +22,9 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Get the parsed information about the token used to call the Web API.
         /// </summary>
-        /// <param name="httpContext">Http context associated with the current request.</param>
-        /// <returns><see cref="JwtSecurityToken"/> used to call the Web API.</returns>
-        internal static JwtSecurityToken GetTokenUsedToCallWebAPI(this HttpContext httpContext)
+        /// <param name="httpContext">HTTP context associated with the current request.</param>
+        /// <returns><see cref="JwtSecurityToken"/> used to call the web API.</returns>
+        internal static JwtSecurityToken? GetTokenUsedToCallWebAPI(this HttpContext httpContext)
         {
             return httpContext.Items["JwtSecurityTokenUsedToCallWebAPI"] as JwtSecurityToken;
         }

--- a/src/Microsoft.Identity.Web/ITokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/ITokenAcquisition.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Identity.Web
         /// <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the
         /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant.</param>
         /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes.</returns>
-        Task<string> GetAccessTokenForUserAsync(IEnumerable<string> scopes, string tenantId = null);
+        Task<string> GetAccessTokenForUserAsync(IEnumerable<string> scopes, string? tenantId = null);
 
         /// <summary>
         /// Acquires a token from the authority configured in the app, for the confidential client itself (not on behalf of a user)
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="scopes">Scopes to consent to.</param>
         /// <param name="msalSeviceException"><see cref="MsalUiRequiredException"/> triggering the challenge.</param>
-        void ReplyForbiddenWithWwwAuthenticateHeader(
+        Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(
             IEnumerable<string> scopes,
             MsalUiRequiredException msalSeviceException);
     }

--- a/src/Microsoft.Identity.Web/ITokenAcquisitionInternal.cs
+++ b/src/Microsoft.Identity.Web/ITokenAcquisitionInternal.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
         /// <param name="scopes">Scopes to request.</param>
+        /// <returns>A <see cref="Task"/> that represents a completed add to cache operation.</returns>
         /// <example>
         /// From the configuration of the Authentication of the ASP.NET Core Web API:
         /// <code>OpenIdConnectOptions options;</code>
@@ -47,7 +48,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="context">RedirectContext passed-in to a <see cref="OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/>
         /// OpenID Connect event.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task"/> that represents a completed remove from cache operation.</returns>
         Task RemoveAccountAsync(RedirectContext context);
     }
 }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerConfigurationRetriever.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerConfigurationRetriever.cs
@@ -10,7 +10,7 @@ using Microsoft.IdentityModel.Protocols;
 namespace Microsoft.Identity.Web.InstanceDiscovery
 {
     /// <summary>
-    /// An implementation of IConfigurationRetriever geared towards Azure AD issuers metadata />.
+    /// An implementation of IConfigurationRetriever geared towards Azure AD issuers metadata.
     /// </summary>
     internal class IssuerConfigurationRetriever : IConfigurationRetriever<IssuerMetadata>
     {
@@ -18,15 +18,17 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         /// <param name="address">Address of the discovery document.</param>
         /// <param name="retriever">The <see cref="T:Microsoft.IdentityModel.Protocols.IDocumentRetriever"/> to use to read the discovery document.</param>
         /// <param name="cancel">A cancellation token that can be used by other objects or threads to receive notice of cancellation. <see cref="T:System.Threading.CancellationToken"/>.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException">address - Azure AD Issuer metadata address url is required
+        /// <returns>
+        /// A <see cref="Task{IssuerMetadata}"/> that, when completed, returns <see cref="IssuerMetadata"/> from the configuration.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">address - Azure AD Issuer metadata address URL is required
         /// or
         /// retriever - No metadata document retriever is provided.</exception>
         public async Task<IssuerMetadata> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancel)
         {
             if (string.IsNullOrEmpty(address))
             {
-                throw new ArgumentNullException(nameof(address), $"Azure AD Issuer metadata address url is required");
+                throw new ArgumentNullException(nameof(address), $"Azure AD Issuer metadata address URL is required");
             }
 
             if (retriever == null)
@@ -40,7 +42,7 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
             };
 
             string doc = await retriever.GetDocumentAsync(address, cancel).ConfigureAwait(false);
-            return JsonSerializer.Deserialize<IssuerMetadata>(doc, options);
+            return JsonSerializer.Deserialize<IssuerMetadata>(doc, options)!; // Note: The analyzer says Deserialize can return null, but the method comment says it just throws exceptions.
         }
     }
 }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerMetadata.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerMetadata.cs
@@ -15,18 +15,18 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         /// Tenant discovery endpoint.
         /// </summary>
         [JsonPropertyName("tenant_discovery_endpoint")]
-        public string TenantDiscoveryEndpoint { get; set; }
+        public string? TenantDiscoveryEndpoint { get; set; }
 
         /// <summary>
         /// API Version.
         /// </summary>
         [JsonPropertyName("api-version")]
-        public string ApiVersion { get; set; }
+        public string? ApiVersion { get; set; }
 
         /// <summary>
         /// List of metadata associated with the endpoint.
         /// </summary>
         [JsonPropertyName("metadata")]
-        public List<Metadata> Metadata { get; set; }
+        public List<Metadata> Metadata { get; set; } = new List<Metadata>();
     }
 }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/Metadata.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/Metadata.cs
@@ -15,19 +15,19 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         /// Preferred alias.
         /// </summary>
         [JsonPropertyName("preferred_network")]
-        public string PreferredNetwork { get; set; }
+        public string? PreferredNetwork { get; set; }
 
         /// <summary>
         /// Preferred alias to cache tokens emitted by one of the aliases (to avoid
         /// SSO islands).
         /// </summary>
         [JsonPropertyName("preferred_cache")]
-        public string PreferredCache { get; set; }
+        public string? PreferredCache { get; set; }
 
         /// <summary>
         /// Aliases of issuer URLs which are equivalent.
         /// </summary>
         [JsonPropertyName("aliases")]
-        public List<string> Aliases { get; set; }
+        public List<string> Aliases { get; set; } = new List<string>();
     }
 }

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -47,12 +47,13 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-  
+
   <PropertyGroup>
-     <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -75,7 +76,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />   
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.1.1" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.0.2" />
@@ -89,5 +90,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
 </Project>

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -16,17 +16,17 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Gets or sets the Azure Active Directory instance, e.g. "https://login.microsoftonline.com".
         /// </summary>
-        public string Instance { get; set; }
+        public string Instance { get; set; } = null!;
 
         /// <summary>
-        /// Gets or sets the tenant Id.
+        /// Gets or sets the tenant ID.
         /// </summary>
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
 
         /// <summary>
         /// Gets or sets the domain of the Azure Active Directory tenant, e.g. contoso.onmicrosoft.com.
         /// </summary>
-        public string Domain { get; set; }
+        public string? Domain { get; set; }
 
         /// <summary>
         /// Gets or sets TokenAcquisition as a Singleton. There are scenarios, like using the Graph SDK,
@@ -37,22 +37,22 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Gets or sets the edit profile user flow name for B2C, e.g. b2c_1_edit_profile.
         /// </summary>
-        public string EditProfilePolicyId { get; set; }
+        public string? EditProfilePolicyId { get; set; }
 
         /// <summary>
         /// Gets or sets the sign up or sign in user flow name for B2C, e.g. b2c_1_susi.
         /// </summary>
-        public string SignUpSignInPolicyId { get; set; }
+        public string? SignUpSignInPolicyId { get; set; }
 
         /// <summary>
         /// Gets or sets the reset password user flow name for B2C, e.g. B2C_1_password_reset.
         /// </summary>
-        public string ResetPasswordPolicyId { get; set; }
+        public string? ResetPasswordPolicyId { get; set; }
 
         /// <summary>
         /// Gets the default user flow (which is signUpsignIn).
         /// </summary>
-        public string DefaultUserFlow => SignUpSignInPolicyId;
+        public string? DefaultUserFlow => SignUpSignInPolicyId;
 
         /// <summary>
         /// Is considered B2C if the attribute SignUpSignInPolicyId is defined.
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Web
         ///   </code>
         ///   See also https://aka.ms/ms-id-web-certificates.
         ///   </example>
-        public IEnumerable<CertificateDescription> ClientCertificates { get; set; }
+        public IEnumerable<CertificateDescription>? ClientCertificates { get; set; }
 
         /// <summary>
         /// Description of the certificates used to decrypt an encrypted token in a Web API.
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Web
         ///   </code>
         ///   See also https://aka.ms/ms-id-web-certificates.
         ///   </example>
-        public IEnumerable<CertificateDescription> TokenDecryptionCertificates { get; set; }
+        public IEnumerable<CertificateDescription>? TokenDecryptionCertificates { get; set; }
 
         /// <summary>
         /// Specifies if the x5c claim (public key of the certificate) should be sent to the STS.

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptionsValidation.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptionsValidation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.Extensions.Options;
@@ -42,8 +41,8 @@ namespace Microsoft.Identity.Web
         }
 
         public static void ValidateEitherClientCertificateOrClientSecret(
-            string clientSecret,
-            IEnumerable<CertificateDescription> cert)
+            string? clientSecret,
+            IEnumerable<CertificateDescription>? cert)
         {
             if (string.IsNullOrEmpty(clientSecret) && (cert == null))
             {

--- a/src/Microsoft.Identity.Web/MigrationAid/Obsolete-LegacyTokenDecryptCertificateParameter.cs
+++ b/src/Microsoft.Identity.Web/MigrationAid/Obsolete-LegacyTokenDecryptCertificateParameter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Web
     /// </summary>
     internal static class ObsoleteLegacyTokenDecryptCertificateParameter
     {
-        internal static void HandleLegacyTokenDecryptionCertificateParameter(MicrosoftIdentityOptions options, Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions, X509Certificate2 tokenDecryptionCertificate)
+        internal static void HandleLegacyTokenDecryptionCertificateParameter(MicrosoftIdentityOptions options, Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions, X509Certificate2? tokenDecryptionCertificate)
         {
             // Case where a legacy tokenDecryptionCertificate was passed. We then replace
             // the delegate called by the developer by a delegate which calls the delegate

--- a/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebApiAuthenticationBuilderExtensions.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Identity.Web
             IConfiguration configuration,
             string configSectionName = "AzureAd",
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
-            X509Certificate2 tokenDecryptionCertificate = null,
+            X509Certificate2? tokenDecryptionCertificate = null,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {
             // Just call the obsolete method below (which takes delegates).
             // This method will do the work of taking into account the legacy
-            // parameter for the token decyrption certificate
+            // parameter for the token decryption certificate
             return builder.AddProtectedWebApi(
                 options => configuration.Bind(configSectionName, options),
                 options => configuration.Bind(configSectionName, options),
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Web
             this AuthenticationBuilder builder,
             Action<JwtBearerOptions> configureJwtBearerOptions,
             Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions,
-            X509Certificate2 tokenDecryptionCertificate = null,
+            X509Certificate2? tokenDecryptionCertificate = null,
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {

--- a/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebApiServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebApiServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Web
             IConfiguration configuration,
             string configSectionName = "AzureAd",
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
-            X509Certificate2 tokenDecryptionCertificate = null,
+            X509Certificate2? tokenDecryptionCertificate = null,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {
             AuthenticationBuilder builder = services.AddAuthentication(jwtBearerScheme);
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Web
             this IServiceCollection services,
             Action<JwtBearerOptions> configureJwtBearerOptions,
             Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions,
-            X509Certificate2 tokenDecryptionCertificate = null,
+            X509Certificate2? tokenDecryptionCertificate = null,
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {

--- a/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebAppServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebAppServiceCollectionExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Web
         /// <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
         /// Set to true if you want to debug, or just understand the OpenIdConnect events.
         /// </param>
-        /// <returns>Yhe service collection for chaining.</returns>
+        /// <returns>The service collection for chaining.</returns>
         [Obsolete("Use AuthenticationBuilder.AddMicrosoftWebApp. See https://aka.ms/ms-id-web/net5")]
         public static IServiceCollection AddSignIn(
             this IServiceCollection services,

--- a/src/Microsoft.Identity.Web/Resource/IJwtBearerMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/IJwtBearerMiddlewareDiagnostics.cs
@@ -6,15 +6,15 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 namespace Microsoft.Identity.Web.Resource
 {
     /// <summary>
-    /// Interface implemented by diagnostics for the JwtBearer middleware.
+    /// Interface implemented by diagnostics for the JWT Bearer middleware.
     /// </summary>
     public interface IJwtBearerMiddlewareDiagnostics
     {
         /// <summary>
-        /// Called to subscribe to JwtBearerEvents.
+        /// Called to subscribe to <see cref="JwtBearerEvents"/>.
         /// </summary>
-        /// <param name="events">JwtBearer events.</param>
-        /// <returns>the events (for chaining).</returns>
+        /// <param name="events">JWT Bearer events.</param>
+        /// <returns>The events (for chaining).</returns>
         JwtBearerEvents Subscribe(JwtBearerEvents events);
     }
 }

--- a/src/Microsoft.Identity.Web/Resource/IOpenIdConnectMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/IOpenIdConnectMiddlewareDiagnostics.cs
@@ -6,15 +6,15 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 namespace Microsoft.Identity.Web.Resource
 {
     /// <summary>
-    /// Diagnostics used in the Open Id Connect middleware
+    /// Diagnostics used in the OpenID Connect middleware
     /// (used in Web Apps).
     /// </summary>
     public interface IOpenIdConnectMiddlewareDiagnostics
     {
         /// <summary>
-        /// Method to subscribe to OpenIDConnect events.
+        /// Method to subscribe to <see cref="OpenIdConnectEvents"/>.
         /// </summary>
-        /// <param name="events">Open Id connect events.</param>
+        /// <param name="events">OpenID Connect events.</param>
         void Subscribe(OpenIdConnectEvents events);
     }
 }

--- a/src/Microsoft.Identity.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
@@ -28,22 +28,22 @@ namespace Microsoft.Identity.Web.Resource
         /// <summary>
         /// Invoked if exceptions are thrown during request processing. The exceptions will be re-thrown after this event unless suppressed.
         /// </summary>
-        private Func<AuthenticationFailedContext, Task> s_onAuthenticationFailed;
+        private Func<AuthenticationFailedContext, Task> s_onAuthenticationFailed = null!;
 
         /// <summary>
         /// Invoked when a protocol message is first received.
         /// </summary>
-        private Func<MessageReceivedContext, Task> s_onMessageReceived;
+        private Func<MessageReceivedContext, Task> s_onMessageReceived = null!;
 
         /// <summary>
         /// Invoked after the security token has passed validation and a ClaimsIdentity has been generated.
         /// </summary>
-        private Func<TokenValidatedContext, Task> s_onTokenValidated;
+        private Func<TokenValidatedContext, Task> s_onTokenValidated = null!;
 
         /// <summary>
         /// Invoked before a challenge is sent back to the caller.
         /// </summary>
-        private Func<JwtBearerChallengeContext, Task> s_onChallenge;
+        private Func<JwtBearerChallengeContext, Task> s_onChallenge = null!;
 
         /// <summary>
         /// Subscribes to all the JwtBearer events, to help debugging, while
@@ -52,10 +52,7 @@ namespace Microsoft.Identity.Web.Resource
         /// <param name="events">Events to subscribe to.</param>
         public JwtBearerEvents Subscribe(JwtBearerEvents events)
         {
-            if (events == null)
-            {
-                events = new JwtBearerEvents();
-            }
+            events ??= new JwtBearerEvents();
 
             s_onAuthenticationFailed = events.OnAuthenticationFailed;
             events.OnAuthenticationFailed = OnAuthenticationFailedAsync;

--- a/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
@@ -10,7 +10,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 namespace Microsoft.Identity.Web.Resource
 {
     /// <summary>
-    /// Diagnostics used in the Open Id Connect middleware
+    /// Diagnostics used in the OpenID Connect middleware
     /// (used in Web Apps).
     /// </summary>
     public class OpenIdConnectMiddlewareDiagnostics : IOpenIdConnectMiddlewareDiagnostics
@@ -32,46 +32,46 @@ namespace Microsoft.Identity.Web.Resource
         //     be used to set ProtocolMessage.State that will be persisted through the authentication
         //     process. The ProtocolMessage can also be used to add or customize parameters
         //     sent to the identity provider.
-        private Func<RedirectContext, Task> s_onRedirectToIdentityProvider;
+        private Func<RedirectContext, Task> s_onRedirectToIdentityProvider = null!;
 
         // Summary:
         //     Invoked when a protocol message is first received.
-        private Func<MessageReceivedContext, Task> s_onMessageReceived;
+        private Func<MessageReceivedContext, Task> s_onMessageReceived = null!;
 
         // Summary:
         //     Invoked after security token validation if an authorization code is present in
         //     the protocol message.
-        private Func<AuthorizationCodeReceivedContext, Task> s_onAuthorizationCodeReceived;
+        private Func<AuthorizationCodeReceivedContext, Task> s_onAuthorizationCodeReceived = null!;
 
         // Summary:
         //     Invoked after "authorization code" is redeemed for tokens at the token endpoint.
-        private Func<TokenResponseReceivedContext, Task> s_onTokenResponseReceived;
+        private Func<TokenResponseReceivedContext, Task> s_onTokenResponseReceived = null!;
 
         // Summary:
         //     Invoked when an IdToken has been validated and produced an AuthenticationTicket.
-        private Func<TokenValidatedContext, Task> s_onTokenValidated;
+        private Func<TokenValidatedContext, Task> s_onTokenValidated = null!;
 
         // Summary:
         //     Invoked when user information is retrieved from the UserInfoEndpoint.
-        private Func<UserInformationReceivedContext, Task> s_onUserInformationReceived;
+        private Func<UserInformationReceivedContext, Task> s_onUserInformationReceived = null!;
 
         // Summary:
         //     Invoked if exceptions are thrown during request processing. The exceptions will
         //     be re-thrown after this event unless suppressed.
-        private Func<AuthenticationFailedContext, Task> s_onAuthenticationFailed;
+        private Func<AuthenticationFailedContext, Task> s_onAuthenticationFailed = null!;
 
         // Summary:
         //     Invoked when a request is received on the RemoteSignOutPath.
-        private Func<RemoteSignOutContext, Task> s_onRemoteSignOut;
+        private Func<RemoteSignOutContext, Task> s_onRemoteSignOut = null!;
 
         // Summary:
         //     Invoked before redirecting to the identity provider to sign out.
-        private Func<RedirectContext, Task> s_onRedirectToIdentityProviderForSignOut;
+        private Func<RedirectContext, Task> s_onRedirectToIdentityProviderForSignOut = null!;
 
         // Summary:
         //     Invoked before redirecting to the Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.SignedOutRedirectUri
         //     at the end of a remote sign-out flow.
-        private Func<RemoteSignOutContext, Task> s_onSignedOutCallbackRedirect;
+        private Func<RemoteSignOutContext, Task> s_onSignedOutCallbackRedirect = null!;
 
         /// <summary>
         /// Subscribes to all the OpenIdConnect events, to help debugging, while
@@ -80,6 +80,8 @@ namespace Microsoft.Identity.Web.Resource
         /// <param name="events">Events to subscribe to.</param>
         public void Subscribe(OpenIdConnectEvents events)
         {
+            events ??= new OpenIdConnectEvents();
+
             s_onRedirectToIdentityProvider = events.OnRedirectToIdentityProvider;
             events.OnRedirectToIdentityProvider = OnRedirectToIdentityProviderAsync;
 
@@ -126,7 +128,7 @@ namespace Microsoft.Identity.Web.Resource
         {
             foreach (var property in message.GetType().GetProperties())
             {
-                object value = property.GetValue(message);
+                object? value = property.GetValue(message);
                 if (value != null)
                 {
                     _logger.LogDebug($"   - {property.Name}={value}");

--- a/src/Microsoft.Identity.Web/Resource/RegisterValidAudience.cs
+++ b/src/Microsoft.Identity.Web/Resource/RegisterValidAudience.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Web.Resource
     /// </summary>
     internal class RegisterValidAudience
     {
-        private string ClientId { get; set; }
+        private string ClientId { get; set; } = null!;
         private bool IsB2C { get; set; } = false;
         private const string Version = "ver";
         private const string V1 = "1.0";
@@ -61,7 +61,12 @@ namespace Microsoft.Identity.Web.Resource
             SecurityToken securityToken,
             TokenValidationParameters validationParameters)
         {
-            JwtSecurityToken token = securityToken as JwtSecurityToken;
+            JwtSecurityToken? token = securityToken as JwtSecurityToken;
+            if (token == null)
+            {
+                throw new SecurityTokenValidationException("Token is not JWT token.");
+            }
+
             string validAudience;
 
             // Case of a default App ID URI (the developer did not provide explicit valid audience(s)

--- a/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Web.Resource
         /// <summary>
         /// When applied to an <see cref="HttpContext"/>, verifies that the user authenticated in the
         /// web API has any of the accepted scopes.
-        /// If there is no authenticated user, the reponse is a 401 (Unauthenticated).
+        /// If there is no authenticated user, the response is a 401 (Unauthenticated).
         /// If the authenticated user does not have any of these <paramref name="acceptedScopes"/>, the
         /// method updates the HTTP response providing a status code 403 (Forbidden)
         /// and writes to the response body a message telling which scopes are expected in the token.
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Web.Resource
                 // Fallback to Scope claim name
                 if (scopeClaim == null)
                 {
-                    scopeClaim = context?.User?.FindFirst(ClaimConstants.Scope);
+                    scopeClaim = context.User.FindFirst(ClaimConstants.Scope);
                 }
 
                 if (scopeClaim == null || !scopeClaim.Value.Split(' ').Intersect(acceptedScopes).Any())

--- a/src/Microsoft.Identity.Web/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Identity.Web
@@ -33,6 +34,11 @@ namespace Microsoft.Identity.Web
             this IServiceCollection services,
             bool isTokenAcquisitionSingleton = false)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             // Token acquisition service
             services.AddHttpContextAccessor();
             if (!isTokenAcquisitionSingleton)

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -33,10 +33,10 @@ namespace Microsoft.Identity.Web
 
         private readonly IMsalTokenCacheProvider _tokenCacheProvider;
 
-        private IConfidentialClientApplication _application;
+        private IConfidentialClientApplication? _application;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private HttpContext CurrentHttpContext => _httpContextAccessor.HttpContext;
-        private IMsalHttpClientFactory _httpClientFactory;
+        private readonly IMsalHttpClientFactory _httpClientFactory;
         private readonly ILogger _logger;
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Web
         /// <param name="httpContextAccessor">Access to the HttpContext of the request.</param>
         /// <param name="microsoftIdentityOptions">Configuration options.</param>
         /// <param name="applicationOptions">MSAL.NET configuration options.</param>
-        /// <param name="httpClientFactory">Http client factory.</param>
+        /// <param name="httpClientFactory">HTTP client factory.</param>
         /// <param name="logger">Logger.</param>
         public TokenAcquisition(
             IMsalTokenCacheProvider tokenCacheProvider,
@@ -131,7 +131,7 @@ namespace Microsoft.Identity.Web
                 // If they are not yet in the HttpContext.User's claims, add them here.
                 if (!context.HttpContext.User.Claims.Any())
                 {
-                    (context.HttpContext.User.Identity as ClaimsIdentity).AddClaims(context.Principal.Claims);
+                    (context.HttpContext.User.Identity as ClaimsIdentity)?.AddClaims(context.Principal.Claims);
                 }
 
                 _application = await GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
@@ -177,7 +177,7 @@ namespace Microsoft.Identity.Web
         [Obsolete("This method has been deprecated, please use the GetAccessTokenForUserAsync() method instead.")]
         public async Task<string> GetAccessTokenOnBehalfOfUserAsync(
             IEnumerable<string> scopes,
-            string tenant = null)
+            string? tenant = null)
         {
             return await GetAccessTokenForUserAsync(scopes, tenant).ConfigureAwait(false);
         }
@@ -193,7 +193,7 @@ namespace Microsoft.Identity.Web
         /// <param name="scopes">Scopes to request for the downstream API to call.</param>
         /// <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
         /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
-        /// <returns>An access token to call the downstream API and populated with this downstream Api's scopes.</returns>
+        /// <returns>An access token to call the downstream API and populated with this downstream API's scopes.</returns>
         /// <remarks>Calling this method from a Web API supposes that you have previously called,
         /// in a method called by JwtBearerOptions.Events.OnTokenValidated, the HttpContextExtensions.StoreTokenUsedToCallWebAPI method
         /// passing the validated token (as a JwtSecurityToken). Calling it from a Web App supposes that
@@ -201,7 +201,7 @@ namespace Microsoft.Identity.Web
         /// OpenIdConnectOptions.Events.OnAuthorizationCodeReceived.</remarks>
         public async Task<string> GetAccessTokenForUserAsync(
             IEnumerable<string> scopes,
-            string tenant = null)
+            string? tenant = null)
         {
             if (scopes == null)
             {
@@ -224,7 +224,7 @@ namespace Microsoft.Identity.Web
 
                 // to get a token for a Web API on behalf of the user, but not necessarily with the on behalf of OAuth2.0
                 // flow as this one only applies to Web APIs.
-                JwtSecurityToken validatedToken = CurrentHttpContext.GetTokenUsedToCallWebAPI();
+                JwtSecurityToken? validatedToken = CurrentHttpContext.GetTokenUsedToCallWebAPI();
 
                 // Case of Web APIs: we need to do an on-behalf-of flow
                 if (validatedToken != null)
@@ -285,12 +285,10 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="context">RedirectContext passed-in to a <see cref="OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/>
         /// OpenID Connect event.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task"/> that represents a completed account removal operation.</returns>
         public async Task RemoveAccountAsync(RedirectContext context)
         {
-            ClaimsPrincipal user = context.HttpContext.User;
             IConfidentialClientApplication app = await GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
-            IAccount account = null;
 
             // For B2C, we should remove all accounts of the user regardless the user flow
             if (_microsoftIdentityOptions.IsB2C)
@@ -306,8 +304,8 @@ namespace Microsoft.Identity.Web
             }
             else
             {
-                string identifier = context.HttpContext.User.GetMsalAccountId();
-                account = await app.GetAccountAsync(identifier).ConfigureAwait(false);
+                string? identifier = context.HttpContext.User.GetMsalAccountId();
+                IAccount account = await app.GetAccountAsync(identifier).ConfigureAwait(false);
 
                 if (account != null)
                 {
@@ -320,7 +318,6 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Creates an MSAL Confidential client application if needed.
         /// </summary>
-        /// <returns></returns>
         private async Task<IConfidentialClientApplication> GetOrBuildConfidentialClientApplicationAsync()
         {
             if (_application == null)
@@ -348,9 +345,6 @@ namespace Microsoft.Identity.Web
                 _applicationOptions.Instance += "/";
             }
 
-            string authority;
-            IConfidentialClientApplication app;
-
             MicrosoftIdentityOptionsValidation.ValidateEitherClientCertificateOrClientSecret(
                 _applicationOptions.ClientSecret,
                 _microsoftIdentityOptions.ClientCertificates);
@@ -361,6 +355,8 @@ namespace Microsoft.Identity.Web
                         .CreateWithApplicationOptions(_applicationOptions)
                         .WithRedirectUri(currentUri)
                         .WithHttpClientFactory(_httpClientFactory);
+
+                string authority;
 
                 if (_microsoftIdentityOptions.IsB2C)
                 {
@@ -375,11 +371,11 @@ namespace Microsoft.Identity.Web
 
                 if (_microsoftIdentityOptions.ClientCertificates != null)
                 {
-                    X509Certificate2 certificate = DefaultCertificateLoader.LoadFirstCertificate(_microsoftIdentityOptions.ClientCertificates);
+                    X509Certificate2? certificate = DefaultCertificateLoader.LoadFirstCertificate(_microsoftIdentityOptions.ClientCertificates);
                     builder.WithCertificate(certificate);
                 }
 
-                app = builder.Build();
+                IConfidentialClientApplication app = builder.Build();
                 // Initialize token cache providers
                 await _tokenCacheProvider.InitializeAsync(app.AppTokenCache).ConfigureAwait(false);
                 await _tokenCacheProvider.InitializeAsync(app.UserTokenCache).ConfigureAwait(false);
@@ -399,7 +395,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Gets an access token for a downstream API on behalf of the user described by its claimsPrincipal.
         /// </summary>
-        /// <param name="application"></param>
+        /// <param name="application"><see cref="IConfidentialClientApplication"/>.</param>
         /// <param name="claimsPrincipal">Claims principal for the user on behalf of whom to get a token.</param>
         /// <param name="scopes">Scopes for the downstream API to call.</param>
         /// <param name="tenant">(optional) Specific tenant for which to acquire a token to access the scopes
@@ -408,12 +404,12 @@ namespace Microsoft.Identity.Web
             IConfidentialClientApplication application,
             ClaimsPrincipal claimsPrincipal,
             IEnumerable<string> scopes,
-            string tenant)
+            string? tenant)
         {
             // Gets MsalAccountId for AAD and B2C scenarios
-            string accountIdentifier = claimsPrincipal.GetMsalAccountId();
-            string loginHint = claimsPrincipal.GetLoginHint();
-            IAccount account = null;
+            string? accountIdentifier = claimsPrincipal.GetMsalAccountId();
+            string? loginHint = claimsPrincipal.GetLoginHint();
+            IAccount? account = null;
 
             if (accountIdentifier != null)
             {
@@ -436,8 +432,8 @@ namespace Microsoft.Identity.Web
             // If it is B2C and could not get an account (most likely because there is no tid claims), try to get it by user flow
             if (_microsoftIdentityOptions.IsB2C && account == null)
             {
-                string currentUserFlow = claimsPrincipal.GetUserFlowId();
-                account = GetAccountByUserFlow(await application.GetAccountsAsync().ConfigureAwait(false), currentUserFlow);
+                string? currentUserFlow = claimsPrincipal.GetUserFlowId();
+                account = GetAccountByUserFlow(await application.GetAccountsAsync().ConfigureAwait(false), currentUserFlow!);
             }
 
             return await GetAccessTokenOnBehalfOfUserFromCacheAsync(application, account, scopes, tenant).ConfigureAwait(false);
@@ -453,9 +449,9 @@ namespace Microsoft.Identity.Web
         /// <param name="tenant"></param>
         private async Task<string> GetAccessTokenOnBehalfOfUserFromCacheAsync(
             IConfidentialClientApplication application,
-            IAccount account,
+            IAccount? account,
             IEnumerable<string> scopes,
-            string tenant)
+            string? tenant)
         {
             if (scopes == null)
             {
@@ -508,8 +504,8 @@ namespace Microsoft.Identity.Web
         /// the client can trigger an interaction with the user so that the user consents to more scopes.
         /// </summary>
         /// <param name="scopes">Scopes to consent to.</param>
-        /// <param name="msalServiceException"><see cref="MsalUiRequiredException"/> triggering the challenge.</param>
-        public void ReplyForbiddenWithWwwAuthenticateHeader(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException)
+        /// <param name="msalServiceException">The <see cref="MsalUiRequiredException"/> that triggered the challenge.</param>
+        public async Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException)
         {
             // A user interaction is required, but we are in a Web API, and therefore, we need to report back to the client through a www-Authenticate header https://tools.ietf.org/html/rfc6750#section-3.1
             string proposedAction = "consent";
@@ -520,6 +516,8 @@ namespace Microsoft.Identity.Web
                     throw msalServiceException;
                 }
             }
+
+            _application = await GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
 
             string consentUrl = $"{_application.Authority}/oauth2/v2.0/authorize?client_id={_applicationOptions.ClientId}"
                 + $"&response_type=code&redirect_uri={_application.AppConfig.RedirectUri}"
@@ -534,14 +532,12 @@ namespace Microsoft.Identity.Web
                 };
 
             string parameterString = string.Join(", ", parameters.Select(p => $"{p.Key}=\"{p.Value}\""));
-            string scheme = "Bearer";
-            StringValues v = new StringValues($"{scheme} {parameterString}");
 
             var httpResponse = CurrentHttpContext.Response;
             var headers = httpResponse.Headers;
             httpResponse.StatusCode = (int)HttpStatusCode.Forbidden;
 
-            headers[HeaderNames.WWWAuthenticate] = v;
+            headers[HeaderNames.WWWAuthenticate] = new StringValues($"Bearer {parameterString}");
         }
 
         private static bool AcceptedTokenVersionMismatch(MsalUiRequiredException msalSeviceException)
@@ -556,10 +552,10 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Gets an IAccount for the current B2C user flow in the user claims.
         /// </summary>
-        /// <param name="accounts"></param>
-        /// <param name="userFlow"></param>
-        /// <returns></returns>
-        private IAccount GetAccountByUserFlow(IEnumerable<IAccount> accounts, string userFlow)
+        /// <param name="accounts">A collection of accounts to search through.</param>
+        /// <param name="userFlow">A B2C user flow.</param>
+        /// <returns>An <see cref="IAccount"/> with the specified user flow.</returns>
+        private IAccount? GetAccountByUserFlow(IEnumerable<IAccount> accounts, string userFlow)
         {
             foreach (var account in accounts)
             {

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/DistributedTokenCacheAdapterExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/DistributedTokenCacheAdapterExtension.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
@@ -12,7 +13,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
     {
         /// <summary>Adds both the app and per-user in-memory token caches.</summary>
         /// <param name="services">The services collection to add to.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IServiceCollection"/> to chain.</returns>
         public static IServiceCollection AddDistributedTokenCaches(
             this IServiceCollection services)
         {
@@ -23,9 +24,15 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 
         /// <summary>Adds the in-memory based application token cache to the service collection.</summary>
         /// <param name="services">The services collection to add to.</param>
+        /// <returns>A <see cref="IServiceCollection"/> to chain.</returns>
         public static IServiceCollection AddDistributedAppTokenCache(
             this IServiceCollection services)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             services.AddDistributedMemoryCache();
             services.AddSingleton<IMsalTokenCacheProvider, MsalDistributedTokenCacheAdapter>();
             return services;
@@ -33,9 +40,15 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 
         /// <summary>Adds the in-memory based per user token cache to the service collection.</summary>
         /// <param name="services">The services collection to add to.</param>
+        /// <returns>A <see cref="IServiceCollection"/> to chain.</returns>
         public static IServiceCollection AddDistributedUserTokenCache(
             this IServiceCollection services)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             services.AddDistributedMemoryCache();
             services.AddHttpContextAccessor();
             services.AddSingleton<IMsalTokenCacheProvider, MsalDistributedTokenCacheAdapter>();

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
@@ -38,6 +39,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                                             IOptions<DistributedCacheEntryOptions> cacheOptions)
             : base(microsoftIdentityOptions, httpContextAccessor)
         {
+            if (cacheOptions == null)
+            {
+                throw new ArgumentNullException(nameof(cacheOptions));
+            }
+
             _distributedCache = memoryCache;
             _cacheOptions = cacheOptions.Value;
         }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// Initializes a token cache (which can be a user token cache or an app token cache).
         /// </summary>
         /// <param name="tokenCache">Token cache for which to initialize the serialization.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task"/> that represents a completed initialization operation.</returns>
         Task InitializeAsync(ITokenCache tokenCache);
 
         /// <summary>
         /// Clear the cache.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task"/> that represents a completed clear operation.</returns>
         Task ClearAsync();
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/InMemoryTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/InMemoryTokenCacheProviderExtension.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
@@ -16,6 +17,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         public static IServiceCollection AddInMemoryTokenCaches(
             this IServiceCollection services)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             services.AddMemoryCache();
             services.AddHttpContextAccessor();
             services.AddSingleton<IMsalTokenCacheProvider, MsalMemoryTokenCacheProvider>();

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,6 +36,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         /// <returns>The service collection.</returns>
         public static IServiceCollection AddSessionTokenCaches(this IServiceCollection services)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             // Add session if you are planning to use session based token cache
             var sessionStoreService = services.FirstOrDefault(x => x.ServiceType.Name == "ISessionStore");
 
@@ -84,6 +90,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         /// <returns>The service collection.</returns>
         public static IServiceCollection AddSessionAppTokenCache(this IServiceCollection services)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             services.AddHttpContextAccessor();
             services.AddScoped<IMsalTokenCacheProvider, MsalSessionTokenCacheProvider>();
             return services;
@@ -112,6 +123,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         /// <returns>The service collection.</returns>
         public static IServiceCollection AddSessionPerUserTokenCache(this IServiceCollection services)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             services.AddHttpContextAccessor();
             services.AddSession(option =>
                 {

--- a/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiAuthenticationBuilderExtensions.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Web
             }
 
             builder.Services.Configure(jwtBearerScheme, configureJwtBearerOptions);
-            builder.Services.Configure<MicrosoftIdentityOptions>(configureMicrosoftIdentityOptions);
+            builder.Services.Configure(configureMicrosoftIdentityOptions);
 
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<MicrosoftIdentityOptions>, MicrosoftIdentityOptionsValidation>());
             builder.Services.AddHttpContextAccessor();
@@ -84,7 +84,7 @@ namespace Microsoft.Identity.Web
             {
                 // TODO:
                 // Suspect. Why not get the IOption<MicrosoftIdentityOptions>?
-                var microsoftIdentityOptions = new MicrosoftIdentityOptions(); // configuration.GetSection(configSectionName).Get<MicrosoftIdentityOptions>();
+                MicrosoftIdentityOptions microsoftIdentityOptions = new MicrosoftIdentityOptions(); // configuration.GetSection(configSectionName).Get<MicrosoftIdentityOptions>();
                 configureMicrosoftIdentityOptions(microsoftIdentityOptions);
 
                 if (string.IsNullOrWhiteSpace(options.Authority))

--- a/src/Microsoft.Identity.Web/WebApiCallsWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiCallsWebApiAuthenticationBuilderExtensions.cs
@@ -57,10 +57,20 @@ namespace Microsoft.Identity.Web
                 throw new ArgumentNullException(nameof(builder));
             }
 
+            if (configureConfidentialClientApplicationOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureConfidentialClientApplicationOptions));
+            }
+
+            if (configureMicrosoftIdentityOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureMicrosoftIdentityOptions));
+            }
+
             builder.Services.Configure<ConfidentialClientApplicationOptions>(configureConfidentialClientApplicationOptions);
             builder.Services.Configure<MicrosoftIdentityOptions>(configureMicrosoftIdentityOptions);
 
-            var microsoftIdentityOptions = new MicrosoftIdentityOptions();
+            MicrosoftIdentityOptions microsoftIdentityOptions = new MicrosoftIdentityOptions();
             configureMicrosoftIdentityOptions(microsoftIdentityOptions);
 
             builder.Services.AddTokenAcquisition(microsoftIdentityOptions.SingletonTokenAcquisition);

--- a/src/Microsoft.Identity.Web/WebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppAuthenticationBuilderExtensions.cs
@@ -67,11 +67,26 @@ namespace Microsoft.Identity.Web
             string cookieScheme = CookieAuthenticationDefaults.AuthenticationScheme,
             bool subscribeToOpenIdConnectMiddlewareDiagnosticsEvents = false)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configureOpenIdConnectOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOpenIdConnectOptions));
+            }
+
+            if (configureMicrosoftIdentityOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureMicrosoftIdentityOptions));
+            }
+
             builder.Services.Configure(openIdConnectScheme, configureOpenIdConnectOptions);
             builder.Services.Configure<MicrosoftIdentityOptions>(configureMicrosoftIdentityOptions);
             builder.Services.AddHttpClient();
 
-            var microsoftIdentityOptions = new MicrosoftIdentityOptions();
+            MicrosoftIdentityOptions microsoftIdentityOptions = new MicrosoftIdentityOptions();
             configureMicrosoftIdentityOptions(microsoftIdentityOptions);
 
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<MicrosoftIdentityOptions>, MicrosoftIdentityOptionsValidation>());

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -5,6 +5,9 @@
 # Code files
 [*.{cs,vb}]
 
+# SA0001: XML comment analysis disabled
+dotnet_diagnostic.SA0001.severity = none
+
 # SA1600: Elements should be documented
 dotnet_diagnostic.SA1600.severity = none
 
@@ -31,3 +34,6 @@ dotnet_diagnostic.SA1402.severity = none
 
 # SA1611: Element parameters should be documented
 dotnet_diagnostic.SA1611.severity = none
+
+# SA1604: Element documentation should have summary
+dotnet_diagnostic.SA1604.severity = none

--- a/tests/Microsoft.Identity.Web.Test/AccountExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AccountExtensionsTests.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Identity.Web.Test
         {
             IAccount account = null;
 
-            var claimsPrincipalResult = account.ToClaimsPrincipal();
-
-            Assert.Null(claimsPrincipalResult);
+            Assert.Throws<ArgumentNullException>("account", () => account.ToClaimsPrincipal());
         }
 
         [Fact]
@@ -34,6 +32,7 @@ namespace Microsoft.Identity.Web.Test
             account.HomeAccountId.Returns(new AccountId("identifier", oid, tid));
 
             var claimsIdentityResult = account.ToClaimsPrincipal().Identity as ClaimsIdentity;
+
             Assert.NotNull(claimsIdentityResult);
             Assert.Equal(3, claimsIdentityResult.Claims.Count());
             Assert.Equal(username, claimsIdentityResult.FindFirst(ClaimTypes.Upn)?.Value);
@@ -42,11 +41,14 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
-        public void ToClaimsPrincipal_AccountWithNullValues_ThrowsException()
+        public void ToClaimsPrincipal_AccountWithNullValues_ReturnsEmptyPrincipal()
         {
             IAccount account = Substitute.For<IAccount>();
 
-            Assert.Throws<ArgumentNullException>("value", () => account.ToClaimsPrincipal());
+            var claimsIdentityResult = account.ToClaimsPrincipal().Identity as ClaimsIdentity;
+
+            Assert.NotNull(claimsIdentityResult);
+            Assert.Single(claimsIdentityResult.Claims);
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/InstanceDiscovery/IssuerConfigurationRetrieverTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/InstanceDiscovery/IssuerConfigurationRetrieverTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Web.Test.InstanceDiscovery
         public async Task GetConfigurationAsync_NullOrEmptyParameters_ThrowsException()
         {
             var configurationRetriever = new IssuerConfigurationRetriever();
-            var expectedAddressExceptionMessage = "Azure AD Issuer metadata address url is required (Parameter 'address')";
+            var expectedAddressExceptionMessage = "Azure AD Issuer metadata address URL is required (Parameter 'address')";
             var expectedRetrieverExceptionMessage = "No metadata document retriever is provided (Parameter 'retriever')";
 
             var exception = await Assert.ThrowsAsync<ArgumentNullException>("address", () => configurationRetriever.GetConfigurationAsync(null, null, CancellationToken.None)).ConfigureAwait(false);


### PR DESCRIPTION
Issue #15 
Original branch #183

- Implemented C# 8 Nullable Reference Type standard.
- Includes additional null checks for public method parameters.
- Few cases where I had to refactor a little to prevent null exceptions.
- Misc warning and comment fixes.

**Note 1:** 
Created a separate branch because rebasing #183 had some conflicts. Work from #183 is included here.

**Note 2:**
Analyzers had some funky behavior. Some code didn't have squiggly underlines. Error list had some weird warning types. Perhaps something to do with preview .NET build?
![image](https://user-images.githubusercontent.com/34331512/85374100-20451780-b4e9-11ea-91f5-3beeed14210a.png)

References:
[Nullable reference types](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references)
[Reserved attributes contribute to the compiler's null state static analysis](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis)
[Try out Nullable Reference Types](https://devblogs.microsoft.com/dotnet/try-out-nullable-reference-types/)
[Update libraries to use nullable reference types and communicate nullable rules to callers](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-migration-strategies)