### PR TITLE
Fixes #253: Check/decide the behavior of VerifyUserHasAnyAcceptedScope()

### DIFF
--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1210,14 +1210,15 @@
             <summary>
             When applied to an <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/>, verifies that the user authenticated in the
             web API has any of the accepted scopes.
+            If there is no authenticated user, the reponse is a 401 (Unauthenticated).
             If the authenticated user does not have any of these <paramref name="acceptedScopes"/>, the
-            method throws an HTTP Unauthorized with the message telling which scopes are expected in the token.
+            method updates the HTTP response providing a status code Forbidden (403)
+            and writes to the response body a message telling which scopes are expected in the token.
             </summary>
             <param name="context">HttpContext (from the controller).</param>
             <param name="acceptedScopes">Scopes accepted by this web API.</param>
-            <exception cref="T:System.Net.Http.HttpRequestException"> with a <see cref="P:Microsoft.AspNetCore.Http.HttpResponse.StatusCode"/> set to
-            <see cref="F:System.Net.HttpStatusCode.Unauthorized"/>.
-            </exception>
+            <remarks>When the scopes don't match the response is a 403 (Forbidden), 
+            because the user is authenticated (hence not 401), but not authorized.</remarks>
         </member>
         <member name="T:Microsoft.Identity.Web.ServiceCollectionExtensions">
             <summary>
@@ -1508,14 +1509,14 @@
             <summary>Initializes a new instance of the <see cref="T:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions"/> class.
             By default, the sliding expiration is set for 14 days.</summary>
         </member>
-        <member name="P:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions.SlidingExpiration">
+        <member name="P:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheOptions.AbsoluteExpirationRelativeToNow">
             <summary>
             Gets or sets the value of the duration after which the cache entry will expire unless it's used
             This is the duration the tokens are kept in memory cache.
             In production, a higher value, up-to 90 days is recommended.
             </summary>
             <value>
-            The SlidingExpiration value.
+            The AbsoluteExpirationRelativeToNow value.
             </value>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.InMemory.MsalMemoryTokenCacheProvider">

--- a/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Identity.Web.Resource
         /// </summary>
         /// <param name="context">HttpContext (from the controller).</param>
         /// <param name="acceptedScopes">Scopes accepted by this web API.</param>
-        /// <remarks>When the scopes don't match the response is a 403 (Forbidden), 
+        /// <remarks>When the scopes don't match the response is a 403 (Forbidden),
         /// because the user is authenticated (hence not 401), but not authorized.</remarks>
         public static void VerifyUserHasAnyAcceptedScope(this HttpContext context, params string[] acceptedScopes)
         {

--- a/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Identity.Web.Resource
         /// </summary>
         /// <param name="context">HttpContext (from the controller).</param>
         /// <param name="acceptedScopes">Scopes accepted by this web API.</param>
-        /// <remarks>When the scopes don't match the response is a 403 (Forbidden),
+        /// <remarks>When the scopes don't match, the response is a 403 (Forbidden),
         /// because the user is authenticated (hence not 401), but not authorized.</remarks>
         public static void VerifyUserHasAnyAcceptedScope(this HttpContext context, params string[] acceptedScopes)
         {

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/HttpContextUtilities.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/HttpContextUtilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.IO;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -21,7 +22,10 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
             featureCollection.Set<IHttpResponseFeature>(new HttpResponseFeature());
             featureCollection.Set<IHttpRequestFeature>(new HttpRequestFeature());
 
-            return contextFactory.Create(featureCollection);
+            HttpContext httpContext = contextFactory.Create(featureCollection);
+            httpContext.Response.Body = new MemoryStream();
+            httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+            return httpContext;
         }
 
         public static HttpContext CreateHttpContext(string[] userScopes)

--- a/tests/Microsoft.Identity.Web.Test/Resource/ScopesRequiredHttpContextExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/ScopesRequiredHttpContextExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             HttpContext httpContext = null;
 
-            Assert.Throws<NullReferenceException>(() => httpContext.VerifyUserHasAnyAcceptedScope(string.Empty));
+            Assert.Throws<ArgumentNullException>(() => httpContext.VerifyUserHasAnyAcceptedScope(string.Empty));
 
             httpContext = HttpContextUtilities.CreateHttpContext();
 
@@ -29,14 +29,13 @@ namespace Microsoft.Identity.Web.Test.Resource
         public void VerifyUserHasAnyAcceptedScope_NoClaims_ThrowsException()
         {
             var acceptedScopes = new[] { "acceptedScope1", "acceptedScope2" };
-            var expectedErrorMessage = $"The 'scope' claim does not contain scopes '{string.Join(",", acceptedScopes)}' or was not found";
             var expectedStatusCode = (int)HttpStatusCode.Unauthorized;
 
             var httpContext = HttpContextUtilities.CreateHttpContext();
+            httpContext.VerifyUserHasAnyAcceptedScope(acceptedScopes);
 
-            var exception = Assert.Throws<HttpRequestException>(() => httpContext.VerifyUserHasAnyAcceptedScope(acceptedScopes));
-            Assert.Equal(expectedStatusCode, httpContext.Response.StatusCode);
-            Assert.Equal(expectedErrorMessage, exception.Message);
+            HttpResponse response = httpContext.Response;
+            Assert.Equal(expectedStatusCode, response.StatusCode);
         }
 
         [Fact]
@@ -44,20 +43,30 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             var acceptedScopes = new[] { "acceptedScope1", "acceptedScope2" };
             var actualScopes = new[] { "acceptedScope3", "acceptedScope4" };
-            var expectedErrorMessage = $"The 'scope' claim does not contain scopes '{string.Join(",", acceptedScopes)}' or was not found";
-            var expectedStatusCode = (int)HttpStatusCode.Unauthorized;
+            var expectedErrorMessage = $"The 'scope' or 'scp' claim does not contain scopes '{string.Join(",", acceptedScopes)}' or was not found";
+            var expectedStatusCode = (int)HttpStatusCode.Forbidden;
 
             var httpContext = HttpContextUtilities.CreateHttpContext(actualScopes);
+            httpContext.VerifyUserHasAnyAcceptedScope(acceptedScopes);
 
-            var exception = Assert.Throws<HttpRequestException>(() => httpContext.VerifyUserHasAnyAcceptedScope(acceptedScopes));
-            Assert.Equal(expectedStatusCode, httpContext.Response.StatusCode);
-            Assert.Equal(expectedErrorMessage, exception.Message);
+            HttpResponse response = httpContext.Response;
+            Assert.Equal(expectedStatusCode, response.StatusCode);
+            Assert.Equal(expectedErrorMessage, GetBody(response));
 
             httpContext = HttpContextUtilities.CreateHttpContext(new[] { "acceptedScope3", "acceptedScope4" });
+            httpContext.VerifyUserHasAnyAcceptedScope(acceptedScopes);
+            response = httpContext.Response;
+            Assert.Equal(expectedStatusCode, response.StatusCode);
+            Assert.Equal(expectedErrorMessage, GetBody(response));
+        }
 
-            exception = Assert.Throws<HttpRequestException>(() => httpContext.VerifyUserHasAnyAcceptedScope(acceptedScopes));
-            Assert.Equal(expectedStatusCode, httpContext.Response.StatusCode);
-            Assert.Equal(expectedErrorMessage, exception.Message);
+        private static string GetBody(HttpResponse response)
+        {
+            byte[] buffer = new byte[response.Body.Length];
+            response.Body.Seek(0, System.IO.SeekOrigin.Begin);
+            response.Body.Read(buffer, 0, buffer.Length);
+            string body = System.Text.Encoding.Default.GetString(buffer);
+            return body;
         }
 
         [Fact]

--- a/tests/WebAppCallsWebApiCallsGraph/Client/Services/TodoListService.cs
+++ b/tests/WebAppCallsWebApiCallsGraph/Client/Services/TodoListService.cs
@@ -105,15 +105,14 @@ namespace TodoListClient.Services
         {
             await PrepareAuthenticatedClient();
             var response = await _httpClient.GetAsync($"{ _TodoListBaseAddress}/api/todolist");
+            var content = await response.Content.ReadAsStringAsync();
+
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var content = await response.Content.ReadAsStringAsync();
                 IEnumerable<Todo> todolist = JsonSerializer.Deserialize<IEnumerable<Todo>>(content, _jsonOptions);
-
                 return todolist;
             }
-
-            throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}.");
+            throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}. Cause: {content}");
         }
 
         private async Task PrepareAuthenticatedClient()


### PR DESCRIPTION
Fixes #253:

- Now checks that the HttpContext is not null, otherwise throws an ArgumentNullException
- If there is no authenticated user, the HTTP response status code is set to 401
- If there is an authenticated user, the HTTP response code is set to 403 and a message tells which scopes to acquire

- Updated the tests with the new behavior.
- Updated the sample to surface an explicit message to the developer of the client.

  ![image](https://user-images.githubusercontent.com/13203188/85851955-fec98180-b7af-11ea-99a4-c73f3499fa1d.png)
