### PR TITLE
Update to .NET Preview 7.

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET Core 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100-preview.5.20279.10
+        dotnet-version: 5.0.100-preview.7.20366.6
         includePreviewVersions: true # Required for preview versions
     - name: Build with dotnet
       run: dotnet test -f net5.0 -p:FROM_GITHUB_ACTION=true --configuration Release Microsoft.Identity.Web.sln

--- a/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Identity.Web
     /// </summary>
     internal static class IDWebErrorMessage
     {
-        // General
-        // public const string IDW10000 = "IDW10000:";
+        // General IDW10000 = "IDW10000:"
+        public const string HttpContextIsNull = "IDW10000: HttpContext is null. ";
 
         // Configuration IDW10100 = "IDW10100:"
         public const string ProvideEitherScopeKeySectionOrScopes = "IDW10101: Either provide the '{0}' or the '{1}' to the 'AuthorizeForScopes'. ";

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.0-preview.6.20312.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.0-preview.6.20312.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.0-preview.7.20365.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.0-preview.7.20365.19" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">

--- a/src/Microsoft.Identity.Web/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web/ServiceCollectionExtensions.cs
@@ -61,12 +61,12 @@ namespace Microsoft.Identity.Web
             if (isTokenAcquisitionSingleton)
             {
                 services.AddSingleton<ITokenAcquisition, TokenAcquisition>();
-                services.AddSingleton<ITokenAcquisitionInternal>(s => (ITokenAcquisitionInternal)s.GetService<ITokenAcquisition>());
+                services.AddSingleton<ITokenAcquisitionInternal>(s => (ITokenAcquisitionInternal)s.GetRequiredService<ITokenAcquisition>());
             }
             else
             {
                 services.AddScoped<ITokenAcquisition, TokenAcquisition>();
-                services.AddScoped<ITokenAcquisitionInternal>(s => (ITokenAcquisitionInternal)s.GetService<ITokenAcquisition>());
+                services.AddScoped<ITokenAcquisitionInternal>(s => (ITokenAcquisitionInternal)s.GetRequiredService<ITokenAcquisition>());
             }
 
             return services;

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Web
 
         private IConfidentialClientApplication? _application;
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private HttpContext CurrentHttpContext => _httpContextAccessor.HttpContext;
+        private HttpContext? CurrentHttpContext => _httpContextAccessor.HttpContext;
         private readonly IMsalHttpClientFactory _httpClientFactory;
         private readonly ILogger _logger;
 
@@ -219,7 +219,7 @@ namespace Microsoft.Identity.Web
             {
                 accessToken = await GetAccessTokenOnBehalfOfUserFromCacheAsync(
                     _application,
-                    user ?? CurrentHttpContext.User,
+                    user ?? CurrentHttpContext?.User,
                     scopes,
                     tenant,
                     userFlow)
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Web
 
                 // to get a token for a Web API on behalf of the user, but not necessarily with the on behalf of OAuth2.0
                 // flow as this one only applies to Web APIs.
-                JwtSecurityToken? validatedToken = CurrentHttpContext.GetTokenUsedToCallWebAPI();
+                JwtSecurityToken? validatedToken = CurrentHttpContext?.GetTokenUsedToCallWebAPI();
 
                 // Case of Web APIs: we need to do an on-behalf-of flow
                 if (validatedToken != null)
@@ -417,7 +417,7 @@ namespace Microsoft.Identity.Web
         /// <param name="userFlow">Azure AD B2C user flow to target.</param>
         private async Task<string> GetAccessTokenOnBehalfOfUserFromCacheAsync(
             IConfidentialClientApplication application,
-            ClaimsPrincipal claimsPrincipal,
+            ClaimsPrincipal? claimsPrincipal,
             IEnumerable<string> scopes,
             string? tenant,
             string? userFlow = null)
@@ -425,14 +425,14 @@ namespace Microsoft.Identity.Web
             IAccount? account = null;
             if (_microsoftIdentityOptions.IsB2C && !string.IsNullOrEmpty(userFlow))
             {
-                string? nameIdentifierId = claimsPrincipal.GetNameIdentifierId();
-                string? utid = claimsPrincipal.GetHomeTenantId();
+                string? nameIdentifierId = claimsPrincipal?.GetNameIdentifierId();
+                string? utid = claimsPrincipal?.GetHomeTenantId();
                 string? b2cAccountIdentifier = string.Format(CultureInfo.InvariantCulture, "{0}-{1}.{2}", nameIdentifierId, userFlow, utid);
                 account = await application.GetAccountAsync(b2cAccountIdentifier).ConfigureAwait(false);
             }
             else
             {
-                string? accountIdentifier = claimsPrincipal.GetMsalAccountId();
+                string? accountIdentifier = claimsPrincipal?.GetMsalAccountId();
 
                 if (accountIdentifier != null)
                 {
@@ -544,6 +544,11 @@ namespace Microsoft.Identity.Web
                 };
 
             string parameterString = string.Join(", ", parameters.Select(p => $"{p.Key}=\"{p.Value}\""));
+
+            if (CurrentHttpContext == null)
+            {
+                throw new InvalidOperationException(IDWebErrorMessage.HttpContextIsNull);
+            }
 
             var httpResponse = CurrentHttpContext.Response;
             var headers = httpResponse.Headers;

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
@@ -66,7 +66,16 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
 
             services.AddHttpContextAccessor();
             services.AddScoped<IMsalTokenCacheProvider, MsalSessionTokenCacheProvider>();
-            services.TryAddScoped(provider => provider.GetService<IHttpContextAccessor>().HttpContext.Session);
+            services.TryAddScoped(provider =>
+            {
+                var httpContext = provider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+                if (httpContext == null)
+                {
+                    throw new InvalidOperationException(IDWebErrorMessage.HttpContextIsNull);
+                }
+
+                return httpContext.Session;
+            });
 
             return services;
         }
@@ -137,7 +146,16 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
                 option.Cookie.IsEssential = true;
             });
             services.AddScoped<IMsalTokenCacheProvider, MsalSessionTokenCacheProvider>();
-            services.TryAddScoped(provider => provider.GetService<IHttpContextAccessor>().HttpContext.Session);
+            services.TryAddScoped(provider =>
+            {
+                var httpContext = provider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+                if (httpContext == null)
+                {
+                    throw new InvalidOperationException(IDWebErrorMessage.HttpContextIsNull);
+                }
+
+                return httpContext.Session;
+            });
 
             return services;
         }
@@ -176,7 +194,16 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
                     option.Cookie.IsEssential = true;
                 });
             services.AddScoped<IMsalTokenCacheProvider, MsalSessionTokenCacheProvider>();
-            services.TryAddScoped(provider => provider.GetService<IHttpContextAccessor>().HttpContext.Session);
+            services.TryAddScoped(provider =>
+            {
+                var httpContext = provider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+                if (httpContext == null)
+                {
+                    throw new InvalidOperationException(IDWebErrorMessage.HttpContextIsNull);
+                }
+
+                return httpContext.Session;
+            });
 
             return services;
         }


### PR DESCRIPTION
Updates to [Preview 7](https://dotnet.microsoft.com/download/dotnet/5.0):
- JwtBearer and OpenIdConnect packages
- .NET version in the GitHub Build action

- This update adds 11 additional warnings related to nullable references.
- VS also seems to have trouble finding a specific version (3.7) of Microsoft.CodeAnalysis libraries in Preview 7 binaries.