### PR TITLE
Fixes the build with the samples included, and fixes issues in templates

### DIFF
--- a/Microsoft.Identity.Web-without-blasorwasm2-sample.sln
+++ b/Microsoft.Identity.Web-without-blasorwasm2-sample.sln
@@ -1,0 +1,138 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29009.5
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Web", "src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj", "{BD795319-75B8-4251-AE92-8DD5A807C28E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Web.Test", "tests\Microsoft.Identity.Web.Test\Microsoft.Identity.Web.Test.csproj", "{E58562C3-A55D-48C8-AA9C-7D0FA7839367}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Web.UI", "src\Microsoft.Identity.Web.UI\Microsoft.Identity.Web.UI.csproj", "{AE164522-E929-4284-883E-511CB46712A3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{79310504-1334-4F14-93C4-1240913224BA}"
+	ProjectSection(SolutionItems) = preProject
+		tests\.editorconfig = tests\.editorconfig
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WebAppCallsWebApiCallsGraph", "WebAppCallsWebApiCallsGraph", "{DA125992-5622-4D9D-B7AB-79CDC45A66B0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "B2CWebAppCallsWebApi", "B2CWebAppCallsWebApi", "{48D133A6-50D7-4783-9048-148E4B4E1353}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoListClient", "tests\B2CWebAppCallsWebApi\Client\TodoListClient.csproj", "{D9C2BF2E-25C8-4BF0-9579-DF1F2AC7CA70}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoListService", "tests\B2CWebAppCallsWebApi\TodoListService\TodoListService.csproj", "{9EAE4CCD-EDEB-4FAE-B873-F24714F070A4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoListService", "tests\WebAppCallsWebApiCallsGraph\TodoListService\TodoListService.csproj", "{A6254A6A-B560-4DC1-8348-DED4D947ADCE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoListClient", "tests\WebAppCallsWebApiCallsGraph\Client\TodoListClient.csproj", "{829BA99E-0E31-4CEE-9A59-CD91531B5ED4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Web.Test.Integration", "tests\Microsoft.Identity.Web.Test.Integration\Microsoft.Identity.Web.Test.Integration.csproj", "{24DE8503-90EB-4788-A603-681DD4D7DB50}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Web.Test.Common", "tests\Microsoft.Identity.Web.Test.Common\Microsoft.Identity.Web.Test.Common.csproj", "{F37646FF-C346-4FF5-A111-2269952AB376}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Web.Test.LabInfrastructure", "tests\Microsoft.Identity.Web.Test.LabInfrastructure\Microsoft.Identity.Web.Test.LabInfrastructure.csproj", "{A9F4539F-51AB-4D98-9204-D76B336E0BE8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DotNet Core Templates", "DotNet Core Templates", "{D845507B-00E8-4506-954E-519CBC0B9F83}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2B919DEC-2539-4357-8E89-8C0CC9889FB4}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		stylecop.json = stylecop.json
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreMicrosoftIdentityWebProjectTemplates", "ProjectTemplates\AspNetCoreMicrosoftIdentityWebProjectTemplates.csproj", "{893905EA-94D6-4F71-957A-43B194751DC7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WebAppCallsGraph", "WebAppCallsGraph", "{6AD49ED7-8975-4B2F-B916-BBA8ABA280D2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebAppCallsMicrosoftGraph", "tests\WebAppCallsMicrosoftGraph\WebAppCallsMicrosoftGraph.csproj", "{FF8EED45-187A-4FBD-875F-334D8DC44990}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "blazorwasm2", "blazorwasm2", "{E7772A02-119A-41B1-9F97-CF6592120B7E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BlazorServerCallsGraph", "BlazorServerCallsGraph", "{5F8B4227-A996-4C4F-802E-C671BB934C93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "blazor", "tests\BlazorServerCallsGraph\blazor.csproj", "{744F5E2B-281C-4BC1-B9E1-D8C0530DC5E3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BD795319-75B8-4251-AE92-8DD5A807C28E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD795319-75B8-4251-AE92-8DD5A807C28E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD795319-75B8-4251-AE92-8DD5A807C28E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD795319-75B8-4251-AE92-8DD5A807C28E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E58562C3-A55D-48C8-AA9C-7D0FA7839367}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E58562C3-A55D-48C8-AA9C-7D0FA7839367}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E58562C3-A55D-48C8-AA9C-7D0FA7839367}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E58562C3-A55D-48C8-AA9C-7D0FA7839367}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE164522-E929-4284-883E-511CB46712A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE164522-E929-4284-883E-511CB46712A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE164522-E929-4284-883E-511CB46712A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE164522-E929-4284-883E-511CB46712A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9C2BF2E-25C8-4BF0-9579-DF1F2AC7CA70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9C2BF2E-25C8-4BF0-9579-DF1F2AC7CA70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9C2BF2E-25C8-4BF0-9579-DF1F2AC7CA70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9C2BF2E-25C8-4BF0-9579-DF1F2AC7CA70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EAE4CCD-EDEB-4FAE-B873-F24714F070A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EAE4CCD-EDEB-4FAE-B873-F24714F070A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EAE4CCD-EDEB-4FAE-B873-F24714F070A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EAE4CCD-EDEB-4FAE-B873-F24714F070A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6254A6A-B560-4DC1-8348-DED4D947ADCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6254A6A-B560-4DC1-8348-DED4D947ADCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6254A6A-B560-4DC1-8348-DED4D947ADCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6254A6A-B560-4DC1-8348-DED4D947ADCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{829BA99E-0E31-4CEE-9A59-CD91531B5ED4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{829BA99E-0E31-4CEE-9A59-CD91531B5ED4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{829BA99E-0E31-4CEE-9A59-CD91531B5ED4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{829BA99E-0E31-4CEE-9A59-CD91531B5ED4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24DE8503-90EB-4788-A603-681DD4D7DB50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24DE8503-90EB-4788-A603-681DD4D7DB50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24DE8503-90EB-4788-A603-681DD4D7DB50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24DE8503-90EB-4788-A603-681DD4D7DB50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F37646FF-C346-4FF5-A111-2269952AB376}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F37646FF-C346-4FF5-A111-2269952AB376}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F37646FF-C346-4FF5-A111-2269952AB376}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F37646FF-C346-4FF5-A111-2269952AB376}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9F4539F-51AB-4D98-9204-D76B336E0BE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9F4539F-51AB-4D98-9204-D76B336E0BE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9F4539F-51AB-4D98-9204-D76B336E0BE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9F4539F-51AB-4D98-9204-D76B336E0BE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{893905EA-94D6-4F71-957A-43B194751DC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{893905EA-94D6-4F71-957A-43B194751DC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{893905EA-94D6-4F71-957A-43B194751DC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{893905EA-94D6-4F71-957A-43B194751DC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF8EED45-187A-4FBD-875F-334D8DC44990}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF8EED45-187A-4FBD-875F-334D8DC44990}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF8EED45-187A-4FBD-875F-334D8DC44990}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF8EED45-187A-4FBD-875F-334D8DC44990}.Release|Any CPU.Build.0 = Release|Any CPU
+		{744F5E2B-281C-4BC1-B9E1-D8C0530DC5E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{744F5E2B-281C-4BC1-B9E1-D8C0530DC5E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{744F5E2B-281C-4BC1-B9E1-D8C0530DC5E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{744F5E2B-281C-4BC1-B9E1-D8C0530DC5E3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E58562C3-A55D-48C8-AA9C-7D0FA7839367} = {79310504-1334-4F14-93C4-1240913224BA}
+		{DA125992-5622-4D9D-B7AB-79CDC45A66B0} = {79310504-1334-4F14-93C4-1240913224BA}
+		{48D133A6-50D7-4783-9048-148E4B4E1353} = {79310504-1334-4F14-93C4-1240913224BA}
+		{D9C2BF2E-25C8-4BF0-9579-DF1F2AC7CA70} = {48D133A6-50D7-4783-9048-148E4B4E1353}
+		{9EAE4CCD-EDEB-4FAE-B873-F24714F070A4} = {48D133A6-50D7-4783-9048-148E4B4E1353}
+		{A6254A6A-B560-4DC1-8348-DED4D947ADCE} = {DA125992-5622-4D9D-B7AB-79CDC45A66B0}
+		{829BA99E-0E31-4CEE-9A59-CD91531B5ED4} = {DA125992-5622-4D9D-B7AB-79CDC45A66B0}
+		{24DE8503-90EB-4788-A603-681DD4D7DB50} = {79310504-1334-4F14-93C4-1240913224BA}
+		{F37646FF-C346-4FF5-A111-2269952AB376} = {79310504-1334-4F14-93C4-1240913224BA}
+		{A9F4539F-51AB-4D98-9204-D76B336E0BE8} = {79310504-1334-4F14-93C4-1240913224BA}
+		{893905EA-94D6-4F71-957A-43B194751DC7} = {D845507B-00E8-4506-954E-519CBC0B9F83}
+		{6AD49ED7-8975-4B2F-B916-BBA8ABA280D2} = {79310504-1334-4F14-93C4-1240913224BA}
+		{FF8EED45-187A-4FBD-875F-334D8DC44990} = {6AD49ED7-8975-4B2F-B916-BBA8ABA280D2}
+		{E7772A02-119A-41B1-9F97-CF6592120B7E} = {79310504-1334-4F14-93C4-1240913224BA}
+		{5F8B4227-A996-4C4F-802E-C671BB934C93} = {79310504-1334-4F14-93C4-1240913224BA}
+		{744F5E2B-281C-4BC1-B9E1-D8C0530DC5E3} = {5F8B4227-A996-4C4F-802E-C671BB934C93}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F4FA8C4C-3251-41CC-939B-7892F5798549}
+	EndGlobalSection
+EndGlobal

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
@@ -167,7 +167,7 @@
           "exclude": [
             "Shared/NavMenu.NoGraphOrApi.razor"
             ]
-        }      
+        }
       ]
     }
   ],
@@ -408,19 +408,19 @@
         "datatype": "string",
         "replaces": "[WebApiUrl]",
         "defaultValue" : "https://graph.microsoft.com/beta",
-        "description": "URL of the API to call from the web app."
+        "description": "URL of the API to call from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified."
     },
     "CallsMicrosoftGraph": {
         "type": "parameter",
         "datatype": "bool",
         "defaultValue": "false",
-        "description": "Specifies if the web app calls Microsoft Graph."
+        "description": "Specifies if the web app calls Microsoft Graph. This option only applies if --auth SingleOrg or --auth MultiOrg is specified."
     },
     "CalledApiScopes": {
       "type": "parameter",
       "datatype": "string",
       "replaces" :  "user.read",
-      "description": "Scopes to request to call the API from the web app."
+      "description": "Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified."
     },
     "GenerateApi": {
         "type": "computed",

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/Services/DownstreamWebApi.cs
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/Services/DownstreamWebApi.cs
@@ -54,7 +54,7 @@ namespace BlazorServerWeb_CSharp
             string accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync(scopes);
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, apiUrl);
             httpRequestMessage.Headers.Add("Authorization", $"bearer {accessToken}");
-           
+
             string apiResult;
             var response = await _httpClient.SendAsync(httpRequestMessage);
             if (response.StatusCode == HttpStatusCode.OK)

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/Services/MicrosoftGraphServiceExtensions.cs
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/Services/MicrosoftGraphServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace BlazorServerWeb_CSharp
         /// <param name="initialScopes">Initial scopes.</param>
         /// <param name="graphBaseUrl">Base URL for Microsoft graph. This can be
         /// changed for instance for applications running in national clouds</param>
-        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services, 
+        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services,
                                              IEnumerable<string> initialScopes,
                                              string graphBaseUrl = "https://graph.microsoft.com/v1.0")
         {

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/Startup.cs
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/Startup.cs
@@ -4,20 +4,15 @@ using System.Linq;
 using System.Threading.Tasks;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.AspNetCore.Authentication;
-#endif
-#if (OrganizationalAuth)
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
+#endif
+#if (OrganizationalAuth)
 #if (MultiOrgAuth)
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 #endif
 using Microsoft.AspNetCore.Authorization;
-#endif
-#if (IndividualB2CAuth)
-using Microsoft.Identity.Web;
-using Microsoft.Identity.Web.UI;
-using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 #endif
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components;
@@ -46,10 +41,10 @@ using Microsoft.IdentityModel.Tokens;
 using BlazorServerWeb_CSharp.Areas.Identity;
 #endif
 using BlazorServerWeb_CSharp.Data;
-
 #if (GenerateGraph)
 using Microsoft.Graph;
 #endif
+
 namespace BlazorServerWeb_CSharp
 {
     public class Startup
@@ -102,7 +97,7 @@ namespace BlazorServerWeb_CSharp
 #endif
             services.AddMicrosoftWebAppAuthentication(Configuration, "AzureAdB2C")
 #if (GenerateApi)
-                    .AddMicrosoftWebAppCallsWebApi(Configuration, 
+                    .AddMicrosoftWebAppCallsWebApi(Configuration,
                                                    scopes,
                                                    "AzureAdB2C")
                     .AddInMemoryTokenCaches();

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/appsettings.json
@@ -34,7 +34,7 @@
 //  },
 ////#endif
 ////#if (GenerateApiOrGraph)
-//    "CalledApi": {
+//  "CalledApi": {
 //    /*
 //     'CalledApiScopes' contains space separated scopes of the Web API you want to call. This can be:
 //      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
@@ -44,7 +44,7 @@
 //    */
 //    "CalledApiScopes": "user.read",
 //    "CalledApiUrl": "[WebApiUrl]"
-//   },
+//  },
 ////#endif
 ////#if (IndividualLocalAuth)
 //  "ConnectionStrings": {

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -24,6 +24,7 @@ app {
     height: 3.5rem;
     display: flex;
     align-items: center;
+    z-index: 10;
 }
 
 .main {

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -224,7 +224,7 @@
              "Server/Services/MicrosoftGraphServiceExtensions.cs",
             "Server/Services/TokenAcquisitionCredentialProvider.cs"
           ]
-        }	
+        }
       ]
     }
   ],
@@ -471,19 +471,19 @@
         "datatype": "string",
         "replaces": "[WebApiUrl]",
         "defaultValue" : "https://graph.microsoft.com/v1.0/me",
-        "description": "URL of the API to call from the web app."
+        "description": "URL of the API to call from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified."
     },
     "CallsMicrosoftGraph": {
         "type": "parameter",
         "datatype": "bool",
         "defaultValue": "false",
-        "description": "Specifies if the web app calls Microsoft Graph."
+        "description": "Specifies if the web app calls Microsoft Graph. This option only applies if --auth SingleOrg or --auth MultiOrg is specified."
     },
     "CalledApiScopes": {
       "type": "parameter",
       "datatype": "string",
       "replaces" :  "user.read",
-      "description": "Scopes to request to call the API from the web app."
+      "description": "Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified."
     },
     "GenerateApi": {
         "type": "computed",

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj
@@ -1,17 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <RazorLangVersion>3.0</RazorLangVersion>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="3.2.0" />
+<!--#if (Hosted) -->
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+<!--#endif -->
+  <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0-preview.6.20312.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0-preview.6.20312.15" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.0-preview.6.20312.15" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="5.0.0-preview.6.20312.15" />
+<!--#if (Hosted) -->
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0-preview.6.20305.6" />
+<!--#endif -->
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0-preview.6.20305.6" />
   </ItemGroup>
 
 <!--#if (Hosted) -->

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
@@ -24,7 +24,6 @@ app {
     height: 3.5rem;
     display: flex;
     align-items: center;
-    z-index: 10;
 }
 
 .main {

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
@@ -15,9 +15,12 @@ using System.Net.Http;
 using Microsoft.Graph;
 #endif
 using Microsoft.AspNetCore.Mvc;
+#if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.Identity.Web.Resource;
+#endif
 using Microsoft.Extensions.Logging;
 using ComponentsWebAssembly_CSharp.Shared;
+
 namespace ComponentsWebAssembly_CSharp.Server.Controllers
 {
 #if (!NoAuth)
@@ -98,7 +101,7 @@ namespace ComponentsWebAssembly_CSharp.Server.Controllers
         [HttpGet]
         public IEnumerable<WeatherForecast> Get()
         {
-#if (!NoAuth)
+#if (OrganizationalAuth || IndividualB2CAuth)
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
 #endif

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Program.cs
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Services/MicrosoftGraphServiceExtensions.cs
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Services/MicrosoftGraphServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace ComponentsWebAssembly_CSharp.Server
         /// <param name="initialScopes">Initial scopes.</param>
         /// <param name="graphBaseUrl">Base URL for Microsoft graph. This can be
         /// changed for instance for applications running in national clouds</param>
-        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services, 
+        public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services,
                                              IEnumerable<string> initialScopes,
                                              string graphBaseUrl = "https://graph.microsoft.com/v1.0")
         {

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Startup.cs
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/Startup.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 #endif
-#if (OrganizationalAuth || IndividualB2CAuth) 
+#if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 #endif
@@ -20,9 +20,9 @@ using Microsoft.Extensions.Hosting;
 using System.Linq;
 #if (IndividualLocalAuth)
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+#endif
 #if (GenerateGraph)
 using Microsoft.Graph;
-#endif
 #endif
 
 namespace ComponentsWebAssembly_CSharp.Server
@@ -63,7 +63,7 @@ namespace ComponentsWebAssembly_CSharp.Server
             // Adds Microsoft Identity platform (AAD v2.0) support to protect this Api
             services.AddMicrosoftWebApiAuthentication(Configuration, "AzureAd")
 #if (GenerateApiOrGraph)
-                    .AddMicrosoftWebAppCallsWebApi(Configuration,
+                    .AddMicrosoftWebApiCallsWebApi(Configuration,
                                                    "AzureAd")
                     .AddInMemoryTokenCaches();
 
@@ -80,7 +80,7 @@ namespace ComponentsWebAssembly_CSharp.Server
 #elif (IndividualB2CAuth)
             services.AddMicrosoftWebApiAuthentication(Configuration, "AzureAdB2C")
 #if (GenerateApi)
-                    .AddMicrosoftWebAppCallsWebApi(Configuration,
+                    .AddMicrosoftWebApiCallsWebApi(Configuration,
                                                    "AzureAdB2C")
                     .AddInMemoryTokenCaches();
 

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/appsettings.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/appsettings.json
@@ -1,70 +1,70 @@
 {
-    ////#if (IndividualLocalAuth)
-    //  "ConnectionStrings": {
-    ////#if (UseLocalDB)
-    //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-ComponentsWebAssembly_CSharp.Server-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
-    ////#else
-    //    "DefaultConnection": "DataSource=app.db"
-    ////#endif
-    //  },
-    ////#elseif (IndividualB2CAuth)
-    //  "AzureAdB2C": {
-    //    "Instance": "https:////aadB2CInstance.b2clogin.com/",
-    //    "ClientId": "11111111-1111-1111-11111111111111111",
-    //    "Domain": "qualified.domain.name",
-    //#if (GenerateApi)
-    //    "ClientSecret": "secret-from-app-registration",
-    //    "ClientCertificates" : [
-    //    ],
-    //#endif
-    //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
-    //  },
-    ////#elseif (OrganizationalAuth)
-    //  "AzureAd": {
-    //#if (!SingleOrgAuth)
-    //    "Instance": "https:////login.microsoftonline.com/common",
-    //#else
-    //    "Instance": "https:////login.microsoftonline.com/",
-    //    "Domain": "qualified.domain.name",
-    //    "TenantId": "22222222-2222-2222-2222-222222222222",
-    //#endif
-    //    "ClientId": "11111111-1111-1111-11111111111111111",
-    //#if (GenerateApiOrGraph)
-    //    "ClientSecret": "secret-from-app-registration",
-    //    "ClientCertificates" : [
-    //    ],
-//#endif
-    //    "CallbackPath": "/signin-oidc"
-    //  },
+////#if (IndividualLocalAuth)
+//  "ConnectionStrings": {
+////#if (UseLocalDB)
+//    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-ComponentsWebAssembly_CSharp.Server-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
+////#else
+//    "DefaultConnection": "DataSource=app.db"
 ////#endif
-    ////#if (GenerateApiOrGraph)
-    //    "CalledApi": {
-    //    /*
-    //     'CalledApiScopes' contains space separated scopes of the Web API you want to call. This can be:
-    //      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
-    //      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
-    //        App ID URI of a legacy v1 Web application
-    //      Applications are registered in the https://portal.azure.com portal.
-    //    */
-    //    "CalledApiScopes": "user.read",
-    //    "CalledApiUrl": "[WebApiUrl]"
-    //   },
-    ////#endif
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
-        }
-    },
-    ////#if (IndividualLocalAuth)
-    //  "IdentityServer": {
-    //    "Clients": {
-    //      "ComponentsWebAssembly_CSharp.Client": {
-    //        "Profile": "IdentityServerSPA"
-    //      }
-    //    }
-    //  },
-    ////#endif
-    "AllowedHosts": "*"
+//  },
+////#elseif (IndividualB2CAuth)
+//  "AzureAdB2C": {
+//    "Instance": "https:////aadB2CInstance.b2clogin.com/",
+//    "ClientId": "11111111-1111-1111-11111111111111111",
+//    "Domain": "qualified.domain.name",
+//#if (GenerateApi)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+//#endif
+//    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
+//  },
+////#elseif (OrganizationalAuth)
+//  "AzureAd": {
+//#if (!SingleOrgAuth)
+//    "Instance": "https:////login.microsoftonline.com/common",
+//#else
+//    "Instance": "https:////login.microsoftonline.com/",
+//    "Domain": "qualified.domain.name",
+//    "TenantId": "22222222-2222-2222-2222-222222222222",
+//#endif
+//    "ClientId": "11111111-1111-1111-11111111111111111",
+//#if (GenerateApiOrGraph)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+//#endif
+//    "CallbackPath": "/signin-oidc"
+//  },
+////#endif
+////#if (GenerateApiOrGraph)
+//  "CalledApi": {
+//    /*
+//     'CalledApiScopes' contains space separated scopes of the Web API you want to call. This can be:
+//      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
+//      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
+//        App ID URI of a legacy v1 Web application
+//      Applications are registered in the https://portal.azure.com portal.
+//    */
+//    "CalledApiScopes": "user.read",
+//    "CalledApiUrl": "[WebApiUrl]"
+//  },
+////#endif
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+////#if (IndividualLocalAuth)
+//  "IdentityServer": {
+//    "Clients": {
+//      "ComponentsWebAssembly_CSharp.Client": {
+//        "Profile": "IdentityServerSPA"
+//      }
+//    }
+//  },
+////#endif
+"AllowedHosts": "*"
 }

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/wwwroot/lib/bootstrap/dist/js/bootstrap.bundle.js
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/wwwroot/lib/bootstrap/dist/js/bootstrap.bundle.js
@@ -1502,7 +1502,7 @@
   };
 
   /**!
-   * @fileOverview Kickass library to create and place poppers near their reference elements.
+   * @fileOverview Library to create and place poppers near their reference elements.
    * @version 1.14.7
    * @license
    * Copyright (c) 2016 Federico Zivolo and contributors

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Controllers/HomeController.cs
@@ -42,6 +42,7 @@ namespace Company.WebApplication1.Controllers
         public async Task<IActionResult> Index()
         {
             ViewData["ApiResult"] = await _downstreamWebApi.CallWebApiAsync();
+
             return View();
         }
 #elseif (GenerateGraph)

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -25,7 +25,6 @@
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-
 //#if (GenerateApiOrGraph)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [

--- a/ProjectTemplates/templates/WebApi-CSharp/Startup.cs
+++ b/ProjectTemplates/templates/WebApi-CSharp/Startup.cs
@@ -45,7 +45,7 @@ namespace Company.WebApplication1
             // Adds Microsoft Identity platform (AAD v2.0) support to protect this Api
             services.AddMicrosoftWebApiAuthentication(Configuration, "AzureAd")
 #if (GenerateApiOrGraph)
-                    .AddMicrosoftWebAppCallsWebApi(Configuration,
+                    .AddMicrosoftWebApiCallsWebApi(Configuration,
                                                    "AzureAd")
                     .AddInMemoryTokenCaches();
 
@@ -62,7 +62,7 @@ namespace Company.WebApplication1
 #elif (IndividualB2CAuth)
             services.AddMicrosoftWebApiAuthentication(Configuration, "AzureAdB2C")
 #if (GenerateApi)
-                    .AddMicrosoftWebAppCallsWebApi(Configuration,
+                    .AddMicrosoftWebApiCallsWebApi(Configuration,
                                                    "AzureAdB2C")
                     .AddInMemoryTokenCaches();
 

--- a/build/template-nuget-pack.yaml
+++ b/build/template-nuget-pack.yaml
@@ -7,11 +7,11 @@ parameters:
 steps:
 - task: DotNetCoreCLI@2
   displayName: 'Pack ${{ parameters.ProjectPath }}'
-  packagesToPack: '${{ parameters.ProjectPath }}'
   inputs:
     command: pack
     projects: '${{ parameters.ProjectPath }}'
     nobuild: '${{parameters.NoBuild}}'
+    packagesToPack: '${{ parameters.ProjectPath }}'
     IncludeSymbols: true
     verbosityPack: normal
     packDirectory:

--- a/build/template-nuget-pack.yaml
+++ b/build/template-nuget-pack.yaml
@@ -7,6 +7,7 @@ parameters:
 steps:
 - task: DotNetCoreCLI@2
   displayName: 'Pack ${{ parameters.ProjectPath }}'
+  packagesToPack: '${{ parameters.ProjectPath }}'
   inputs:
     command: pack
     projects: '${{ parameters.ProjectPath }}'

--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -18,9 +18,9 @@ steps:
 # But since .NET 5 is still in preview, we only build the .NET Core 3.1 target.
 # The previous task does the restore
 - task: VSBuild@1
-  displayName: 'Build solution Microsoft.Identity.Web.sln'
+  displayName: 'Build solution Microsoft.Identity.Web-without-blasorwasm2-sample.sln for governance'
   inputs:
-    solution: Microsoft.Identity.Web.sln
+    solution: Microsoft.Identity.Web-without-blasorwasm2-sample.sln
     vsVersion: '16.0'
     msbuildArgs: '/p:RunCodeAnalysis=false /p:TargetFramework=netcoreapp3.1 /p:MsIdentityWebSemVer=${{ parameters.MsIdentityWebSemVer }} /p:SourceLinkCreate=true'
     platform: ${{ parameters.BuildPlatform }}

--- a/tests/blazorwasm2/Client/blazorwasm2-singleOrg-hosted4.Client.csproj
+++ b/tests/blazorwasm2/Client/blazorwasm2-singleOrg-hosted4.Client.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <RazorLangVersion>3.0</RazorLangVersion>
     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
   </PropertyGroup>
 
@@ -11,10 +12,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="3.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
-  <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0-preview.6.20312.15" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0-preview.6.20312.15" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.0-preview.6.20312.15" />

--- a/tests/blazorwasm2/Client/blazorwasm2-singleOrg-hosted4.Client.csproj
+++ b/tests/blazorwasm2/Client/blazorwasm2-singleOrg-hosted4.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
   </PropertyGroup>
@@ -15,7 +15,7 @@
     <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0-preview.6.20312.15" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0-preview.6.20312.15" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.0-preview.6.20312.15" />

--- a/tests/blazorwasm2/Client/blazorwasm2-singleOrg-hosted4.Client.csproj
+++ b/tests/blazorwasm2/Client/blazorwasm2-singleOrg-hosted4.Client.csproj
@@ -1,27 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
-    <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="3.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0-preview.6.20312.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0-preview.6.20312.15" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.0-preview.6.20312.15" />
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="5.0.0-preview.6.20312.15" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0-preview.6.20305.6" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0-preview.6.20305.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/blazorwasm2/Client/blazorwasm2-singleOrg-hosted4.Client.csproj
+++ b/tests/blazorwasm2/Client/blazorwasm2-singleOrg-hosted4.Client.csproj
@@ -1,17 +1,26 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <RazorLangVersion>3.0</RazorLangVersion>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="3.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+  <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0-preview.6.20312.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0-preview.6.20312.15" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.0-preview.6.20312.15" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="5.0.0-preview.6.20312.15" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0-preview.6.20305.6" />
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0-preview.6.20305.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/blazorwasm2/Server/blazorwasm2-singleOrg-hosted4.Server.csproj
+++ b/tests/blazorwasm2/Server/blazorwasm2-singleOrg-hosted4.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.0" />

--- a/tests/blazorwasm2/Server/blazorwasm2-singleOrg-hosted4.Server.csproj
+++ b/tests/blazorwasm2/Server/blazorwasm2-singleOrg-hosted4.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.0" />

--- a/tests/blazorwasm2/Shared/blazorwasm2-singleOrg-hosted4.Shared.csproj
+++ b/tests/blazorwasm2/Shared/blazorwasm2-singleOrg-hosted4.Shared.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tests/blazorwasm2/Shared/blazorwasm2-singleOrg-hosted4.Shared.csproj
+++ b/tests/blazorwasm2/Shared/blazorwasm2-singleOrg-hosted4.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tests/blazorwasm2/Shared/blazorwasm2-singleOrg-hosted4.Shared.csproj
+++ b/tests/blazorwasm2/Shared/blazorwasm2-singleOrg-hosted4.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tests/blazorwasm2/Shared/blazorwasm2-singleOrg-hosted4.Shared.csproj
+++ b/tests/blazorwasm2/Shared/blazorwasm2-singleOrg-hosted4.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Synching the templates from ASP.NET Core (johluo/identity-web-templates-balzor)
- fixing the Startup.cs of the Web API template (AddMicrosoftWebApiCallsWebApi)
- fixing the Startup.cs of the BlazorServerWeb-CSharp\Server template (AddMicrosoftWebApiCallsWebApi)
- Adding the net5.0 client ComponentsWebAssembly target to both the blazorwasm2 template and sample
- Fixing the build pack break (Incorparating the change from @pmaytak; #365)