### PR TITLE
Parallelize Github build action

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -4,21 +4,26 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        dotNetInstallVersion: [3.1.302]
+        dotNetRunVersion: [netcoreapp3.1]
+        solution: [Microsoft.Identity.Web.sln]
+        include:
+          - DotNetInstallVersion: 5.0.100-preview.7.20366.6
+            DotNetRunVersion: net5.0
+            Solution: Microsoft.Identity.Web-without-blasorwasm2-sample.sln
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core 5
-      uses: actions/setup-dotnet@v1
+    - name: Checkout repository
+      uses: actions/checkout@v2.3.1
+
+    - name: Setup .NET ${{ matrix.dotNetInstallVersion }}
+      uses: actions/setup-dotnet@v1.5.0
       with:
-        dotnet-version: 5.0.100-preview.5.20279.10
-        includePreviewVersions: true # Required for preview versions
-    - name: Build with dotnet
-      run: dotnet test -f net5.0 -p:FROM_GITHUB_ACTION=true --configuration Release Microsoft.Identity.Web-without-blasorwasm2-sample.sln # is netstandard2.1
-    - name: Setup .NET Core 3.1.101
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
-    - name: Build with dotnet
-      run: dotnet test -f netcoreapp3.1 -p:FROM_GITHUB_ACTION=true --configuration Release Microsoft.Identity.Web.sln
+        dotnet-version: ${{ matrix.dotNetInstallVersion }}
+
+    - name: Build with .NET ${{ matrix.dotNetRunVersion }}
+      run: dotnet test -f ${{ matrix.dotNetRunVersion }} -p:FROM_GITHUB_ACTION=true --configuration Release ${{ matrix.solution }}


### PR DESCRIPTION
Updated the Github build action to run build commands for different .NET versions in parallel. Also updated the framework versions to 3.1.302 and 5.0 Preview 7. [Previous run example](https://github.com/AzureAD/microsoft-identity-web/actions/runs/191003994).

Was kind of a Hackathon project / POC so that the learnings can be used for the main build pipeline. 

[Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy)