### PR TITLE
Remove cases in templates as B2C does not support OBO

### DIFF
--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
@@ -428,7 +428,7 @@
     },
     "GenerateGraph": {
         "type": "computed",
-        "value": "((IndividualB2CAuth || OrganizationalAuth) && CallsMicrosoftGraph)"
+        "value": "(OrganizationalAuth && CallsMicrosoftGraph)"
     },
     "GenerateApiOrGraph": {
         "type": "computed",

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -487,11 +487,11 @@
     },
     "GenerateApi": {
         "type": "computed",
-        "value": "((IndividualB2CAuth || OrganizationalAuth) && (CalledApiUrl != \"https://graph.microsoft.com/v1.0/me\" || CalledApiScopes != \"user.read\"))"
+        "value": "( ((IndividualB2CAuth && !Hosted) || OrganizationalAuth) && (CalledApiUrl != \"https://graph.microsoft.com/v1.0/me\" || CalledApiScopes != \"user.read\"))"
     },
     "GenerateGraph": {
         "type": "computed",
-        "value": "((IndividualB2CAuth || OrganizationalAuth) && CallsMicrosoftGraph)"
+        "value": "(OrganizationalAuth && CallsMicrosoftGraph)"
     },
     "GenerateApiOrGraph": {
         "type": "computed",

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
+    <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
@@ -16,14 +17,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0-preview.6.20312.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0-preview.6.20312.15" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.0-preview.6.20312.15" />
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="5.0.0-preview.6.20312.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0-*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.0-*" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="5.0.0-*" />
 <!--#if (Hosted) -->
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0-preview.6.20305.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0-*" />
 <!--#endif -->
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0-preview.6.20305.6" />
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0-*" />
   </ItemGroup>
 
 <!--#if (Hosted) -->

--- a/ProjectTemplates/test-templates.bat
+++ b/ProjectTemplates/test-templates.bat
@@ -94,13 +94,6 @@ dotnet new webapi2 --auth IndividualB2C
 dotnet sln ..\..\tests.sln add webapi2-b2c.csproj
 cd ..
 
-echo "Test webapi2, b2c, calling a downstream web api"
-mkdir webapi2-b2c-callswebapi
-cd webapi2-b2c-callswebapi
-dotnet new webapi2 --auth IndividualB2C --called-api-url "https://localhost:44332/api/todolist" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read"
-dotnet sln ..\..\tests.sln add webapi2-b2c-callswebapi.csproj
-cd ..
-
 cd ..
 
 REM MVC Web app
@@ -269,15 +262,6 @@ dotnet new blazorwasm2 --auth IndividualB2C  --hosted
 dotnet sln ..\..\tests.sln add Shared\blazorwasm2-b2c-hosted.Shared.csproj
 dotnet sln ..\..\tests.sln add Server\blazorwasm2-b2c-hosted.Server.csproj
 dotnet sln ..\..\tests.sln add Client\blazorwasm2-b2c-hosted.Client.csproj
-cd ..
-
-echo "Test blazorwasm2, b2c, with hosted blazor web server web api, calling a downstream web api"
-mkdir blazorwasm2-b2c-callswebapi-hosted
-cd blazorwasm2-b2c-callswebapi-hosted
-dotnet new blazorwasm2 --auth IndividualB2C --called-api-url "https://localhost:44332/api/todolist" --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/tasks/read" --hosted
-dotnet sln ..\..\tests.sln add Shared\blazorwasm2-b2c-callswebapi-hosted.Shared.csproj
-dotnet sln ..\..\tests.sln add Server\blazorwasm2-b2c-callswebapi-hosted.Server.csproj
-dotnet sln ..\..\tests.sln add Client\blazorwasm2-b2c-callswebapi-hosted.Client.csproj
 cd ..
 
 cd ..


### PR DESCRIPTION
Remove cases in templates as B2C does not support OBO
- (bug in Blazor templates) B2C apps don't call Microsoft Graph
- B2C Web APIs (that is webapi2 and blazowasm -hosted with B2C) don't call downstream APIs since OBO is not supported in B2C

- Updating Blazor web assembly hosted client to .NET 5.0 preview 7 (requires RuntimeIdentitier)
- Removing the cases where B2C would do an OBO in test-templates.bat