### PR TITLE
fix bugs in session cache provider.

### DIFF
--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
     /// An implementation of token cache for confidential clients backed by an HTTP session.
     /// </summary>
     /// <remarks>
-    /// For this session cache to work effectively the ASP.NET Core session has to be configured properly.
+    /// For this session cache to work effectively, the ASP.NET Core session has to be configured properly.
     /// The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state
     ///
     /// In the method <c>public void ConfigureServices(IServiceCollection services)</c> in Startup.cs, add the following:
@@ -32,13 +32,13 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
     public class MsalSessionTokenCacheProvider : MsalAbstractTokenCacheProvider, IMsalTokenCacheProvider
     {
         private HttpContext CurrentHttpContext => _httpContextAccessor.HttpContext;
-        private ILogger _logger;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// MSAL Token cache provider constructor.
         /// </summary>
         /// <param name="microsoftIdentityOptions">Configuration options.</param>
-        /// <param name="httpContextAccessor">accessor for an HttpContext.</param>
+        /// <param name="httpContextAccessor">Accessor for an HttpContext.</param>
         /// <param name="logger">Logger.</param>
         public MsalSessionTokenCacheProvider(
             IOptions<MicrosoftIdentityOptions> microsoftIdentityOptions,
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         {
             await CurrentHttpContext.Session.LoadAsync().ConfigureAwait(false);
 
-            s_sessionLock.EnterReadLock();
+            _sessionLock.EnterReadLock();
             try
             {
                 if (CurrentHttpContext.Session.TryGetValue(cacheKey, out byte[] blob))
@@ -75,53 +75,53 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
             }
             finally
             {
-                s_sessionLock.ExitReadLock();
+                _sessionLock.ExitReadLock();
             }
         }
 
         /// <summary>
         /// Writes the token cache identified by its key to the serialization mechanism.
         /// </summary>
-        /// <param name="cacheKey">key for the cache (account ID or app ID).</param>
-        /// <param name="bytes">blob to write to the cache.</param>
+        /// <param name="cacheKey">Key for the cache (account ID or app ID).</param>
+        /// <param name="bytes">Blob to write to the cache.</param>
         protected override async Task WriteCacheBytesAsync(string cacheKey, byte[] bytes)
         {
-            s_sessionLock.EnterWriteLock();
+            _sessionLock.EnterWriteLock();
             try
             {
                 _logger.LogInformation($"Serializing session {CurrentHttpContext.Session.Id}, cacheId {cacheKey}");
 
                 // Reflect changes in the persistent store
                 CurrentHttpContext.Session.Set(cacheKey, bytes);
-                await CurrentHttpContext.Session.CommitAsync().ConfigureAwait(false);
+                await Task.CompletedTask.ConfigureAwait(false);
             }
             finally
             {
-                s_sessionLock.ExitWriteLock();
+                _sessionLock.ExitWriteLock();
             }
         }
 
         /// <summary>
-        /// Removes a cache described from its key.
+        /// Removes a cache described by its key.
         /// </summary>
-        /// <param name="cacheKey">key of the token cache (user account or app ID).</param>
+        /// <param name="cacheKey">Key of the token cache (user account or app ID).</param>
         protected override async Task RemoveKeyAsync(string cacheKey)
         {
-            s_sessionLock.EnterWriteLock();
+            _sessionLock.EnterWriteLock();
             try
             {
                 _logger.LogInformation($"Clearing session {CurrentHttpContext.Session.Id}, cacheId {cacheKey}");
 
                 // Reflect changes in the persistent store
                 CurrentHttpContext.Session.Remove(cacheKey);
-                await CurrentHttpContext.Session.CommitAsync().ConfigureAwait(false);
+                await Task.CompletedTask.ConfigureAwait(false);
             }
             finally
             {
-                s_sessionLock.ExitWriteLock();
+                _sessionLock.ExitWriteLock();
             }
         }
 
-        private static readonly ReaderWriterLockSlim s_sessionLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+        private readonly ReaderWriterLockSlim _sessionLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
     }
 }


### PR DESCRIPTION
- remove static
- remove commit, as it's done automatically

for testing:
In Startup.cs:
	• using Microsoft.Identity.Web.TokenCacheProviders.Session; 
	•  `services.AddInMemoryTokenCaches();` replace with `services.AddSessionTokenCaches(); `
In Startup.cs, in the configure method: Configure
`app.UseSession();`
before 
`app.UseAuthentication();`


#252 