### PR TITLE
Fixes the blazorwasm2 hosted templates:

### DIFF
--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <UseBlazorWebAssembly>true</UseBlazorWebAssembly>
+    <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
@@ -13,7 +14,7 @@
 <!--#if (Hosted) -->
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
 <!--#endif -->
-  <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
@@ -27,10 +28,10 @@
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0-*" />
   </ItemGroup>
 
-<!--#if (Hosted) -->
+  <!--#if (Hosted) -->
   <ItemGroup>
     <ProjectReference Include="..\Shared\ComponentsWebAssembly-CSharp.Shared.csproj" />
   </ItemGroup>
-<!--#endif -->
+  <!--#endif -->
 
 </Project>


### PR DESCRIPTION
- replaces netcoreapp3.1 by netstandard2.1
- adds the RazorLangVersion XML element

IMPORTANT:
To debug, the server needs to be the startup project to run the template