### PR TITLE
fix b2c sign-in error

### DIFF
--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/Shared/LoginDisplay.IndividualB2CAuth.razor
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/Shared/LoginDisplay.IndividualB2CAuth.razor
@@ -24,7 +24,7 @@
 
     protected override void OnInitialized()
     {
-        var options = microsoftIdentityOptions.Get();
+        var options = microsoftIdentityOptions.CurrentValue;
         canEditProfile = !string.IsNullOrEmpty(options.EditProfilePolicyId);
     }
 }


### PR DESCRIPTION
I was getting build errors after creating the b2c web app, not sure if this is the right fix, as I also could not get the sign-in page to load. Also had build errors doing `dotnet build`, when trying to create just the web app.

And this:
![image](https://user-images.githubusercontent.com/19942418/87745340-7d5b8280-c7a2-11ea-9ffe-b2ca4a7bba8f.png)
In the --calls-graph one