### PR TITLE
Updating the projects for templates to 0.2.3-preview

### DIFF
--- a/ProjectTemplates/AspNetCoreMicrosoftIdentityWebProjectTemplates.csproj
+++ b/ProjectTemplates/AspNetCoreMicrosoftIdentityWebProjectTemplates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--This should be passed from the VSTS build-->
-    <ClientSemVer Condition="'$(ClientSemVer)' == ''">0.2.2-preview</ClientSemVer>
+    <ClientSemVer Condition="'$(ClientSemVer)' == ''">0.2.3-preview</ClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <PackageVersion>$(ClientSemVer)</PackageVersion>
     

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/BlazorServerWeb-CSharp.csproj
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/BlazorServerWeb-CSharp.csproj
@@ -3,8 +3,8 @@
      <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.2-preview" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.2-preview" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.3-preview" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.3-preview" />
 <!--#if (GenerateGraph) -->
   <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
 <!--#endif -->

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
+    <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
@@ -13,7 +14,7 @@
 <!--#if (Hosted) -->
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
 <!--#endif -->
-  <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/ComponentsWebAssembly-CSharp.Server.csproj
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/ComponentsWebAssembly-CSharp.Server.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.2-preview" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.3-preview" />
 <!--#if (GenerateGraph) -->
   <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
 <!--#endif -->

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/Company.WebApplication1.csproj
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/Company.WebApplication1.csproj
@@ -3,8 +3,8 @@
      <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.2-preview" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.2-preview" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.3-preview" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.3-preview" />
 <!--#if (GenerateGraph) -->
     <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
 <!--#endif -->     

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Company.WebApplication1.csproj
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Company.WebApplication1.csproj
@@ -3,8 +3,8 @@
      <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.2-preview" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.2-preview" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.3-preview" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="0.2.3-preview" />
 <!--#if (GenerateGraph) -->
     <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
 <!--#endif -->

--- a/ProjectTemplates/templates/WebApi-CSharp/Company.WebApplication1.csproj
+++ b/ProjectTemplates/templates/WebApi-CSharp/Company.WebApplication1.csproj
@@ -3,7 +3,7 @@
      <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.2-preview" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="0.2.3-preview" />
 <!--#if (GenerateGraph) -->
     <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
 <!--#endif -->    

--- a/ProjectTemplates/test-templates.bat
+++ b/ProjectTemplates/test-templates.bat
@@ -2,7 +2,7 @@ echo "Build and Install templates"
 dotnet pack AspNetCoreMicrosoftIdentityWebProjectTemplates.csproj
 cd bin
 cd Debug
-dotnet new -i Microsoft.Identity.Web.ProjectTemplates.0.2.2-preview.nupkg
+dotnet new -i Microsoft.Identity.Web.ProjectTemplates.0.2.3-preview.nupkg
 
 echo "Test templates"
 mkdir tests


### PR DESCRIPTION
- Updates the .csproj files for the projects templates to 0.2.3-preview
- Updates the .bat file to 0.2.3-preview
__

Tested that everything builds by:
- `dotnet pack /p:ClientSemVer=0.2.3-preview` at the root of the repo
- then
  - `cd ProjectTemplates`
  - `test-templates.bat`