### PR TITLE
Update the project templates to improve the experience for B2C applications

### DIFF
--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/template.json
@@ -154,21 +154,28 @@
     "SignUpSignInPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "",
+      "defaultValue": "b2c_1_susi",
       "replaces": "MySignUpSignInPolicyId",
       "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignedOutCallbackPath": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "/signout/B2C_1_susi",
+        "replaces": "/signout/MySignUpSignInPolicyId",
+        "description": "The global signout callback (use with IndividualB2C auth)."
     },
     "ResetPasswordPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "",
+      "defaultValue": "b2c_1_reset",
       "replaces": "MyResetPasswordPolicyId",
       "description": "The reset password policy ID for this project (use with IndividualB2C auth)."
     },
     "EditProfilePolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "",
+      "defaultValue": "b2c_1_edit_profile",
       "replaces": "MyEditProfilePolicyId",
       "description": "The edit profile policy ID for this project (use with IndividualB2C auth)."
     },

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/Startup.cs
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/Startup.cs
@@ -110,6 +110,9 @@ namespace Company.WebApplication1
                     .Build();
                 options.Filters.Add(new AuthorizeFilter(policy));
             }).AddMicrosoftIdentityUI();
+#elif (IndividualB2CAuth)
+            services.AddRazorPages()
+                    .AddMicrosoftIdentityUI();
 #else
             services.AddRazorPages();
 #endif

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/appsettings.json
@@ -5,6 +5,7 @@
 //    "ClientId": "11111111-1111-1111-11111111111111111",
 //    "CallbackPath": "/signin-oidc",
 //    "Domain": "qualified.domain.name",
+//    "SignedOutCallbackPath": "/signout/MySignUpSignInPolicyId",
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
 //    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
 //    "EditProfilePolicyId": "MyEditProfilePolicyId"

--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
@@ -150,21 +150,28 @@
     "SignUpSignInPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "",
+      "defaultValue": "b2c_1_susi",
       "replaces": "MySignUpSignInPolicyId",
       "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignedOutCallbackPath": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "/signout/B2C_1_susi",
+        "replaces": "/signout/MySignUpSignInPolicyId",
+        "description": "The global signout callback (use with IndividualB2C auth)."
     },
     "ResetPasswordPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "",
+      "defaultValue": "b2c_1_reset",
       "replaces": "MyResetPasswordPolicyId",
       "description": "The reset password policy ID for this project (use with IndividualB2C auth)."
     },
     "EditProfilePolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "",
+      "defaultValue": "b2c_1_edit_profile",
       "replaces": "MyEditProfilePolicyId",
       "description": "The edit profile policy ID for this project (use with IndividualB2C auth)."
     },

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -5,6 +5,7 @@
 //    "ClientId": "11111111-1111-1111-11111111111111111",
 //    "CallbackPath": "/signin-oidc",
 //    "Domain": "qualified.domain.name",
+//    "SignedOutCallbackPath": "/signout/MySignUpSignInPolicyId",
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
 //    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
 //    "EditProfilePolicyId": "MyEditProfilePolicyId"

--- a/tests/WebAppCallsMicrosoftGraph/Properties/serviceDependencies.json
+++ b/tests/WebAppCallsMicrosoftGraph/Properties/serviceDependencies.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets"
+    }
+  }
+}

--- a/tests/WebAppCallsMicrosoftGraph/Properties/serviceDependencies.local.json
+++ b/tests/WebAppCallsMicrosoftGraph/Properties/serviceDependencies.local.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets.user"
+    }
+  }
+}


### PR DESCRIPTION
Update the project templates to improve the experience for B2C applications
- policies names have a default value
- [Bug fix] the Razor (webapp2) was not adding the MicrosoftIdentityUI
- Adding a setting for the signout callback


@jennyf19 : you could create a B2C web app calling a B2C API with something like:

```shell
dotnet new webapp2 --auth IndividualB2C --aad-b2c-instance "https://fabrikamb2c.b2clogin.com" --client-id "fdb91ff5-5ce6-41f3-bdbd-8267c817015d" --domain "fabrikamb2c.onmicrosoft.com" --called-api-url "https://fabrikamb2c.onmicrosoft.com/tasks" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
```

(and add the client secret)