### PR TITLE
Fixes your build

### DIFF
--- a/build/template-nuget-pack.yaml
+++ b/build/template-nuget-pack.yaml
@@ -10,6 +10,7 @@ steps:
   inputs:
     command: pack
     projects: '${{ parameters.ProjectPath }}'
+    packagesToPack: '${{ parameters.ProjectPath }}'
     nobuild: '${{parameters.NoBuild}}'
     IncludeSymbols: true
     verbosityPack: normal


### PR DESCRIPTION
I added `packagesToPack` argument. This makes sure only the specified project is packed. Without it, it was packing all of the projects in the subdirectories and breaking on Blazor WebAssembly.

Feel free to just merge this.

More info:
[.NET Core CLI task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/dotnet-core-cli?view=azure-devops)