### PR TITLE
Make GetTokenForAppAsync less confusing and allow to pass tenantId #413

### DIFF
--- a/src/Microsoft.Identity.Web/Constants/Constants.cs
+++ b/src/Microsoft.Identity.Web/Constants/Constants.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Identity.Web
         public const string MsaTenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
         public const string Consumers = "consumers";
         public const string Organizations = "organizations";
+        public const string Common = "common";
 
         // ClientInfo
         public const string ClientInfo = "client_info";

--- a/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Web
         public const string ClientCredentialScopeParameterShouldEndInDotDefault =
        "IDW10404: 'scope' parameter should be of the form 'AppIdUri/.default'. See https://aka.ms/ms-id-web/daemon-scenarios.";
         public const string ClientCredentialTenantShouldBeTenanted =
-       "IDW10405: 'tenant' parameter should be a tenant ID or domain name, not 'common', 'organizations' or 'consumers'. See https://aka.ms/ms-id-web/daemon-scenarios.";
+       "IDW10405: 'tenant' parameter should be a tenant ID or domain name, not 'common', or 'organizations'. See https://aka.ms/ms-id-web/daemon-scenarios.";
 
         // MSAL IDW10500 = "IDW10500:"
         public const string ExceptionAcquiringTokenForConfidentialClient = "IDW10501: Exception acquiring token for a confidential client. ";

--- a/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
@@ -42,6 +42,10 @@ namespace Microsoft.Identity.Web
         public const string TenantIdClaimNotPresentInToken = "IDW10401: Neither `tid` nor `tenantId` claim is present in the token obtained from Microsoft identity platform. ";
         public const string ClientInfoReturnedFromServerIsNull = "IDW10402: Client info returned from the server is null. ";
         public const string TokenIsNotJwtToken = "IDW10403: Token is not JWT token. ";
+        public const string ClientCredentialScopeParameterShouldEndInDotDefault =
+       "IDW10404: 'scope' parameter should be of the form 'AppIdUri/.default'.";
+        public const string ClientCredentialTenantShouldBeTenanted =
+       "IDW10405: 'tenant' parameter should be a tenant ID or domain name, not 'common', 'organizations' or 'consumers'.";
 
         // MSAL IDW10500 = "IDW10500:"
         public const string ExceptionAcquiringTokenForConfidentialClient = "IDW10501: Exception acquiring token for a confidential client. ";

--- a/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Identity.Web
         public const string ClientInfoReturnedFromServerIsNull = "IDW10402: Client info returned from the server is null. ";
         public const string TokenIsNotJwtToken = "IDW10403: Token is not JWT token. ";
         public const string ClientCredentialScopeParameterShouldEndInDotDefault =
-       "IDW10404: 'scope' parameter should be of the form 'AppIdUri/.default'.";
+       "IDW10404: 'scope' parameter should be of the form 'AppIdUri/.default'. See https://aka.ms/ms-id-web/daemon-scenarios.";
         public const string ClientCredentialTenantShouldBeTenanted =
-       "IDW10405: 'tenant' parameter should be a tenant ID or domain name, not 'common', 'organizations' or 'consumers'.";
+       "IDW10405: 'tenant' parameter should be a tenant ID or domain name, not 'common', 'organizations' or 'consumers'. See https://aka.ms/ms-id-web/daemon-scenarios.";
 
         // MSAL IDW10500 = "IDW10500:"
         public const string ExceptionAcquiringTokenForConfidentialClient = "IDW10501: Exception acquiring token for a confidential client. ";

--- a/src/Microsoft.Identity.Web/ITokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/ITokenAcquisition.cs
@@ -37,12 +37,15 @@ namespace Microsoft.Identity.Web
         /// Acquires a token from the authority configured in the app, for the confidential client itself (not on behalf of a user)
         /// using the client credentials flow. See https://aka.ms/msal-net-client-credentials.
         /// </summary>
-        /// <param name="scopes">scopes requested to access a protected API. For this flow (client credentials), the scopes
+        /// <param name="scope">scope requested to access a protected API. For this flow (client credentials), the scope
         /// should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
         /// Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
-        /// in the portal, and cannot be overridden in the application.</param>
+        /// in the portal, cannot be overridden in the application, and you can request a token for only one resource at a time (use
+        /// several call to get tokens for other resources).</param>
+        /// <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
+        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
         /// <returns>An access token for the app itself, based on its scopes.</returns>
-        Task<string> GetAccessTokenForAppAsync(IEnumerable<string> scopes);
+        Task<string> GetAccessTokenForAppAsync(string scope, string? tenant);
 
         /// <summary>
         /// Used in Web APIs (which therefore cannot have an interaction with the user).

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -658,15 +658,18 @@
             cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
             <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.ITokenAcquisition.GetAccessTokenForAppAsync(System.Collections.Generic.IEnumerable{System.String})">
+        <member name="M:Microsoft.Identity.Web.ITokenAcquisition.GetAccessTokenForAppAsync(System.String,System.String)">
             <summary>
             Acquires a token from the authority configured in the app, for the confidential client itself (not on behalf of a user)
             using the client credentials flow. See https://aka.ms/msal-net-client-credentials.
             </summary>
-            <param name="scopes">scopes requested to access a protected API. For this flow (client credentials), the scopes
+            <param name="scope">scope requested to access a protected API. For this flow (client credentials), the scope
             should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
             Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
-            in the portal, and cannot be overridden in the application.</param>
+            in the portal, cannot be overridden in the application, and you can request a token for only one resource at a time (use
+            several call to get tokens for other resources).</param>
+            <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
+            cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
             <returns>An access token for the app itself, based on its scopes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ITokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeaderAsync(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException,Microsoft.AspNetCore.Http.HttpResponse)">
@@ -1224,15 +1227,18 @@
             you have previously called AddAccountToCacheFromAuthorizationCodeAsync from a method called by
             OpenIdConnectOptions.Events.OnAuthorizationCodeReceived.</remarks>
         </member>
-        <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetAccessTokenForAppAsync(System.Collections.Generic.IEnumerable{System.String})">
+        <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetAccessTokenForAppAsync(System.String,System.String)">
             <summary>
             Acquires a token from the authority configured in the app, for the confidential client itself (not on behalf of a user)
             using the client credentials flow. See https://aka.ms/msal-net-client-credentials.
             </summary>
-            <param name="scopes">scopes requested to access a protected API. For this flow (client credentials), the scopes
+            <param name="scope">scope requested to access a protected API. For this flow (client credentials), the scope
             should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
             Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
-            in the portal, and cannot be overridden in the application.</param>
+            in the portal, cannot be overridden in the application, and you can request a token for only one resource at a time (use
+            several call to get tokens for other resources).</param>
+            <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
+            cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
             <returns>An access token for the app itself, based on its scopes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.RemoveAccountAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.RedirectContext)">

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1153,6 +1153,11 @@
             Scopes which are already requested by MSAL.NET. They should not be re-requested;.
             </summary>
         </member>
+        <member name="F:Microsoft.Identity.Web.TokenAcquisition._metaTenantIdentifiers">
+            <summary>
+            meta-tenant identifiers which are not allowed in client credentials.
+            </summary>
+        </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.AddAccountToCacheFromAuthorizationCodeAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.AuthorizationCodeReceivedContext,System.Collections.Generic.IEnumerable{System.String})">
              <summary>
              This handler is executed after the authorization code is received (once the user signs-in and consents) during the

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -663,13 +663,13 @@
             Acquires a token from the authority configured in the app, for the confidential client itself (not on behalf of a user)
             using the client credentials flow. See https://aka.ms/msal-net-client-credentials.
             </summary>
-            <param name="scope">scope requested to access a protected API. For this flow (client credentials), the scope
+            <param name="scope">The scope requested to access a protected API. For this flow (client credentials), the scope
             should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
             Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
-            in the portal, cannot be overridden in the application, and you can request a token for only one resource at a time (use
-            several call to get tokens for other resources).</param>
+            in the portal, cannot be overridden in the application, as you can request a token for only one resource at a time (use
+            several calls to get tokens for other resources).</param>
             <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
-            cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
+            cases where a given account is a guest in other tenants, and you want to acquire tokens for a specific tenant.</param>
             <returns>An access token for the app itself, based on its scopes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.ITokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeaderAsync(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException,Microsoft.AspNetCore.Http.HttpResponse)">
@@ -1237,13 +1237,13 @@
             Acquires a token from the authority configured in the app, for the confidential client itself (not on behalf of a user)
             using the client credentials flow. See https://aka.ms/msal-net-client-credentials.
             </summary>
-            <param name="scope">scope requested to access a protected API. For this flow (client credentials), the scope
+            <param name="scope">The scope requested to access a protected API. For this flow (client credentials), the scope
             should be of the form "{ResourceIdUri/.default}" for instance <c>https://management.azure.net/.default</c> or, for Microsoft
             Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
-            in the portal, cannot be overridden in the application, and you can request a token for only one resource at a time (use
-            several call to get tokens for other resources).</param>
-            <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
-            cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant, like where the user is a guest in.</param>
+            in the portal, cannot be overridden in the application, as you can request a token for only one resource at a time (use
+            several calls to get tokens for other resources).</param>
+            <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful
+            for multi tenant apps or daemons.</param>
             <returns>An access token for the app itself, based on its scopes.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.RemoveAccountAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.RedirectContext)">

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -84,12 +84,14 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// meta-tenant identifiers which are not allowed in client credentials.
         /// </summary>
-        private readonly string[] unwantedTenantIdentifiersInClientCredentials = new string[]
-        {
-            "common",
-            "organizations",
-            "consumers",
-        };
+        private readonly ISet<string> _metaTenantIdentifiers = new HashSet<string>(
+            new[]
+            {
+                Constants.Common,
+                Constants.Organizations,
+                Constants.Consumers,
+            },
+            StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// This handler is executed after the authorization code is received (once the user signs-in and consents) during the
@@ -313,7 +315,7 @@ namespace Microsoft.Identity.Web
         /// <returns>An access token for the app itself, based on its scopes.</returns>
         public async Task<string> GetAccessTokenForAppAsync(string scope, string? tenant = null)
         {
-            if (scope == null)
+            if (string.IsNullOrEmpty(scope))
             {
                 throw new ArgumentNullException(nameof(scope));
             }
@@ -323,8 +325,7 @@ namespace Microsoft.Identity.Web
                 throw new ArgumentException(IDWebErrorMessage.ClientCredentialScopeParameterShouldEndInDotDefault, nameof(scope));
             }
 
-            if (!string.IsNullOrEmpty(tenant)
-                && unwantedTenantIdentifiersInClientCredentials.Any(u => u.Equals(tenant, StringComparison.InvariantCultureIgnoreCase)))
+            if (!string.IsNullOrEmpty(tenant) && _metaTenantIdentifiers.Contains(tenant))
             {
                 throw new ArgumentException(IDWebErrorMessage.ClientCredentialTenantShouldBeTenanted, nameof(tenant));
             }

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -87,7 +87,6 @@ namespace Microsoft.Identity.Web
         private readonly ISet<string> _metaTenantIdentifiers = new HashSet<string>(
             new[]
             {
-                Constants.Common,
                 Constants.Organizations,
                 Constants.Consumers,
             },
@@ -310,8 +309,8 @@ namespace Microsoft.Identity.Web
         /// Graph, <c>https://graph.microsoft.com/.default</c> as the requested scopes are defined statically with the application registration
         /// in the portal, cannot be overridden in the application, as you can request a token for only one resource at a time (use
         /// several calls to get tokens for other resources).</param>
-        /// <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful in the
-        /// cases where a given account is a guest in other tenants, and you want to acquire tokens for a specific tenant.</param>
+        /// <param name="tenant">Enables overriding of the tenant/account for the same identity. This is useful
+        /// for multi tenant apps or daemons.</param>
         /// <returns>An access token for the app itself, based on its scopes.</returns>
         public async Task<string> GetAccessTokenForAppAsync(string scope, string? tenant = null)
         {

--- a/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
@@ -78,10 +78,7 @@ namespace Microsoft.Identity.Web.Test.Common
             ProductionNotPrefEnvironmentAlias,
         };
 
-        public static readonly IEnumerable<string> s_scopesForApp = new[]
-        {
-            "https://graph.microsoft.com/.default",
-        };
+        public static readonly string s_scopeForApp = "https://graph.microsoft.com/.default";
 
         public static readonly IEnumerable<string> s_scopesForUser = new[]
         {

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -70,8 +70,11 @@ namespace Microsoft.Identity.Web.Test.Integration
             AssertAppTokenInMemoryCache(TestConstants.ConfidentialClientId, 1);
         }
 
-        [Fact]
-        public async Task GetAccessTokenForApp_WithMetaTenant()
+        [Theory]
+        [InlineData(Constants.Common)]
+        [InlineData(Constants.Organizations)]
+        [InlineData(Constants.Consumers)]
+        public async Task GetAccessTokenForApp_WithMetaTenant(string metaTenant)
         {
             // Arrange
             InitializeTokenAcquisitionObjects();
@@ -79,7 +82,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             Assert.Equal(0, _msalTestTokenCacheProvider.Count);
 
             async Task result() =>
-                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp, "organizations").ConfigureAwait(false);
+                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp, metaTenant).ConfigureAwait(false);
 
             ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(result).ConfigureAwait(false);
             Assert.Contains(IDWebErrorMessage.ClientCredentialTenantShouldBeTenanted, ex.Message);

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -61,12 +62,28 @@ namespace Microsoft.Identity.Web.Test.Integration
 
             // Act
             string token =
-                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopesForApp).ConfigureAwait(false);
+                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp).ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(token);
 
             AssertAppTokenInMemoryCache(TestConstants.ConfidentialClientId, 1);
+        }
+
+        [Fact]
+        public async Task GetAccessTokenForApp_WithMetaTenant()
+        {
+            // Arrange
+            InitializeTokenAcquisitionObjects();
+
+            Assert.Equal(0, _msalTestTokenCacheProvider.Count);
+
+            async Task result() =>
+                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp, "organizations").ConfigureAwait(false);
+
+            ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(result).ConfigureAwait(false);
+            Assert.Contains(IDWebErrorMessage.ClientCredentialTenantShouldBeTenanted, ex.Message);
+            Assert.Equal(0, _msalTestTokenCacheProvider.Count);
         }
 
         [Fact]
@@ -77,13 +94,11 @@ namespace Microsoft.Identity.Web.Test.Integration
 
             // Act & Assert
             async Task result() =>
-                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopesForUser).ConfigureAwait(false);
+                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopesForUser.FirstOrDefault()).ConfigureAwait(false);
 
-            MsalServiceException ex = await Assert.ThrowsAsync<MsalServiceException>(result).ConfigureAwait(false);
+            ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(result).ConfigureAwait(false);
 
-            Assert.Contains(TestConstants.InvalidScopeError, ex.Message);
-            Assert.Equal(TestConstants.InvalidScope, ex.ErrorCode);
-            Assert.StartsWith(TestConstants.InvalidScopeErrorcode, ex.Message);
+            Assert.Contains(IDWebErrorMessage.ClientCredentialScopeParameterShouldEndInDotDefault, ex.Message);
             Assert.Equal(0, _msalTestTokenCacheProvider.Count);
         }
 

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -71,7 +71,6 @@ namespace Microsoft.Identity.Web.Test.Integration
         }
 
         [Theory]
-        [InlineData(Constants.Common)]
         [InlineData(Constants.Organizations)]
         [InlineData(Constants.Consumers)]
         public async Task GetAccessTokenForApp_WithMetaTenant(string metaTenant)


### PR DESCRIPTION
Checked with @hpsin and here is what we agreed to:
- Change the signature of `GetAccessTokenForUserAsync` to take a `string` (instead of a `IEnumerable<string>`) as there is only one possible string for a given resource of App Id URI AppIdUri: "AppIdUri/.default". Check that the resource ends in "./default"
- Add an additional optional parameter `tenant` to support this scenario, and verify that this tenant is not organizations (and of course common and consumers, which don't make sense)

```CSharp
public async Task<string> GetAccessTokenForAppAsync(string scope, string? tenant = null)
```