### PR TITLE
Moved literal error messages, log messages, constants into constants files

### DIFF
--- a/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
+++ b/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Web
             // Correlation ID: f99deff4-f43b-43cc-b4e7-36141dbaf0a0
             // Timestamp: 2018-03-05 02:49:35Z
             // ', error_uri: 'error_uri is null'.
-            if (context.Failure is OpenIdConnectProtocolException && context.Failure.Message.Contains("AADB2C90118"))
+            if (context.Failure is OpenIdConnectProtocolException && context.Failure.Message.Contains(ErrorCodes.B2CForgottenPassword))
             {
                 // If the user clicked the reset password link, redirect to the reset password route
                 context.Response.Redirect($"{context.Request.PathBase}/MicrosoftIdentity/Account/ResetPassword/{SchemeName}");
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Web
             // Correlation ID: d01c8878-0732-4eb2-beb8-da82a57432e0
             // Timestamp: 2018-03-05 02:56:49Z
             // ', error_uri: 'error_uri is null'.
-            else if (context.Failure is OpenIdConnectProtocolException && context.Failure.Message.Contains("access_denied"))
+            else if (context.Failure is OpenIdConnectProtocolException && context.Failure.Message.Contains(ErrorCodes.AccessDenied))
             {
                 context.Response.Redirect($"{context.Request.PathBase}/");
             }

--- a/src/Microsoft.Identity.Web/Base64UrlHelpers.cs
+++ b/src/Microsoft.Identity.Web/Base64UrlHelpers.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
@@ -19,11 +18,11 @@ namespace Microsoft.Identity.Web
 
         private static readonly string DoubleBase64PadCharacter = string.Format(CultureInfo.InvariantCulture, "{0}{0}", Base64PadCharacter);
 
-        // The following functions perform base64url encoding which differs from regular base64 encoding as follows
-        // * padding is skipped so the pad character '=' doesn't have to be percent encoded
-        // * the 62nd and 63rd regular base64 encoding characters ('+' and '/') are replace with ('-' and '_')
-        // The changes make the encoding alphabet file and URL safe
-        // See RFC4648, section 5 for more info
+        // The following functions perform Base64URL encoding which differs from regular Base64 encoding:
+        // * Padding is skipped so the pad character '=' doesn't have to be percent encoded.
+        // * The 62nd and 63rd regular Base64 encoding characters ('+' and '/') are replaced with ('-' and '_').
+        // The changes make the encoding alphabet file and URL safe.
+        // See RFC4648, section 5 for more info.
         public static string? Encode(string arg)
         {
             if (arg == null)
@@ -63,10 +62,10 @@ namespace Microsoft.Identity.Web
                     s += Base64PadCharacter;
                     break; // One pad char
                 default:
-                    throw new ArgumentException("Illegal base64url string!", nameof(arg));
+                    throw new ArgumentException(IDWebErrorMessage.InvalidBase64UrlString, nameof(arg));
             }
 
-            return Convert.FromBase64String(s); // Standard base64 decoder
+            return Convert.FromBase64String(s); // Standard Base64 decoder
         }
 
         internal static string? Encode(byte[] arg)
@@ -77,7 +76,7 @@ namespace Microsoft.Identity.Web
             }
 
             string s = Convert.ToBase64String(arg);
-            s = s.Split(Base64PadCharacter)[0]; // RemoveAccount any trailing padding
+            s = s.Split(Base64PadCharacter)[0]; // Remove any trailing padding
             s = s.Replace(Base64Character62, Base64UrlCharacter62); // 62nd char of encoding
             s = s.Replace(Base64Character63, Base64UrlCharacter63); // 63rd char of encoding
 

--- a/src/Microsoft.Identity.Web/ClientInfo.cs
+++ b/src/Microsoft.Identity.Web/ClientInfo.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Identity.Web
 {
     internal class ClientInfo
     {
-        [JsonPropertyName(Constants.Uid)]
+        [JsonPropertyName(ClaimConstants.UniqueObjectIdentifier)]
         public string UniqueObjectIdentifier { get; set; } = null!;
 
-        [JsonPropertyName(Constants.Utid)]
+        [JsonPropertyName(ClaimConstants.UniqueTenantIdentifier)]
         public string UniqueTenantIdentifier { get; set; } = null!;
 
         public static ClientInfo? CreateFromJson(string clientInfo)

--- a/src/Microsoft.Identity.Web/Constants/Constants.cs
+++ b/src/Microsoft.Identity.Web/Constants/Constants.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Identity.Web
 {
+    /// <summary>
+    /// General constants.
+    /// </summary>
     internal static class Constants
     {
         // IssuerMetadata
@@ -30,16 +33,17 @@ namespace Microsoft.Identity.Web
         public const string Organizations = "organizations";
 
         // ClientInfo
-        public const string Uid = "uid";
-        public const string Utid = "utid";
         public const string ClientInfo = "client_info";
         public const string One = "1";
 
+        // Certificates
+        public const string MediaTypePksc12 = "application/x-pkcs12";
+        public const string PersonalUserCertificateStorePath = "CurrentUser/My";
+
         // Miscellaneous
         public const string UserAgent = "User-Agent";
-        public const string JwtSecurityTokenUsedToCallWebAPI = "JwtSecurityTokenUsedToCallWebAPI";
+        public const string JwtSecurityTokenUsedToCallWebApi = "JwtSecurityTokenUsedToCallWebAPI";
         public const string AzureAd = "AzureAd";
-        public const string PreferredUserName = "preferred_username";
-        public const string NameClaim = "name";
+        public const string AzureAdB2C = "AzureAdB2C";
     }
 }

--- a/src/Microsoft.Identity.Web/Constants/ErrorCodes.cs
+++ b/src/Microsoft.Identity.Web/Constants/ErrorCodes.cs
@@ -7,5 +7,9 @@ namespace Microsoft.Identity.Web
     {
         public const string MissingClientCredentials = "missing_client_credentials";
         public const string DuplicateClientCredentials = "duplicate_client_credentials";
+
+        // AzureADB2COpenIDConnectEventHandlers
+        public const string B2CForgottenPassword = "AADB2C90118";
+        public const string AccessDenied = "access_denied";
     }
 }

--- a/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
@@ -3,9 +3,12 @@
 
 namespace Microsoft.Identity.Web
 {
+    /// <summary>
+    /// Constants related to the error messages.
+    /// </summary>
     internal static class IDWebErrorMessage
     {
-        // general
+        // General
         // public const string IDW10000 = "IDW10000:";
 
         // Configuration IDW10100 = "IDW10100:"
@@ -13,26 +16,39 @@ namespace Microsoft.Identity.Web
         public const string ScopeKeySectionIsProvidedButNotPresentInTheServicesCollection = "IDW10102: The {0} is provided but the IConfiguration instance is not present in the services collection. ";
         public const string NoScopesProvided = "IDW10103: No scopes provided in scopes... ";
         public const string ClientSecretAndCertficateNull =
-               "IDW10104: Both client secret & client certificate cannot be null or whitespace, " +
-               "and ONE, must be included in the configuration of the web app when calling a web API. " +
+               "IDW10104: Both client secret and client certificate cannot be null or whitespace, " +
+               "and only ONE must be included in the configuration of the web app when calling a web API. " +
                "For instance, in the appsettings.json file. ";
-        public const string BothClientSecretAndCertificateProvided = "IDW10105: Both Client secret & client certificate, " +
+        public const string BothClientSecretAndCertificateProvided = "IDW10105: Both client secret and client certificate, " +
                    "cannot be included in the configuration of the web app when calling a web API. ";
+        public const string ConfigurationOptionRequired = "The '{0}' option must be provided. ";
 
         // Authorization IDW10200 = "IDW10200:"
         public const string NeitherScopeOrRolesClaimFoundInToken = "IDW10201: Neither scope or roles claim was found in the bearer token. ";
+        public const string MissingRoles = "The 'roles' or 'role' claim does not contain roles '{0}' or was not found. ";
+        public const string MissingScopes = "The 'scope' or 'scp' claim does not contain scopes '{0}' or was not found. ";
 
         // Token Validation IDW10300 = "IDW10300:"
-        public const string IssuerMetadataURLIsRequired = "IDW10301: Azure AD Issuer metadata address URL is required. ";
+        public const string IssuerMetadataUrlIsRequired = "IDW10301: Azure AD Issuer metadata address URL is required. ";
         public const string NoMetadataDocumentRetrieverProvided = "IDW10302: No metadata document retriever is provided. ";
         public const string IssuerDoesNotMatchValidIssuers = "IDW10303: Issuer: '{0}', does not match any of the valid issuers provided for this application. ";
 
         // Protocol IDW10400 = "IDW10400:"
         public const string TenantIdClaimNotPresentInToken = "IDW10401: Neither `tid` nor `tenantId` claim is present in the token obtained from Microsoft identity platform. ";
         public const string ClientInfoReturnedFromServerIsNull = "IDW10402: Client info returned from the server is null. ";
-        public const string TokenIsNotJWTToken = "IDW10403: Token is not JWT token. ";
+        public const string TokenIsNotJwtToken = "IDW10403: Token is not JWT token. ";
 
         // MSAL IDW10500 = "IDW10500:"
         public const string ExceptionAcquiringTokenForConfidentialClient = "IDW10501: Exception acquiring token for a confidential client. ";
+
+        // Encoding IDW10600 = "IDW10600:"
+        public const string InvalidBase64UrlString = "IDW10601: Invalid Base64URL string. ";
+
+        // Certificates IDW10700 = "IDW10700:"
+        public const string OnlyPkcs12IsSupported = "IDW10701: Only PKCS #12 content type is supported. Found Content-Type: {0}. ";
+        public const string IncorrectNumberOfUriSegments = "IDW10702: Number of URI segments is incorrect: {0}, URI: {1}. ";
+        public const string InvalidCertificateStorePath = "IDW10703: Certificate store path must be of the form 'StoreLocation/StoreName'. " +
+            "StoreLocation must be one of 'CurrentUser', 'CurrentMachine'. " +
+            "StoreName must be empty or one of '{0}'. ";
     }
 }

--- a/src/Microsoft.Identity.Web/Constants/LogMessages.cs
+++ b/src/Microsoft.Identity.Web/Constants/LogMessages.cs
@@ -3,9 +3,19 @@
 
 namespace Microsoft.Identity.Web
 {
+    /// <summary>
+    /// Constants related to the log messages.
+    /// </summary>
     internal static class LogMessages
     {
-        public const string MissingRoles = "The 'roles' or 'role' claim does not contain roles '{0}' or was not found";
-        public const string MissingScopes = "The 'scope' or 'scp' claim does not contain scopes '{0}' or was not found";
+        // Diagnostics
+        public const string MethodBegin = "Begin {0}. ";
+        public const string MethodEnd = "End {0}. ";
+
+        // Caching
+        public const string DeserializingSessionCache = "Deserializing session {0}, cache key {1}. ";
+        public const string SessionCacheKeyNotFound = "Cache key {0} not found in session {1}. ";
+        public const string SerializingSessionCache = "Serializing session {0}, cache key {1}. ";
+        public const string ClearingSessionCache = "Clearing session {0}, cache key {1}. ";
     }
 }

--- a/src/Microsoft.Identity.Web/HttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/HttpContextExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Web
         /// it can be used in the actions.</param>
         internal static void StoreTokenUsedToCallWebAPI(this HttpContext httpContext, JwtSecurityToken? token)
         {
-            httpContext.Items.Add(Constants.JwtSecurityTokenUsedToCallWebAPI, token);
+            httpContext.Items.Add(Constants.JwtSecurityTokenUsedToCallWebApi, token);
         }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Microsoft.Identity.Web
         /// <returns><see cref="JwtSecurityToken"/> used to call the web API.</returns>
         internal static JwtSecurityToken? GetTokenUsedToCallWebAPI(this HttpContext httpContext)
         {
-            return httpContext.Items[Constants.JwtSecurityTokenUsedToCallWebAPI] as JwtSecurityToken;
+            return httpContext.Items[Constants.JwtSecurityTokenUsedToCallWebApi] as JwtSecurityToken;
         }
     }
 }

--- a/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerConfigurationRetriever.cs
+++ b/src/Microsoft.Identity.Web/InstanceDiscovery/IssuerConfigurationRetriever.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Web.InstanceDiscovery
         {
             if (string.IsNullOrEmpty(address))
             {
-                throw new ArgumentNullException(nameof(address), IDWebErrorMessage.IssuerMetadataURLIsRequired);
+                throw new ArgumentNullException(nameof(address), IDWebErrorMessage.IssuerMetadataUrlIsRequired);
             }
 
             if (retriever == null)

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -469,6 +469,21 @@
             Tfp claim: "tfp".
             </summary>
         </member>
+        <member name="T:Microsoft.Identity.Web.Constants">
+            <summary>
+            General constants.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Identity.Web.IDWebErrorMessage">
+            <summary>
+            Constants related to the error messages.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Identity.Web.LogMessages">
+            <summary>
+            Constants related to the log messages.
+            </summary>
+        </member>
         <member name="T:Microsoft.Identity.Web.CookiePolicyOptionsExtensions">
             <summary>
             Extension class containing cookie policies (work around for same site).

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptionsValidation.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptionsValidation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
 
@@ -13,26 +14,26 @@ namespace Microsoft.Identity.Web
         {
             if (string.IsNullOrEmpty(options.ClientId))
             {
-                return ValidateOptionsResult.Fail($"The '{nameof(options.ClientId)}' option must be provided.");
+                return ValidateOptionsResult.Fail(string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.ClientId)));
             }
 
             if (string.IsNullOrEmpty(options.Instance))
             {
-                return ValidateOptionsResult.Fail($"The '{nameof(options.Instance)}' option must be provided.");
+                return ValidateOptionsResult.Fail(string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.Instance)));
             }
 
             if (options.IsB2C)
             {
                 if (string.IsNullOrEmpty(options.Domain))
                 {
-                    return ValidateOptionsResult.Fail($"The '{nameof(options.Domain)}' option must be provided.");
+                    return ValidateOptionsResult.Fail(string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.Domain)));
                 }
             }
             else
             {
                 if (string.IsNullOrEmpty(options.TenantId))
                 {
-                    return ValidateOptionsResult.Fail($"The '{nameof(options.TenantId)}' option must be provided.");
+                    return ValidateOptionsResult.Fail(string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.TenantId)));
                 }
             }
 

--- a/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebApiAuthenticationBuilderExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Identity.Web
         public static AuthenticationBuilder AddProtectedWebApi(
             this AuthenticationBuilder builder,
             IConfiguration configuration,
-            string configSectionName = "AzureAd",
+            string configSectionName = Constants.AzureAd,
             string jwtBearerScheme = JwtBearerDefaults.AuthenticationScheme,
             X509Certificate2? tokenDecryptionCertificate = null,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)

--- a/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/MigrationAid/Obsolete-WebAppAuthenticationBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Web
         public static AuthenticationBuilder AddSignIn(
             this AuthenticationBuilder builder,
             IConfiguration configuration,
-            string configSectionName = "AzureAd",
+            string configSectionName = Constants.AzureAd,
             string openIdConnectScheme = OpenIdConnectDefaults.AuthenticationScheme,
             string cookieScheme = CookieAuthenticationDefaults.AuthenticationScheme,
             bool subscribeToOpenIdConnectMiddlewareDiagnosticsEvents = false) =>

--- a/src/Microsoft.Identity.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Logging;
@@ -72,35 +73,35 @@ namespace Microsoft.Identity.Web.Resource
 
         private async Task OnMessageReceivedAsync(MessageReceivedContext context)
         {
-            _logger.LogDebug($"1. Begin {nameof(OnMessageReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnMessageReceivedAsync)));
 
             // Place a breakpoint here and examine the bearer token (context.Request.Headers.HeaderAuthorization / context.Request.Headers["Authorization"])
             // Use https://jwt.ms to decode the token and observe claims
             await s_onMessageReceived(context).ConfigureAwait(false);
-            _logger.LogDebug($"1. End - {nameof(OnMessageReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnMessageReceivedAsync)));
         }
 
         private async Task OnAuthenticationFailedAsync(AuthenticationFailedContext context)
         {
-            _logger.LogDebug($"99. Begin {nameof(OnAuthenticationFailedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnAuthenticationFailedAsync)));
 
             // Place a breakpoint here and examine context.Exception
             await s_onAuthenticationFailed(context).ConfigureAwait(false);
-            _logger.LogDebug($"99. End - {nameof(OnAuthenticationFailedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnAuthenticationFailedAsync)));
         }
 
         private async Task OnTokenValidatedAsync(TokenValidatedContext context)
         {
-            _logger.LogDebug($"2. Begin {nameof(OnTokenValidatedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnTokenValidatedAsync)));
             await s_onTokenValidated(context).ConfigureAwait(false);
-            _logger.LogDebug($"2. End - {nameof(OnTokenValidatedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnTokenValidatedAsync)));
         }
 
         private async Task OnChallengeAsync(JwtBearerChallengeContext context)
         {
-            _logger.LogDebug($"55. Begin {nameof(OnChallengeAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnChallengeAsync)));
             await s_onChallenge(context).ConfigureAwait(false);
-            _logger.LogDebug($"55. End - {nameof(OnChallengeAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnChallengeAsync)));
         }
     }
 }

--- a/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Logging;
@@ -115,13 +116,13 @@ namespace Microsoft.Identity.Web.Resource
 
         private async Task OnRedirectToIdentityProviderAsync(RedirectContext context)
         {
-            _logger.LogDebug($"1. Begin {nameof(OnRedirectToIdentityProviderAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnRedirectToIdentityProviderAsync)));
 
             await s_onRedirectToIdentityProvider(context).ConfigureAwait(false);
 
             _logger.LogDebug("   Sending OpenIdConnect message:");
             DisplayProtocolMessage(context.ProtocolMessage);
-            _logger.LogDebug($"1. End - {nameof(OnRedirectToIdentityProviderAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnRedirectToIdentityProviderAsync)));
         }
 
         private void DisplayProtocolMessage(OpenIdConnectMessage message)
@@ -138,67 +139,67 @@ namespace Microsoft.Identity.Web.Resource
 
         private async Task OnMessageReceivedAsync(MessageReceivedContext context)
         {
-            _logger.LogDebug($"2. Begin {nameof(OnMessageReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnMessageReceivedAsync)));
             _logger.LogDebug("   Received from STS the OpenIdConnect message:");
             DisplayProtocolMessage(context.ProtocolMessage);
             await s_onMessageReceived(context).ConfigureAwait(false);
-            _logger.LogDebug($"2. End - {nameof(OnMessageReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnMessageReceivedAsync)));
         }
 
         private async Task OnAuthorizationCodeReceivedAsync(AuthorizationCodeReceivedContext context)
         {
-            _logger.LogDebug($"4. Begin {nameof(OnAuthorizationCodeReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnAuthorizationCodeReceivedAsync)));
             await s_onAuthorizationCodeReceived(context).ConfigureAwait(false);
-            _logger.LogDebug($"4. End - {nameof(OnAuthorizationCodeReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnAuthorizationCodeReceivedAsync)));
         }
 
         private async Task OnTokenResponseReceivedAsync(TokenResponseReceivedContext context)
         {
-            _logger.LogDebug($"5. Begin {nameof(OnTokenResponseReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnTokenResponseReceivedAsync)));
             await s_onTokenResponseReceived(context).ConfigureAwait(false);
-            _logger.LogDebug($"5. End - {nameof(OnTokenResponseReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnTokenResponseReceivedAsync)));
         }
 
         private async Task OnTokenValidatedAsync(TokenValidatedContext context)
         {
-            _logger.LogDebug($"3. Begin {nameof(OnTokenValidatedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnTokenValidatedAsync)));
             await s_onTokenValidated(context).ConfigureAwait(false);
-            _logger.LogDebug($"3. End - {nameof(OnTokenValidatedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnTokenValidatedAsync)));
         }
 
         private async Task OnUserInformationReceivedAsync(UserInformationReceivedContext context)
         {
-            _logger.LogDebug($"6. Begin {nameof(OnUserInformationReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnUserInformationReceivedAsync)));
             await s_onUserInformationReceived(context).ConfigureAwait(false);
-            _logger.LogDebug($"6. End - {nameof(OnUserInformationReceivedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnUserInformationReceivedAsync)));
         }
 
         private async Task OnAuthenticationFailedAsync(AuthenticationFailedContext context)
         {
-            _logger.LogDebug($"99. Begin {nameof(OnAuthenticationFailedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnAuthenticationFailedAsync)));
             await s_onAuthenticationFailed(context).ConfigureAwait(false);
-            _logger.LogDebug($"99. End - {nameof(OnAuthenticationFailedAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnAuthenticationFailedAsync)));
         }
 
         private async Task OnRedirectToIdentityProviderForSignOutAsync(RedirectContext context)
         {
-            _logger.LogDebug($"10. Begin {nameof(OnRedirectToIdentityProviderForSignOutAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnRedirectToIdentityProviderForSignOutAsync)));
             await s_onRedirectToIdentityProviderForSignOut(context).ConfigureAwait(false);
-            _logger.LogDebug($"10. End - {nameof(OnRedirectToIdentityProviderForSignOutAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnRedirectToIdentityProviderForSignOutAsync)));
         }
 
         private async Task OnRemoteSignOutAsync(RemoteSignOutContext context)
         {
-            _logger.LogDebug($"11. Begin {nameof(OnRemoteSignOutAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnRemoteSignOutAsync)));
             await s_onRemoteSignOut(context).ConfigureAwait(false);
-            _logger.LogDebug($"11. End - {nameof(OnRemoteSignOutAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnRemoteSignOutAsync)));
         }
 
         private async Task OnSignedOutCallbackRedirectAsync(RemoteSignOutContext context)
         {
-            _logger.LogDebug($"12. Begin {nameof(OnSignedOutCallbackRedirectAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodBegin, nameof(OnSignedOutCallbackRedirectAsync)));
             await s_onSignedOutCallbackRedirect(context).ConfigureAwait(false);
-            _logger.LogDebug($"12. End {nameof(OnSignedOutCallbackRedirectAsync)}");
+            _logger.LogDebug(string.Format(CultureInfo.InvariantCulture, LogMessages.MethodEnd, nameof(OnSignedOutCallbackRedirectAsync)));
         }
     }
 }

--- a/src/Microsoft.Identity.Web/Resource/RegisterValidAudience.cs
+++ b/src/Microsoft.Identity.Web/Resource/RegisterValidAudience.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Web.Resource
             JwtSecurityToken? token = securityToken as JwtSecurityToken;
             if (token == null)
             {
-                throw new SecurityTokenValidationException(IDWebErrorMessage.TokenIsNotJWTToken);
+                throw new SecurityTokenValidationException(IDWebErrorMessage.TokenIsNotJwtToken);
             }
 
             validationParameters.AudienceValidator = null;

--- a/src/Microsoft.Identity.Web/Resource/RolesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/RolesRequiredHttpContextExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Identity.Web.Resource
                 if (rolesClaim == null || !rolesClaim.Value.Split(' ').Intersect(acceptedRoles).Any())
                 {
                     context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
-                    string message = string.Format(CultureInfo.InvariantCulture, LogMessages.MissingRoles, string.Join(",", acceptedRoles));
+                    string message = string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.MissingRoles, string.Join(",", acceptedRoles));
                     context.Response.WriteAsync(message);
                 }
             }

--- a/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Web.Resource
                 if (scopeClaim == null || !scopeClaim.Value.Split(' ').Intersect(acceptedScopes).Any())
                 {
                     context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
-                    string message = string.Format(CultureInfo.InvariantCulture, LogMessages.MissingScopes, string.Join(",", acceptedScopes));
+                    string message = string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.MissingScopes, string.Join(",", acceptedScopes));
                     context.Response.WriteAsync(message);
                 }
             }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/DistributedTokenCacheAdapterExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/DistributedTokenCacheAdapterExtension.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             builder.Services.AddDistributedTokenCaches();

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/InMemoryTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/InMemoryTokenCacheProviderExtension.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             builder.Services.AddInMemoryTokenCaches();

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -61,11 +62,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
             {
                 if (_session.TryGetValue(cacheKey, out byte[] blob))
                 {
-                    _logger.LogInformation($"Deserializing session {_session.Id}, cacheId {cacheKey}");
+                    _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, LogMessages.DeserializingSessionCache, _session.Id, cacheKey));
                 }
                 else
                 {
-                    _logger.LogInformation($"CacheId {cacheKey} not found in session {_session.Id}");
+                    _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, LogMessages.SessionCacheKeyNotFound, cacheKey, _session.Id));
                 }
 
                 return blob;
@@ -87,7 +88,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
             _sessionLock.EnterWriteLock();
             try
             {
-                _logger.LogInformation($"Serializing session {_session.Id}, cacheId {cacheKey}");
+                _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, LogMessages.SerializingSessionCache, _session.Id, cacheKey));
 
                 // Reflect changes in the persistent store
                 _session.Set(cacheKey, bytes);
@@ -109,7 +110,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
             _sessionLock.EnterWriteLock();
             try
             {
-                _logger.LogInformation($"Clearing session {_session.Id}, cacheId {cacheKey}");
+                _logger.LogInformation(string.Format(CultureInfo.InvariantCulture, LogMessages.ClearingSessionCache, _session.Id, cacheKey));
 
                 // Reflect changes in the persistent store
                 _session.Remove(cacheKey);

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             builder.Services.AddSessionTokenCaches();

--- a/src/Microsoft.Identity.Web/WebAppExtensions/WebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/WebAppAuthenticationBuilderExtensions.cs
@@ -111,11 +111,11 @@ namespace Microsoft.Identity.Web
                 // B2C doesn't have preferred_username claims
                 if (microsoftIdentityOptions.Value.IsB2C)
                 {
-                    options.TokenValidationParameters.NameClaimType = Constants.NameClaim;
+                    options.TokenValidationParameters.NameClaimType = ClaimConstants.Name;
                 }
                 else
                 {
-                    options.TokenValidationParameters.NameClaimType = Constants.PreferredUserName;
+                    options.TokenValidationParameters.NameClaimType = ClaimConstants.PreferredUserName;
                 }
 
                 // If the developer registered an IssuerValidator, do not overwrite it

--- a/tests/Microsoft.Identity.Web.Test/Base64UrlHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Base64UrlHelpersTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Identity.Web.Test
             Action decodeAction = () => Base64UrlHelpers.DecodeToBytes(stringToDecodeWithInvalidLength);
 
             var exception = Assert.Throws<ArgumentException>(decodeAction);
-            Assert.Equal("Illegal base64url string! (Parameter 'arg')", exception.Message);
+            Assert.Equal(IDWebErrorMessage.InvalidBase64UrlString + " (Parameter 'arg')", exception.Message);
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/ClaimsPrincipalExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClaimsPrincipalExtensionsTests.cs
@@ -201,12 +201,10 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void GetDomainHint_WithTenantIdClaims_ReturnsDomainHint()
         {
-            var msaTenantId = "9188040D-6c67-4c5b-b112-36a304b66dad";
-
             var claimsPrincipalWithMsaTenant = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
-                    new Claim(ClaimConstants.TenantId, msaTenantId),
+                    new Claim(ClaimConstants.TenantId, Constants.MsaTenantId),
                 }));
 
             var claimsPrincipalWithNonMsaTenant = new ClaimsPrincipal(
@@ -215,8 +213,8 @@ namespace Microsoft.Identity.Web.Test
                     new Claim(ClaimConstants.TenantId, TestConstants.TenantIdAsGuid),
                 }));
 
-            Assert.Equal("consumers", claimsPrincipalWithMsaTenant.GetDomainHint());
-            Assert.Equal("organizations", claimsPrincipalWithNonMsaTenant.GetDomainHint());
+            Assert.Equal(Constants.Consumers, claimsPrincipalWithMsaTenant.GetDomainHint());
+            Assert.Equal(Constants.Organizations, claimsPrincipalWithNonMsaTenant.GetDomainHint());
         }
 
         [Fact]

--- a/tests/Microsoft.Identity.Web.Test/CookiePolicyOptionsExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CookiePolicyOptionsExtensionsTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Identity.Web.Test
 {
     public class CookiePolicyOptionsExtensionsTests
     {
-        private string _userAgentHeaderName = "User-Agent";
         private string _cookieName = "cookieName";
         private string _cookieValue = "cookieValue";
         private CookiePolicyOptions _cookiePolicyOptions;
@@ -35,7 +34,7 @@ namespace Microsoft.Identity.Web.Test
         [InlineData(SameSiteMode.Strict, SameSiteMode.Strict, "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148")]
         public void HandleSameSiteCookieCompatibility_Default_ExecutesSuccessfully(SameSiteMode initialSameSiteMode, SameSiteMode expectedSameSiteMode, string userAgent)
         {
-            _httpContext.Request.Headers.Add(_userAgentHeaderName, userAgent);
+            _httpContext.Request.Headers.Add(Constants.UserAgent, userAgent);
             var appendCookieOptions = new CookieOptions() { SameSite = initialSameSiteMode };
             var deleteCookieOptions = new CookieOptions() { SameSite = initialSameSiteMode };
             var appendCookieContext = new AppendCookieContext(_httpContext, appendCookieOptions, _cookieName, _cookieValue);
@@ -58,7 +57,7 @@ namespace Microsoft.Identity.Web.Test
         [InlineData(SameSiteMode.Strict, SameSiteMode.Strict, false, "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148")]
         public void HandleSameSiteCookieCompatibility_CustomFilter_ExecutesSuccessfully(SameSiteMode initialSameSiteMode, SameSiteMode expectedSameSiteMode, bool expectedEventCalled, string userAgent)
         {
-            _httpContext.Request.Headers.Add(_userAgentHeaderName, userAgent);
+            _httpContext.Request.Headers.Add(Constants.UserAgent, userAgent);
             var appendCookieOptions = new CookieOptions() { SameSite = initialSameSiteMode };
             var deleteCookieOptions = new CookieOptions() { SameSite = initialSameSiteMode };
             var appendCookieContext = new AppendCookieContext(_httpContext, appendCookieOptions, _cookieName, _cookieValue);

--- a/tests/Microsoft.Identity.Web.Test/HttpContextExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/HttpContextExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Identity.Web.Test
 {
     public class HttpContextExtensionsTests
     {
-        private const string WebApiTokenKeyName = "JwtSecurityTokenUsedToCallWebAPI";
+        private const string WebApiTokenKeyName = Constants.JwtSecurityTokenUsedToCallWebApi;
 
         [Fact]
         public void StoreTokenUsedToCallWebAPI()

--- a/tests/Microsoft.Identity.Web.Test/InstanceDiscovery/IssuerConfigurationRetrieverTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/InstanceDiscovery/IssuerConfigurationRetrieverTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Web.Test.InstanceDiscovery
         {
             var configurationRetriever = new IssuerConfigurationRetriever();
 
-            string expectedErrorMessage = IDWebErrorMessage.IssuerMetadataURLIsRequired + " (Parameter 'address')";
+            string expectedErrorMessage = IDWebErrorMessage.IssuerMetadataUrlIsRequired + " (Parameter 'address')";
 
             var exception = await Assert.ThrowsAsync<ArgumentNullException>("address", () => configurationRetriever.GetConfigurationAsync(null, null, CancellationToken.None)).ConfigureAwait(false);
             Assert.Equal(expectedErrorMessage, exception.Message);

--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Identity.Web.Test
     public class MicrosoftIdentityOptionsTests
     {
         private MicrosoftIdentityOptions microsoftIdentityOptions;
-        private const string AzureAd = "AzureAd";
-        private const string AzureAdB2C = "AzureAdB2C";
+        private const string AzureAd = Constants.AzureAd;
+        private const string AzureAdB2C = Constants.AzureAdB2C;
 
         [Fact]
         public void IsB2C_NotNullOrEmptyUserFlow_ReturnsTrue()
@@ -78,10 +78,10 @@ namespace Microsoft.Identity.Web.Test
 
         private void CheckReturnValueAgainstExpectedMissingParam(MissingParam missingParam, ValidateOptionsResult result)
         {
-            if (result.Failed == true)
+            if (result.Failed)
             {
-                string msg = string.Format(CultureInfo.InvariantCulture, "The '{0}' option must be provided.", missingParam);
-                Assert.Equal(msg, result.FailureMessage);
+                string message = string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, missingParam);
+                Assert.Equal(message, result.FailureMessage);
             }
             else
             {

--- a/tests/Microsoft.Identity.Web.Test/Resource/RolesRequiredHttpContextExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RolesRequiredHttpContextExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -43,7 +44,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             var acceptedRoles = new[] { "access_as_application", "access_as_application_for_write" };
             var actualRoles = new[] { "access_as_application_for_read_all_directory", "access_as_application_for_read" };
-            var expectedErrorMessage = $"The 'roles' or 'role' claim does not contain roles '{string.Join(",", acceptedRoles)}' or was not found";
+            var expectedErrorMessage = string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.MissingRoles, string.Join(",", acceptedRoles));
             var expectedStatusCode = (int)HttpStatusCode.Forbidden;
 
             var httpContext = HttpContextUtilities.CreateHttpContext(actualRoles);

--- a/tests/Microsoft.Identity.Web.Test/Resource/ScopesRequiredHttpContextExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/ScopesRequiredHttpContextExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Identity.Web.Resource;
@@ -42,7 +43,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             var acceptedScopes = new[] { "acceptedScope1", "acceptedScope2" };
             var actualScopes = new[] { "acceptedScope3", "acceptedScope4" };
-            var expectedErrorMessage = $"The 'scope' or 'scp' claim does not contain scopes '{string.Join(",", acceptedScopes)}' or was not found";
+            var expectedErrorMessage = string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.MissingScopes, string.Join(",", acceptedScopes));
             var expectedStatusCode = (int)HttpStatusCode.Forbidden;
 
             var httpContext = HttpContextUtilities.CreateHttpContext(actualScopes);


### PR DESCRIPTION
Moved most of literals into constants classes. Left some as literals (like Regex values in SamSite code) since that seems more readable. Left other literals since they're kind of generic, but feel free to refactor. Updated some exception messages, which would be considered breaking change.