### PR TITLE
This is an improvement leveraging the fact that MSAL.NET now exposes …

### DIFF
--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         private async Task OnAfterAccessAsync(TokenCacheNotificationArgs args)
         {
             // The access operation resulted in a cache update.
-            if (args.HasStateChanged && !string.IsNullOrEmpty(args.SuggestedCacheKey))
+            if (args.HasStateChanged)
             {
                 if (args.HasTokens)
                 {

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
@@ -41,17 +41,29 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private async Task OnAfterAccessAsync(TokenCacheNotificationArgs args)
         {
-            // if the access operation resulted in a cache update
-            if (args.HasStateChanged)
+            // The access operation resulted in a cache update.
+            if (args.HasStateChanged && !string.IsNullOrEmpty(args.SuggestedCacheKey))
             {
-                await WriteCacheBytesAsync(args.SuggestedCacheKey, args.TokenCache.SerializeMsalV3()).ConfigureAwait(false);
+                if (args.HasTokens)
+                {
+                    await WriteCacheBytesAsync(args.SuggestedCacheKey, args.TokenCache.SerializeMsalV3()).ConfigureAwait(false);
+                }
+                else
+                {
+                    // No token in the cache. we can remove the cache entry
+                    await RemoveKeyAsync(args.SuggestedCacheKey).ConfigureAwait(false);
+                }
             }
+
         }
 
         private async Task OnBeforeAccessAsync(TokenCacheNotificationArgs args)
         {
-            byte[] tokenCacheBytes = await ReadCacheBytesAsync(args.SuggestedCacheKey).ConfigureAwait(false);
-            args.TokenCache.DeserializeMsalV3(tokenCacheBytes, shouldClearExistingCache: true);
+            if (!string.IsNullOrEmpty(args.SuggestedCacheKey))
+            {
+                byte[] tokenCacheBytes = await ReadCacheBytesAsync(args.SuggestedCacheKey).ConfigureAwait(false);
+                args.TokenCache.DeserializeMsalV3(tokenCacheBytes, shouldClearExistingCache: true);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
                     await RemoveKeyAsync(args.SuggestedCacheKey).ConfigureAwait(false);
                 }
             }
-
         }
 
         private async Task OnBeforeAccessAsync(TokenCacheNotificationArgs args)

--- a/tests/B2CWebAppCallsWebApi/Client/appsettings.json
+++ b/tests/B2CWebAppCallsWebApi/Client/appsettings.json
@@ -1,15 +1,15 @@
 {
-  "AzureAdB2C": {
-    "Instance": "https://fabrikamb2c.b2clogin.com",
-    "ClientId": "fdb91ff5-5ce6-41f3-bdbd-8267c817015d",
-    "Domain": "fabrikamb2c.onmicrosoft.com",
-    "SignedOutCallbackPath": "/signout/B2C_1_susi",
-    "SignUpSignInPolicyId": "b2c_1_susi",
-    "ResetPasswordPolicyId": "b2c_1_reset",
-    "EditProfilePolicyId": "b2c_1_edit_profile", // Optional profile editing policy
-    "ClientSecret": "[Copy the client secret added to the app from the Azure portal]"
-    //"CallbackPath": "/signin/B2C_1_sign_up_in"  // defaults to /signin-oidc
-  },
+    "AzureAdB2C": {
+        "Instance": "https://fabrikamb2c.b2clogin.com",
+        "ClientId": "fdb91ff5-5ce6-41f3-bdbd-8267c817015d",
+        "Domain": "fabrikamb2c.onmicrosoft.com",
+        "SignedOutCallbackPath": "/signout/B2C_1_susi",
+        "SignUpSignInPolicyId": "b2c_1_susi",
+        "ResetPasswordPolicyId": "b2c_1_reset",
+        "EditProfilePolicyId": "b2c_1_edit_profile", // Optional profile editing policy
+        "ClientSecret": "X330F3#92!z614M4"
+        //"CallbackPath": "/signin/B2C_1_sign_up_in"  // defaults to /signin-oidc
+    },
   "TodoList": {
     /*
       TodoListScope is the scope of the Web API you want to call. This can be: "api://8f085429-c424-45c4-beb3-75f6f0a7924f/user_impersonation",

--- a/tests/B2CWebAppCallsWebApi/Client/appsettings.json
+++ b/tests/B2CWebAppCallsWebApi/Client/appsettings.json
@@ -7,7 +7,7 @@
         "SignUpSignInPolicyId": "b2c_1_susi",
         "ResetPasswordPolicyId": "b2c_1_reset",
         "EditProfilePolicyId": "b2c_1_edit_profile", // Optional profile editing policy
-        "ClientSecret": "X330F3#92!z614M4"
+        "ClientSecret": "[Copy the client secret added to the app from the Azure portal]"
         //"CallbackPath": "/signin/B2C_1_sign_up_in"  // defaults to /signin-oidc
     },
   "TodoList": {


### PR DESCRIPTION
…TokenCacheNotificationArgs.HasTokens which enable applications (and Microsoft.Identity.Web) to remove cache entries when the cache is empty

Also OnBeforeAccessAsync tests if the SuggestedCacheKey is null (can happen in B2C cases, as we still call GetAccountsAsync()