### PR TITLE
Jmprieur/final templates cleanup

### DIFF
--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
@@ -95,7 +95,7 @@
             "Shared/LoginDisplay.WindowsAuth.razor"
           ]
         },
-	{
+        {
           "condition": "(IndividualB2CAuth)",
           "rename": {
             "Shared/LoginDisplay.IndividualB2CAuth.razor": "Shared/LoginDisplay.razor"
@@ -288,7 +288,7 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Whether to exclude launchSettings.json in the generated template."
+      "description": "Whether to exclude launchSettings.json from the generated template."
     },
     "HttpPort": {
       "type": "parameter",
@@ -448,19 +448,6 @@
   ],
   "defaultName": "WebApplication",
   "postActions": [
-  {
-     "condition": "(GenerateGraph)",
-     "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-     "description": "Adds Microsoft Graph package.",
-    "manualInstructions": [
-    ],
-    "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Graph",
-        "version": "3.8.0"
-    },
-   "continueOnError": true
-  },
     {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/BlazorServerWeb-CSharp.csproj
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/BlazorServerWeb-CSharp.csproj
@@ -5,5 +5,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Web" Version="0.2.1-preview" />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.1-preview" />
+<!--#if (GenerateGraph) -->
+  <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
+<!--#endif -->
   </ItemGroup>
 </Project>

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/appsettings.json
@@ -6,6 +6,11 @@
 //    "CallbackPath": "/signin-oidc",
 //    "Domain": "qualified.domain.name",
 //    "SignedOutCallbackPath": "/signout/MySignUpSignInPolicyId",
+//#if (GenerateApi)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+//#endif
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
 //    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
 //    "EditProfilePolicyId": "MyEditProfilePolicyId"
@@ -20,13 +25,14 @@
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-////#if (GenerateApiOrGraph)
+//#if (GenerateApiOrGraph)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
 //    ],
-////#endif
+//#endif
 //    "CallbackPath": "/signin-oidc"
 //  },
+////#endif
 ////#if (GenerateApiOrGraph)
 //    "CalledApi": {
 //    /*
@@ -40,16 +46,15 @@
 //    "CalledApiUrl": "[WebApiUrl]"
 //   },
 ////#endif
-//#endif
 ////#if (IndividualLocalAuth)
 //  "ConnectionStrings": {
-////#if (UseLocalDB)
+//#if (UseLocalDB)
 //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-BlazorServerWeb-CSharp-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
-////#else
+//#else
 //    "DefaultConnection": "DataSource=app.db;Cache=Shared"
 //#endif
 //  },
-//#endif
+////#endif
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/appsettings.json
@@ -20,7 +20,7 @@
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-////#if (GenerateApi)
+////#if (GenerateApiOrGraph)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
 //    ],
@@ -46,7 +46,7 @@
 ////#if (UseLocalDB)
 //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-BlazorServerWeb-CSharp-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
 ////#else
-//    "DefaultConnection": "DataSource=app.db"
+//    "DefaultConnection": "DataSource=app.db;Cache=Shared"
 //#endif
 //  },
 //#endif

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "name": "Blazor WebAssembly App",
   "defaultName": "WebApplication",
   "description": "A project template for creating a Blazor app that runs on WebAssembly and is optionally hosted by an ASP.NET Core app. This template can be used for web apps with rich dynamic user interfaces (UIs).",
-  "groupIdentity": "Microsoft.Web.Blazor.Wasm",
+  "groupIdentity": "Microsoft.Web.Blazor2.Wasm",
   "precedence": "6002",
   "guids": [
     "4C26868E-5E7C-458D-82E3-040509D0C71F",
@@ -19,7 +19,7 @@
     "09732173-2cef-46b7-83db-1334bcb079d3", // Tenant ID
     "53bc9b9d-9d6a-45d4-8429-2a2761773502" // Client ID
   ],
-  "identity": "Microsoft.Web.Blazor.Wasm.CSharp.5.0",
+  "identity": "Microsoft.Web.Blazor.Wasm2.CSharp.5.0",
   "thirdPartyNotices": "https://aka.ms/aspnetcore/5.0-third-party-notices",
   "preferNameDirectory": true,
   "primaryOutputs": [
@@ -496,14 +496,14 @@
     "GenerateApiOrGraph": {
         "type": "computed",
         "value": "(GenerateApi || GenerateGraph)"
-    }    
+    }
   },
   "tags": {
     "language": "C#",
     "type": "project"
   },
   "postActions": [
-  {
+    {
       "condition": "(!skipRestore && Hosted)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
@@ -53,8 +53,6 @@ namespace ComponentsWebAssembly_CSharp.Server.Controllers
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
             string downstreamApiResult = await _downstreamWebApi.CallWebApi();
-            // You can also specify the relative endpoint and the scopes
-            // downstreamApiResult = await _downstreamWebApi.CallWebApi("me", new string[] {"user.read"});
 
             var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/appsettings.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/appsettings.json
@@ -24,7 +24,7 @@
     //    "TenantId": "22222222-2222-2222-2222-222222222222",
     //#endif
     //    "ClientId": "11111111-1111-1111-11111111111111111",
-    ////#if (GenerateApi)
+    //#if (GenerateApiOrGraph)
     //    "ClientSecret": "secret-from-app-registration",
     //    "ClientCertificates" : [
     //    ],

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/appsettings.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/appsettings.json
@@ -12,6 +12,11 @@
     //    "Instance": "https:////aadB2CInstance.b2clogin.com/",
     //    "ClientId": "11111111-1111-1111-11111111111111111",
     //    "Domain": "qualified.domain.name",
+    //#if (GenerateApi)
+    //    "ClientSecret": "secret-from-app-registration",
+    //    "ClientCertificates" : [
+    //    ],
+    //#endif
     //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
     //  },
     ////#elseif (OrganizationalAuth)
@@ -28,9 +33,10 @@
     //    "ClientSecret": "secret-from-app-registration",
     //    "ClientCertificates" : [
     //    ],
-    ////#endif
+//#endif
     //    "CallbackPath": "/signin-oidc"
     //  },
+////#endif
     ////#if (GenerateApiOrGraph)
     //    "CalledApi": {
     //    /*
@@ -44,9 +50,6 @@
     //    "CalledApiUrl": "[WebApiUrl]"
     //   },
     ////#endif
-    //#endif
-    //  },
-    //#endif
     "Logging": {
         "LogLevel": {
             "Default": "Information",

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/template.json
@@ -360,19 +360,19 @@
         "datatype": "string",
         "replaces": "[WebApiUrl]",
         "defaultValue" : "https://graph.microsoft.com/v1.0/me",
-        "description": "URL of the API to call from the web app."
+        "description": "URL of the API to call from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified."
     },
     "CallsMicrosoftGraph": {
         "type": "parameter",
         "datatype": "bool",
         "defaultValue": "false",
-        "description": "Specifies if the web app calls Microsoft Graph."
+        "description": "Specifies if the web app calls Microsoft Graph. This option only applies if --auth SingleOrg or --auth MultiOrg is specified."
     },
     "CalledApiScopes": {
       "type": "parameter",
       "datatype": "string",
       "replaces" :  "user.read",
-      "description": "Scopes to request to call the API from the web app."
+      "description": "Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified."
     },
     "GenerateApi": {
         "type": "computed",
@@ -380,7 +380,7 @@
     },
     "GenerateGraph": {
         "type": "computed",
-        "value": "((IndividualB2CAuth || OrganizationalAuth) && CallsMicrosoftGraph)"
+        "value": "(OrganizationalAuth && CallsMicrosoftGraph)"
     },
     "GenerateApiOrGraph": {
         "type": "computed",
@@ -394,19 +394,6 @@
   ],
   "defaultName": "WebApplication",
   "postActions": [
-    {
-      "condition": "(GenerateGraph)",
-      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-       "description": "Adds Microsoft Graph package.",
-      "manualInstructions": [
-      ],
-      "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Graph",
-        "version": "3.8.0"
-      },
-     "continueOnError": true
-    },
     {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/Company.WebApplication1.csproj
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/Company.WebApplication1.csproj
@@ -5,5 +5,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Web" Version="0.2.1-preview" />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.1-preview" />
+<!--#if (GenerateGraph) -->
+    <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
+<!--#endif -->     
   </ItemGroup>
 </Project>

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/Pages/Index.cshtml.cs
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/Pages/Index.cshtml.cs
@@ -37,10 +37,6 @@ namespace Company.WebApplication1.Pages
         public async Task OnGet()
         {
             ViewData["ApiResult"] = await _downstreamWebApi.CallWebApi();
-
-            // You can also specify the relative endpoint and the scopes
-            // ViewData["ApiResult"] = await _downstreamWebApi.CallWebApi("me",
-            //                                                             new string[] {"user.read"});
         }
 #elseif (GenerateGraph)
         private readonly GraphServiceClient _graphServiceClient;

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/Pages/Index.cshtml.cs
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/Pages/Index.cshtml.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Identity.Web;
 using System.Net;
 using System.Net.Http;
-using Company.WebApplication1;
 #endif
 #if (GenerateGraph)
 using Microsoft.Graph;

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/Services/MicrosoftGraphServiceExtensions.cs
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/Services/MicrosoftGraphServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace Company.WebApplication1
         /// <param name="initialScopes">Initial scopes.</param>
         /// <param name="graphBaseUrl">Base URL for Microsoft graph. This can be
         /// changed for instance for applications running in national clouds</param>
-        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services, 
+        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services,
                                              IEnumerable<string> initialScopes,
                                              string graphBaseUrl = "https://graph.microsoft.com/v1.0")
         {
@@ -30,6 +30,7 @@ namespace Company.WebApplication1
                             new GraphServiceClient(graphBaseUrl, new TokenAcquisitionCredentialProvider(tokenAquisitionService, initialScopes));
                 return client;
             });
+
             return services;
         }
     }

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/appsettings.json
@@ -5,6 +5,11 @@
 //    "ClientId": "11111111-1111-1111-11111111111111111",
 //    "CallbackPath": "/signin-oidc",
 //    "Domain": "qualified.domain.name",
+//#if (GenerateApi)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+//#endif
 //    "SignedOutCallbackPath": "/signout/MySignUpSignInPolicyId",
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
 //    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
@@ -20,13 +25,14 @@
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-////#if (GenerateApiOrGraph)
+//#if (GenerateApiOrGraph)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
 //    ],
-////#endif
+//#endif
 //    "CallbackPath": "/signin-oidc"
 //  },
+////#endif
 ////#if (GenerateApiOrGraph)
 //  "CalledApi": {
 //    /*
@@ -40,16 +46,15 @@
 //    "CalledApiUrl": "[WebApiUrl]"
 //  },
 ////#endif
-//#endif
 ////#if (IndividualLocalAuth)
 //  "ConnectionStrings": {
-////#if (UseLocalDB)
+//#if (UseLocalDB)
 //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
-////#else
+//#else
 //    "DefaultConnection": "DataSource=app.db;Cache=Shared"
 //#endif
 //  },
-//#endif
+////#endif
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/appsettings.json
@@ -20,7 +20,7 @@
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-////#if (GenerateApi)
+////#if (GenerateApiOrGraph)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
 //    ],
@@ -28,7 +28,7 @@
 //    "CallbackPath": "/signin-oidc"
 //  },
 ////#if (GenerateApiOrGraph)
-//    "CalledApi": {
+//  "CalledApi": {
 //    /*
 //     'CalledApiScopes' contains space separated scopes of the Web API you want to call. This can be:
 //      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
@@ -38,7 +38,7 @@
 //    */
 //    "CalledApiScopes": "user.read",
 //    "CalledApiUrl": "[WebApiUrl]"
-//   },
+//  },
 ////#endif
 //#endif
 ////#if (IndividualLocalAuth)

--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
@@ -356,19 +356,19 @@
         "datatype": "string",
         "replaces": "[WebApiUrl]",
         "defaultValue" : "https://graph.microsoft.com/v1.0/me",
-        "description": "URL of the API to call from the web app."
+        "description": "URL of the API to call from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified."
     },
     "CallsMicrosoftGraph": {
         "type": "parameter",
         "datatype": "bool",
         "defaultValue": "false",
-        "description": "Specifies if the web app calls Microsoft Graph."
+        "description": "Specifies if the web app calls Microsoft Graph. This option only applies if --auth SingleOrg or --auth MultiOrg is specified."
     },
     "CalledApiScopes": {
       "type": "parameter",
       "datatype": "string",
       "replaces" :  "user.read",
-      "description": "Scopes to request to call the API from the web app."
+      "description": "Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified."
     },
     "GenerateApi": {
         "type": "computed",
@@ -376,7 +376,7 @@
     },
     "GenerateGraph": {
         "type": "computed",
-        "value": "((IndividualB2CAuth || OrganizationalAuth) && CallsMicrosoftGraph)"
+        "value": "(OrganizationalAuth && CallsMicrosoftGraph)"
     },
     "GenerateApiOrGraph": {
         "type": "computed",
@@ -390,29 +390,16 @@
   ],
   "defaultName": "WebApplication",
   "postActions": [
-  {
-     "condition": "(CallsMicrosoftGraph)",
-     "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-     "description": "Adds Microsoft Graph package.",
-    "manualInstructions": [
-    ],
-    "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Graph",
-        "version": "3.8.0"
-    },
-   "continueOnError": true
-  },
-  {
-    "condition": "(!skipRestore)",
-    "description": "Restore NuGet packages required by this project.",
-    "manualInstructions": [
-      {
-        "text": "Run 'dotnet restore'"
-      }
-    ],
-    "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-    "continueOnError": true
-  }
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
   ]
 }

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Company.WebApplication1.csproj
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Company.WebApplication1.csproj
@@ -7,5 +7,6 @@
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.1-preview" />
 <!--#if (GenerateGraph) -->
     <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
-<!--#endif -->   </ItemGroup>
+<!--#endif -->
+  </ItemGroup>
 </Project>

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Company.WebApplication1.csproj
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Company.WebApplication1.csproj
@@ -5,5 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Web" Version="0.2.1-preview" />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.1-preview" />
-  </ItemGroup>
+<!--#if (GenerateGraph) -->
+    <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
+<!--#endif -->   </ItemGroup>
 </Project>

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Identity.Web;
 using System.Net;
 using System.Net.Http;
-using Company.WebApplication1;
 #endif
 #if (GenerateGraph)
 using Microsoft.Graph;

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
@@ -42,10 +42,6 @@ namespace Company.WebApplication1.Controllers
         public async Task<IActionResult> Index()
         {
             ViewData["ApiResult"] = await _downstreamWebApi.CallWebApi();
-
-            // You can also specify the relative endpoint and the scopes
-            // ViewData["ApiResult"] = await _downstreamWebApi.CallWebApi("me", new string[] {"user.read"});
-
             return View();
         }
 #elseif (GenerateGraph)

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Services/MicrosoftGraphServiceExtensions.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Services/MicrosoftGraphServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace Company.WebApplication1
         /// <param name="initialScopes">Initial scopes.</param>
         /// <param name="graphBaseUrl">Base URL for Microsoft graph. This can be
         /// changed for instance for applications running in national clouds</param>
-        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services, 
+        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services,
                                              IEnumerable<string> initialScopes,
                                              string graphBaseUrl = "https://graph.microsoft.com/v1.0")
         {
@@ -30,6 +30,7 @@ namespace Company.WebApplication1
                             new GraphServiceClient(graphBaseUrl, new TokenAcquisitionCredentialProvider(tokenAquisitionService, initialScopes));
                 return client;
             });
+
             return services;
         }
     }

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Startup.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Startup.cs
@@ -41,9 +41,6 @@ using Microsoft.Extensions.Hosting;
 #if(MultiOrgAuth)
 using Microsoft.IdentityModel.Tokens;
 #endif
-#if (GenerateApiOrGraph)
-using Company.WebApplication1;
-#endif
 #if (GenerateGraph)
 using Microsoft.Graph;
 #endif

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Views/Home/Index.cshtml
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Views/Home/Index.cshtml
@@ -8,5 +8,6 @@
 </div>
     @* #if(GenerateApiOrGraph)
 <div>Api result</div>
+
 <div>@ViewData["ApiResult"]</div>
     #endif*@

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -3,12 +3,17 @@
 //  "AzureAdB2C": {
 //    "Instance": "https:////login.microsoftonline.com/tfp/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-//    "CallbackPath": "/signin-oidc",
 //    "Domain": "qualified.domain.name",
 //    "SignedOutCallbackPath": "/signout/MySignUpSignInPolicyId",
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
 //    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
-//    "EditProfilePolicyId": "MyEditProfilePolicyId"
+//    "EditProfilePolicyId": "MyEditProfilePolicyId",
+//#if (GenerateApi)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+//#endif
+//    "CallbackPath": "/signin-oidc"
 //  },
 ////#elseif (OrganizationalAuth)
 //  "AzureAd": {
@@ -20,13 +25,15 @@
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-////#if (GenerateApiOrGraph)
+
+//#if (GenerateApiOrGraph)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
 //    ],
-////#endif
+//#endif
 //    "CallbackPath": "/signin-oidc"
 //  },
+////#endif
 ////#if (GenerateApiOrGraph)
 //  "CalledApi": {
 //    /*
@@ -40,16 +47,15 @@
 //    "CalledApiUrl": "[WebApiUrl]"
 //  },
 ////#endif
-//#endif
 ////#if (IndividualLocalAuth)
 //  "ConnectionStrings": {
-////#if (UseLocalDB)
+//#if (UseLocalDB)
 //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
-////#else
+//#else
 //    "DefaultConnection": "DataSource=app.db;Cache=Shared"
 //#endif
 //  },
-//#endif
+////#endif
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -20,7 +20,7 @@
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-////#if (GenerateApi)
+////#if (GenerateApiOrGraph)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
 //    ],
@@ -28,9 +28,9 @@
 //    "CallbackPath": "/signin-oidc"
 //  },
 ////#if (GenerateApiOrGraph)
-//    "CalledApi": {
+//  "CalledApi": {
 //    /*
-//     'CalledApiScope' is the scope of the Web API you want to call. This can be:
+//     'CalledApiScopes' contains space separated scopes of the Web API you want to call. This can be:
 //      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
 //      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
 //        App ID URI of a legacy v1 Web application
@@ -38,7 +38,7 @@
 //    */
 //    "CalledApiScopes": "user.read",
 //    "CalledApiUrl": "[WebApiUrl]"
-//   },
+//  },
 ////#endif
 //#endif
 ////#if (IndividualLocalAuth)

--- a/ProjectTemplates/templates/WebApi-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/.template.config/template.json
@@ -252,19 +252,19 @@
         "datatype": "string",
         "replaces": "[WebApiUrl]",
         "defaultValue" : "https://graph.microsoft.com/v1.0/me",
-        "description": "URL of the API to call from the web app."
+        "description": "URL of the API to call from the web app. This option only applies if --auth SingleOrg or --auth IndividualB2C is specified."
     },
     "CallsMicrosoftGraph": {
         "type": "parameter",
         "datatype": "bool",
         "defaultValue": "false",
-        "description": "Specifies if the web app calls Microsoft Graph."
+        "description": "Specifies if the web app calls Microsoft Graph. This option only applies if --auth SingleOrg is specified."
     },
     "CalledApiScopes": {
       "type": "parameter",
       "datatype": "string",
       "replaces" :  "user.read",
-      "description": "Scopes to request to call the API from the web app."
+      "description": "Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg or --auth IndividualB2C is specified."
     },
     "GenerateApi": {
         "type": "computed",
@@ -272,7 +272,7 @@
     },
     "GenerateGraph": {
         "type": "computed",
-        "value": "((IndividualB2CAuth || OrganizationalAuth) && CallsMicrosoftGraph)"
+        "value": "(OrganizationalAuth && CallsMicrosoftGraph)"
     },
     "GenerateApiOrGraph": {
         "type": "computed",
@@ -286,29 +286,16 @@
   ],
   "defaultName": "WebApplication",
   "postActions": [
-  {
-     "condition": "(CallsMicrosoftGraph)",
-     "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-     "description": "Adds Microsoft Graph package.",
-    "manualInstructions": [
-    ],
-    "args": {
-        "referenceType": "package",
-        "reference": "Microsoft.Graph",
-        "version": "3.8.0"
-    },
-   "continueOnError": true
-  },
-  {
-    "condition": "(!skipRestore)",
-    "description": "Restore NuGet packages required by this project.",
-    "manualInstructions": [
-      {
-        "text": "Run 'dotnet restore'"
-      }
-    ],
-    "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-    "continueOnError": true
-   }
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
   ]
 }

--- a/ProjectTemplates/templates/WebApi-CSharp/Company.WebApplication1.csproj
+++ b/ProjectTemplates/templates/WebApi-CSharp/Company.WebApplication1.csproj
@@ -4,5 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Web" Version="0.2.1-preview" />
+<!--#if (GenerateGraph) -->
+    <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
+<!--#endif -->    
   </ItemGroup>
 </Project>

--- a/ProjectTemplates/templates/WebApi-CSharp/Controllers/WeatherForecastController.cs
+++ b/ProjectTemplates/templates/WebApi-CSharp/Controllers/WeatherForecastController.cs
@@ -55,8 +55,6 @@ namespace Company.WebApplication1.Controllers
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
             string downstreamApiResult = await _downstreamWebApi.CallWebApi();
-            // You can also specify the relative endpoint and the scopes
-            // downstreamApiResult = await _downstreamWebApi.CallWebApi("me", new string[] {"user.read"});
 
             var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast

--- a/ProjectTemplates/templates/WebApi-CSharp/Controllers/WeatherForecastController.cs
+++ b/ProjectTemplates/templates/WebApi-CSharp/Controllers/WeatherForecastController.cs
@@ -10,14 +10,16 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Identity.Web;
 using System.Net;
 using System.Net.Http;
-using Company.WebApplication1;
 #endif
 #if (GenerateGraph)
 using Microsoft.Graph;
 #endif
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Identity.Web.Resource;
 using Microsoft.Extensions.Logging;
+#if (OrganizationalAuth || IndividualB2CAuth)
+using Microsoft.Identity.Web.Resource;
+#endif
+
 namespace Company.WebApplication1.Controllers
 {
 #if (!NoAuth)
@@ -100,7 +102,7 @@ namespace Company.WebApplication1.Controllers
         [HttpGet]
         public IEnumerable<WeatherForecast> Get()
         {
-#if (!NoAuth)
+#if (OrganizationalAuth || IndividualB2CAuth)
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
 #endif

--- a/ProjectTemplates/templates/WebApi-CSharp/Services/MicrosoftGraphServiceExtensions.cs
+++ b/ProjectTemplates/templates/WebApi-CSharp/Services/MicrosoftGraphServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace Company.WebApplication1
         /// <param name="initialScopes">Initial scopes.</param>
         /// <param name="graphBaseUrl">Base URL for Microsoft graph. This can be
         /// changed for instance for applications running in national clouds</param>
-        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services, 
+        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services,
                                              IEnumerable<string> initialScopes,
                                              string graphBaseUrl = "https://graph.microsoft.com/v1.0")
         {
@@ -30,6 +30,7 @@ namespace Company.WebApplication1
                             new GraphServiceClient(graphBaseUrl, new TokenAcquisitionCredentialProvider(tokenAquisitionService, initialScopes));
                 return client;
             });
+
             return services;
         }
     }

--- a/ProjectTemplates/templates/WebApi-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/appsettings.json
@@ -1,44 +1,42 @@
 {
-    ////#if (IndividualB2CAuth)
-    //  "AzureAdB2C": {
-    //    "Instance": "https:////login.microsoftonline.com/tfp/",
-    //    "ClientId": "11111111-1111-1111-11111111111111111",
-    //    "Domain": "qualified.domain.name",
-    //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
-    //  },
-    ////#elseif (OrganizationalAuth)
-    //  "AzureAd": {
-    //#if (!SingleOrgAuth)
-    //    "Instance": "https:////login.microsoftonline.com/common",
-    //#else
-    //    "Instance": "https:////login.microsoftonline.com/",
-    //    "Domain": "qualified.domain.name",
-    //    "TenantId": "22222222-2222-2222-2222-222222222222",
-    //#endif
-    //    "ClientId": "11111111-1111-1111-11111111111111111",
-    ////#if (GenerateApi)
-    //    "ClientSecret": "secret-from-app-registration",
-    //    "ClientCertificates" : [
-    //    ],
-    ////#endif
-    //    "CallbackPath": "/signin-oidc"
-    //  },
-    ////#if (GenerateApiOrGraph)
-    //    "CalledApi": {
-    //    /*
-    //     'CalledApiScopes' contains space separated scopes of the Web API you want to call. This can be:
-    //      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
-    //      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
-    //        App ID URI of a legacy v1 Web application
-    //      Applications are registered in the https://portal.azure.com portal.
-    //    */
-    //    "CalledApiScopes": "user.read",
-    //    "CalledApiUrl": "[WebApiUrl]"
-    //   },
-    ////#endif
-    //#endif
-    //  },
-    //#endif
+////#if (IndividualB2CAuth)
+//  "AzureAdB2C": {
+//    "Instance": "https:////login.microsoftonline.com/tfp/",
+//    "ClientId": "11111111-1111-1111-11111111111111111",
+//    "Domain": "qualified.domain.name",
+//    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
+//  },
+////#elseif (OrganizationalAuth)
+//  "AzureAd": {
+//#if (!SingleOrgAuth)
+//    "Instance": "https:////login.microsoftonline.com/common",
+//#else
+//    "Instance": "https:////login.microsoftonline.com/",
+//    "Domain": "qualified.domain.name",
+//    "TenantId": "22222222-2222-2222-2222-222222222222",
+//#endif
+//    "ClientId": "11111111-1111-1111-11111111111111111",
+////#if (GenerateApiOrGraph)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+////#endif
+//    "CallbackPath": "/signin-oidc"
+//  },
+////#if (GenerateApiOrGraph)
+//  "CalledApi": {
+//    /*
+//     'CalledApiScopes' contains space separated scopes of the Web API you want to call. This can be:
+//      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
+//      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
+//        App ID URI of a legacy v1 Web application
+//      Applications are registered in the https://portal.azure.com portal.
+//    */
+//    "CalledApiScopes": "user.read",
+//    "CalledApiUrl": "[WebApiUrl]"
+//  },
+////#endif
+//#endif
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/ProjectTemplates/templates/WebApi-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/appsettings.json
@@ -4,6 +4,11 @@
 //    "Instance": "https:////login.microsoftonline.com/tfp/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
 //    "Domain": "qualified.domain.name",
+//#if (GenerateApi)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+//#endif
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
 //  },
 ////#elseif (OrganizationalAuth)
@@ -16,13 +21,15 @@
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-////#if (GenerateApiOrGraph)
+
+//#if (GenerateApiOrGraph)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
 //    ],
-////#endif
+//#endif
 //    "CallbackPath": "/signin-oidc"
 //  },
+////#endif
 ////#if (GenerateApiOrGraph)
 //  "CalledApi": {
 //    /*
@@ -36,7 +43,6 @@
 //    "CalledApiUrl": "[WebApiUrl]"
 //  },
 ////#endif
-//#endif
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/ProjectTemplates/test-templates.bat
+++ b/ProjectTemplates/test-templates.bat
@@ -9,270 +9,235 @@ mkdir tests
 cd tests
 dotnet new sln --name tests
 
-echo " Test Web app (No auth)"
-mkdir webapp-noauth
-cd webapp-noauth
+REM Razor web app
+mkdir webapp2
+cd webapp2
+echo "Test webapp2, no auth"
+mkdir webapp2-noauth
+cd webapp2-noauth
 dotnet new webapp2
-dotnet sln ..\tests.sln add webapp-noauth.csproj
+dotnet sln ..\..\tests.sln add webapp2-noauth.csproj
 cd ..
 
-echo " Test Web app (No auth)"
-mkdir mvcwebapp-noauth
-cd mvcwebapp-noauth
-dotnet new mvc2
-dotnet sln ..\tests.sln add mvcwebapp-noauth.csproj
-cd ..
-
-echo " Test Web API (No auth)"
-mkdir webapi-noauth
-cd webapi-noauth
-dotnet new webapi2
-dotnet sln ..\tests.sln add webapi-noauth.csproj
-cd ..
-
-
-echo " Test Web app (Microsoft identity platform, MVC, Single Org)"
-mkdir mvcwebapp
-cd mvcwebapp
-dotnet new mvc2 --auth SingleOrg
-dotnet sln ..\tests.sln add mvcwebapp.csproj
-cd ..
-
-echo " Test Web app (Microsoft identity platform, MVC, Multiple Orgs)"
-mkdir mvcwebapp-multi-org
-cd mvcwebapp-multi-org
-dotnet new mvc2 --auth MultiOrg
-dotnet sln ..\tests.sln add mvcwebapp-multi-org.csproj
-cd ..
-
-echo " Test Web app (MVC, Azure AD B2C)"
-mkdir mvcwebapp-b2c
-cd mvcwebapp-b2c
-dotnet new mvc2 --auth  IndividualB2C
-dotnet sln ..\tests.sln add mvcwebapp-b2c.csproj
-cd ..
-
-
-echo " Test Web app calling Web API (Microsoft identity platform, MVC, Single Org)"
-mkdir mvcwebapp-api
-cd mvcwebapp-api
-dotnet new mvc2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add mvcwebapp-api.csproj
-cd ..
-
-echo " Test Web app calling Web API  (Microsoft identity platform, MVC, Multiple Orgs)"
-mkdir mvcwebapp-multi-org-api
-cd mvcwebapp-multi-org-api
-dotnet new mvc2 --auth MultiOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add mvcwebapp-multi-org-api.csproj
-cd ..
-
-
-echo " Test Web app calling Microsoft Graph (Microsoft identity platform, MVC, Single Org)"
-mkdir mvcwebapp-graph
-cd mvcwebapp-graph
-dotnet new mvc2 --auth SingleOrg --calls-graph --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add mvcwebapp-graph.csproj
-cd ..
-
-echo " Test Web app calling Microsoft Graph (Microsoft identity platform, MVC, Multiple Orgs)"
-mkdir mvcwebapp-multi-org-graph
-cd mvcwebapp-multi-org-graph
-dotnet new mvc2 --auth MultiOrg --calls-graph --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add mvcwebapp-multi-org-graph.csproj
-cd ..
-
-
-echo " Test Web app calling Web API  (MVC, Azure AD B2C)"
-mkdir mvcwebapp-b2c-api
-cd mvcwebapp-b2c-api
-dotnet new mvc2 --auth  IndividualB2C --called-api-url "https://localhost:44332" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
-dotnet sln ..\tests.sln add mvcwebapp-b2c-api.csproj
-cd ..
-
-
-echo " Test Web app (Microsoft identity platform, Razor, Single Org)"
-mkdir webapp
-cd webapp
+echo "Test webapp2, single-org"
+mkdir webapp2-singleorg
+cd webapp2-singleorg
 dotnet new webapp2 --auth SingleOrg
-dotnet sln ..\tests.sln add webapp.csproj
+dotnet sln ..\..\tests.sln add webapp2-singleorg.csproj
 cd ..
 
-echo " Test Web app (Microsoft identity platform, Razor, Multiple Orgs)"
-mkdir webapp-multi-org
-cd webapp-multi-org
-dotnet new webapp2 --auth MultiOrg
-dotnet sln ..\tests.sln add webapp-multi-org.csproj
+echo "Test webapp2, single-org, calling microsoft graph"
+mkdir webapp2-singleorg-callsgraph
+cd webapp2-singleorg-callsgraph
+dotnet new webapp2 --auth SingleOrg --calls-graph
+dotnet sln ..\..\tests.sln add webapp2-singleorg-callsgraph.csproj
 cd ..
 
-echo " Test Web app (Razor, Azure AD B2C)"
-mkdir webapp-b2c
-cd webapp-b2c
-dotnet new webapp2 --auth  IndividualB2C
-dotnet sln ..\tests.sln add webapp-b2c.csproj
-cd ..
-
-echo " Test Web app calling Web API  (Microsoft identity platform, Razor, Single Org)"
-mkdir webapp-api
-cd webapp-api
+echo "Test webapp2, single-org, calling a downstream web api"
+mkdir webapp2-singleorg-callswebapi
+cd webapp2-singleorg-callswebapi
 dotnet new webapp2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add webapp-api.csproj
+dotnet sln ..\..\tests.sln add webapp2-singleorg-callswebapi.csproj
 cd ..
 
-echo " Test Web app calling Web API  (Microsoft identity platform, Razor, Multiple Orgs)"
-mkdir webapp-multi-org-api
-cd webapp-multi-org-api
-dotnet new webapp2 --auth MultiOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add webapp-multi-org-api.csproj
+echo "Test webapp2, b2c"
+mkdir webapp2-b2c
+cd webapp2-b2c
+dotnet new webapp2 --auth IndividualB2C
+dotnet sln ..\..\tests.sln add webapp2-b2c.csproj
 cd ..
 
-echo " Test Web app calling Web API (Razor, Azure AD B2C)"
-mkdir webapp-b2c-api
-cd webapp-b2c-api
-dotnet new webapp2 --auth  IndividualB2C --called-api-url "https://localhost:44332" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
-dotnet sln ..\tests.sln add webapp-b2c-api.csproj
+echo "Test webapp2, b2c, calling a downstream web api"
+mkdir webapp2-b2c-callswebapi
+cd webapp2-b2c-callswebapi
+dotnet new webapp2 --auth IndividualB2C --called-api-url "https://localhost:44332/api/todolist" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
+dotnet sln ..\..\tests.sln add webapp2-b2c-callswebapi.csproj
 cd ..
 
-echo " Test Web app calling Microsoft Graph (Microsoft identity platform, Razor, Single Org)"
-mkdir webapp-graph
-cd webapp-graph
-dotnet new webapp2 --auth SingleOrg --calls-graph --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add webapp-graph.csproj
 cd ..
 
-echo " Test Web app calling Microsoft Graph (Microsoft identity platform, Razor, Single Org)"
-mkdir webapp-graph-multiorg
-cd webapp-graph-multiorg
-dotnet new webapp2 --auth MultiOrg --calls-graph --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add webapp-graph-multiorg.csproj
+REM Web api
+mkdir webapi2
+cd webapi2
+echo "Test webapi2, no auth"
+mkdir webapi2-noauth
+cd webapi2-noauth
+dotnet new webapi2
+dotnet sln ..\..\tests.sln add webapi2-noauth.csproj
 cd ..
 
-
-echo " Test Web API  (Microsoft identity platform, SingleOrg)"
-mkdir webapi
-cd webapi
+echo "Test webapi2, single-org"
+mkdir webapi2-singleorg
+cd webapi2-singleorg
 dotnet new webapi2 --auth SingleOrg
-dotnet sln ..\tests.sln add webapi.csproj
+dotnet sln ..\..\tests.sln add webapi2-singleorg.csproj
 cd ..
 
-echo " Test Web API  (AzureAD B2C)"
-mkdir webapi-b2c
-cd webapi-b2c
-dotnet new webapi2 --auth IndividualB2C
-dotnet sln ..\tests.sln add webapi-b2c.csproj
-cd ..
-
-echo " Test Web API calling Web API (Microsoft identity platform, SingleOrg)"
-mkdir webapi-api
-cd webapi-api
-dotnet new webapi2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
-dotnet sln ..\tests.sln add webapi-api.csproj
-cd ..
-
-echo " Test Web API calling Web API (AzureAD B2C)"
-mkdir webapi-b2c-api
-cd webapi-b2c-api
-dotnet new webapi2 --auth IndividualB2C --called-api-url "https://localhost:44332" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
-dotnet sln ..\tests.sln add webapi-b2c-api.csproj
-cd ..
-
-echo " Test Web API calling Graph (Microsoft identity platform, SingleOrg)"
-mkdir webapi-graph
-cd webapi-graph
+echo "Test webapi2, single-org, calling microsoft graph"
+mkdir webapi2-singleorg-callsgraph
+cd webapi2-singleorg-callsgraph
 dotnet new webapi2 --auth SingleOrg --calls-graph
-dotnet sln ..\tests.sln add webapi-graph.csproj
+dotnet sln ..\..\tests.sln add webapi2-singleorg-callsgraph.csproj
 cd ..
 
+echo "Test webapi2, single-org, calling a downstream web api"
+mkdir webapi2-singleorg-callswebapi
+cd webapi2-singleorg-callswebapi
+dotnet new webapi2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
+dotnet sln ..\..\tests.sln add webapi2-singleorg-callswebapi.csproj
+cd ..
 
-mkdir blazor
-cd blazor
+echo "Test webapi2, b2c"
+mkdir webapi2-b2c
+cd webapi2-b2c
+dotnet new webapi2 --auth IndividualB2C
+dotnet sln ..\..\tests.sln add webapi2-b2c.csproj
+cd ..
 
-echo " Test Blazor app (No auth)"
-mkdir blazorserver
-cd blazorserver
+echo "Test webapi2, b2c, calling a downstream web api"
+mkdir webapi2-b2c-callswebapi
+cd webapi2-b2c-callswebapi
+dotnet new webapi2 --auth IndividualB2C --called-api-url "https://localhost:44332/api/todolist" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
+dotnet sln ..\..\tests.sln add webapi2-b2c-callswebapi.csproj
+cd ..
+
+cd ..
+
+REM MVC Web app
+mkdir mvc2
+cd mvc2
+echo "Test mvc2, no auth"
+mkdir mvc2-noauth
+cd mvc2-noauth
+dotnet new mvc2
+dotnet sln ..\..\tests.sln add mvc2-noauth.csproj
+cd ..
+
+echo "Test mvc2, single-org"
+mkdir mvc2-singleorg
+cd mvc2-singleorg
+dotnet new mvc2 --auth SingleOrg
+dotnet sln ..\..\tests.sln add mvc2-singleorg.csproj
+cd ..
+
+echo "Test mvc2, single-org, calling microsoft graph"
+mkdir mvc2-singleorg-callsgraph
+cd mvc2-singleorg-callsgraph
+dotnet new mvc2 --auth SingleOrg --calls-graph
+dotnet sln ..\..\tests.sln add mvc2-singleorg-callsgraph.csproj
+cd ..
+
+echo "Test mvc2, single-org, calling a downstream web api"
+mkdir mvc2-singleorg-callswebapi
+cd mvc2-singleorg-callswebapi
+dotnet new mvc2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
+dotnet sln ..\..\tests.sln add mvc2-singleorg-callswebapi.csproj
+cd ..
+
+echo "Test mvc2, b2c"
+mkdir mvc2-b2c
+cd mvc2-b2c
+dotnet new mvc2 --auth IndividualB2C
+dotnet sln ..\..\tests.sln add mvc2-b2c.csproj
+cd ..
+
+echo "Test mvc2, b2c, calling a downstream web api"
+mkdir mvc2-b2c-callswebapi
+cd mvc2-b2c-callswebapi
+dotnet new mvc2 --auth IndividualB2C --called-api-url "https://localhost:44332/api/todolist" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
+dotnet sln ..\..\tests.sln add mvc2-b2c-callswebapi.csproj
+cd ..
+
+cd ..
+
+REM Blazor server app
+mkdir blazorserver2
+cd blazorserver2
+echo "Test blazorserver2, no auth"
+mkdir blazorserver2-noauth
+cd blazorserver2-noauth
 dotnet new blazorserver2
-dotnet sln ..\..\tests.sln add blazorserver.csproj
+dotnet sln ..\..\tests.sln add blazorserver2-noauth.csproj
 cd ..
 
-echo " Test Blazor app (Microsoft identity platform, SingleOrg)"
-mkdir blazorserver-SingleOrg
-cd blazorserver-SingleOrg
+echo "Test blazorserver2, single-org"
+mkdir blazorserver2-singleorg
+cd blazorserver2-singleorg
 dotnet new blazorserver2 --auth SingleOrg
-dotnet sln ..\..\tests.sln add blazorserver-SingleOrg.csproj
+dotnet sln ..\..\tests.sln add blazorserver2-singleorg.csproj
 cd ..
 
-echo " Test Blazor app (AzureAD B2C)"
-mkdir blazorserver-b2c
-cd blazorserver-b2c
-dotnet new blazorserver2 --auth IndividualB2C
-dotnet sln ..\..\tests.sln add blazorserver-b2c.csproj
-cd ..
-
-echo " Test Blazor app  calling Web API (Microsoft identity platform, SingleOrg)"
-mkdir blazorserver-api
-cd blazorserver-api
-dotnet new blazorserver2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
-dotnet sln ..\..\tests.sln add blazorserver-api.csproj
-cd ..
-
-echo " Test Blazor app  calling Web API (AzureAD B2C)"
-mkdir blazorserver-b2c-api
-cd blazorserver-b2c-api
-dotnet new blazorserver2 --auth IndividualB2C --called-api-url "https://localhost:44332" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
-dotnet sln ..\..\tests.sln add blazorserver-b2c-api.csproj
-cd ..
-
-echo " Test Blazor app  calling Graph (Microsoft identity platform, SingleOrg)"
-mkdir blazorserver-graph
-cd blazorserver-graph
+echo "Test blazorserver2, single-org, calling microsoft graph"
+mkdir blazorserver2-singleorg-callsgraph
+cd blazorserver2-singleorg-callsgraph
 dotnet new blazorserver2 --auth SingleOrg --calls-graph
-dotnet sln ..\..\tests.sln add blazorserver-graph.csproj
+dotnet sln ..\..\tests.sln add blazorserver2-singleorg-callsgraph.csproj
 cd ..
 
-REM Blazor
+echo "Test blazorserver2, single-org, calling a downstream web api"
+mkdir blazorserver2-singleorg-callswebapi
+cd blazorserver2-singleorg-callswebapi
+dotnet new blazorserver2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
+dotnet sln ..\..\tests.sln add blazorserver2-singleorg-callswebapi.csproj
 cd ..
 
-REM Blazor web assembly
+echo "Test blazorserver2, b2c"
+mkdir blazorserver2-b2c
+cd blazorserver2-b2c
+dotnet new blazorserver2 --auth IndividualB2C
+dotnet sln ..\..\tests.sln add blazorserver2-b2c.csproj
+cd ..
+
+echo "Test blazorserver2, b2c, calling a downstream web api"
+mkdir blazorserver2-b2c-callswebapi
+cd blazorserver2-b2c-callswebapi
+dotnet new blazorserver2 --auth IndividualB2C --called-api-url "https://localhost:44332/api/todolist" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
+dotnet sln ..\..\tests.sln add blazorserver2-b2c-callswebapi.csproj
+cd ..
+
+cd ..
+
+REM Blazor web assembly app
 mkdir blazorwasm2
 cd blazorwasm2
-echo "Test blazorwasm2, no authentication, "
-mkdir blazorwasm2-noauth-nodownstreamapi
-cd blazorwasm2-noauth-nodownstreamapi
+echo "Test blazorwasm2, no auth"
+mkdir blazorwasm2-noauth
+cd blazorwasm2-noauth
 dotnet new blazorwasm2
-dotnet sln ..\..\tests.sln add blazorwasm2-noauth-nodownstreamapi.csproj
+dotnet sln ..\..\tests.sln add blazorwasm2-noauth.csproj
 cd ..
 
-echo "Test blazorwasm2, SingleOrg, "
-mkdir blazorwasm2-singleorg-nodownstreamapi
-cd blazorwasm2-singleorg-nodownstreamapi
+echo "Test blazorwasm2, single-org"
+mkdir blazorwasm2-singleorg
+cd blazorwasm2-singleorg
 dotnet new blazorwasm2 --auth SingleOrg
-dotnet sln ..\..\tests.sln add blazorwasm2-singleorg-nodownstreamapi.csproj
+dotnet sln ..\..\tests.sln add blazorwasm2-singleorg.csproj
 cd ..
 
-echo "Test blazorwasm2, SingleOrg, calling Microsoft Graph"
+echo "Test blazorwasm2, single-org, calling microsoft graph"
 mkdir blazorwasm2-singleorg-callsgraph
 cd blazorwasm2-singleorg-callsgraph
 dotnet new blazorwasm2 --auth SingleOrg --calls-graph
 dotnet sln ..\..\tests.sln add blazorwasm2-singleorg-callsgraph.csproj
 cd ..
 
-echo "Test blazorwasm2, SingleOrg, calling a web API"
+echo "Test blazorwasm2, single-org, calling a downstream web api"
 mkdir blazorwasm2-singleorg-callswebapi
 cd blazorwasm2-singleorg-callswebapi
 dotnet new blazorwasm2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read"
 dotnet sln ..\..\tests.sln add blazorwasm2-singleorg-callswebapi.csproj
 cd ..
 
-echo "Test blazorwasm2, SingleOrg,  hosted"
-mkdir blazorwasm2-singleorg-nodownstreamapi-hosted
-cd blazorwasm2-singleorg-nodownstreamapi-hosted
+echo "Test blazorwasm2, single-org, with hosted blazor web server web api"
+mkdir blazorwasm2-singleorg-hosted
+cd blazorwasm2-singleorg-hosted
 dotnet new blazorwasm2 --auth SingleOrg  --hosted
-dotnet sln ..\..\tests.sln add Shared\blazorwasm2-singleorg-nodownstreamapi-hosted.Shared.csproj
-dotnet sln ..\..\tests.sln add Server\blazorwasm2-singleorg-nodownstreamapi-hosted.Server.csproj
-dotnet sln ..\..\tests.sln add Client\blazorwasm2-singleorg-nodownstreamapi-hosted.Client.csproj
+dotnet sln ..\..\tests.sln add Shared\blazorwasm2-singleorg-hosted.Shared.csproj
+dotnet sln ..\..\tests.sln add Server\blazorwasm2-singleorg-hosted.Server.csproj
+dotnet sln ..\..\tests.sln add Client\blazorwasm2-singleorg-hosted.Client.csproj
 cd ..
 
-echo "Test blazorwasm2, SingleOrg, calling Microsoft Graph, hosted"
+echo "Test blazorwasm2, single-org, with hosted blazor web server web api, calling microsoft graph"
 mkdir blazorwasm2-singleorg-callsgraph-hosted
 cd blazorwasm2-singleorg-callsgraph-hosted
 dotnet new blazorwasm2 --auth SingleOrg --calls-graph --hosted
@@ -281,7 +246,7 @@ dotnet sln ..\..\tests.sln add Server\blazorwasm2-singleorg-callsgraph-hosted.Se
 dotnet sln ..\..\tests.sln add Client\blazorwasm2-singleorg-callsgraph-hosted.Client.csproj
 cd ..
 
-echo "Test blazorwasm2, SingleOrg, calling a web API, hosted"
+echo "Test blazorwasm2, single-org, with hosted blazor web server web api, calling a downstream web api"
 mkdir blazorwasm2-singleorg-callswebapi-hosted
 cd blazorwasm2-singleorg-callswebapi-hosted
 dotnet new blazorwasm2 --auth SingleOrg --called-api-url "https://graph.microsoft.com/beta/me" --called-api-scopes "user.read" --hosted
@@ -290,34 +255,32 @@ dotnet sln ..\..\tests.sln add Server\blazorwasm2-singleorg-callswebapi-hosted.S
 dotnet sln ..\..\tests.sln add Client\blazorwasm2-singleorg-callswebapi-hosted.Client.csproj
 cd ..
 
-echo "Test blazorwasm2, B2C, "
-mkdir blazorwasm2-b2c-nodownstreamapi
-cd blazorwasm2-b2c-nodownstreamapi
+echo "Test blazorwasm2, b2c"
+mkdir blazorwasm2-b2c
+cd blazorwasm2-b2c
 dotnet new blazorwasm2 --auth IndividualB2C
-dotnet sln ..\..\tests.sln add blazorwasm2-b2c-nodownstreamapi.csproj
+dotnet sln ..\..\tests.sln add blazorwasm2-b2c.csproj
 cd ..
 
-echo "Test blazorwasm2, B2C,  hosted"
-mkdir blazorwasm2-b2c-nodownstreamapi-hosted
-cd blazorwasm2-b2c-nodownstreamapi-hosted
+echo "Test blazorwasm2, b2c, with hosted blazor web server web api"
+mkdir blazorwasm2-b2c-hosted
+cd blazorwasm2-b2c-hosted
 dotnet new blazorwasm2 --auth IndividualB2C  --hosted
-dotnet sln ..\..\tests.sln add Shared\blazorwasm2-b2c-nodownstreamapi-hosted.Shared.csproj
-dotnet sln ..\..\tests.sln add Server\blazorwasm2-b2c-nodownstreamapi-hosted.Server.csproj
-dotnet sln ..\..\tests.sln add Client\blazorwasm2-b2c-nodownstreamapi-hosted.Client.csproj
+dotnet sln ..\..\tests.sln add Shared\blazorwasm2-b2c-hosted.Shared.csproj
+dotnet sln ..\..\tests.sln add Server\blazorwasm2-b2c-hosted.Server.csproj
+dotnet sln ..\..\tests.sln add Client\blazorwasm2-b2c-hosted.Client.csproj
 cd ..
 
-echo "Test blazorwasm2, B2C, calling a web API, hosted"
+echo "Test blazorwasm2, b2c, with hosted blazor web server web api, calling a downstream web api"
 mkdir blazorwasm2-b2c-callswebapi-hosted
 cd blazorwasm2-b2c-callswebapi-hosted
-dotnet new blazorwasm2 --auth IndividualB2C --called-api-url "https://localhost:44332" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read" --hosted
+dotnet new blazorwasm2 --auth IndividualB2C --called-api-url "https://localhost:44332/api/todolist" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read" --hosted
 dotnet sln ..\..\tests.sln add Shared\blazorwasm2-b2c-callswebapi-hosted.Shared.csproj
 dotnet sln ..\..\tests.sln add Server\blazorwasm2-b2c-callswebapi-hosted.Server.csproj
 dotnet sln ..\..\tests.sln add Client\blazorwasm2-b2c-callswebapi-hosted.Client.csproj
 cd ..
 
-REM Blazor web assembly
 cd ..
-
 
 echo "Build the solution with all the projects created by applying the templates"
 dotnet build


### PR DESCRIPTION
Resynchronizing the templates from ASP.NET Core and fixing issues discovered while testing:
- Client secrets/certificates sections need to be generated when GenerateApiOrGraph
- Replacing the post actions to install the MicrosoftGraph SDK by a conditional package reference in projects
- Removing unsued usings
- Ensuring that client secrets/certificates settings are available when needed
- Adressing Barry's feedback (unwanted comments in controllers and or blazor pages)


@JunTaoLuo 
@Tratcher