### PR TITLE
add basic unit tests for graph and downstream web api

### DIFF
--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiOptions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Base URL for the called downstream web API. For instance <c>"https://graph.microsoft.com/beta/".</c>.
         /// </summary>
-        public string BaseUrl { get; set; } = "https://graph.microsoft.com/v1.0";
+        public string BaseUrl { get; set; } = Constants.GraphBaseUrlV1;
 
         /// <summary>
         /// Path relative to the <see cref="BaseUrl"/> (for instance "me").

--- a/src/Microsoft.Identity.Web/MicrosoftGraph/MicrosoftGraphOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftGraph/MicrosoftGraphOptions.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Identity.Web
         /// but it can be changed to use the Microsoft Graph Beta endpoint or national cloud versions
         /// of MicrosoftGraph.
         /// </summary>
-        public string BaseUrl { get; set; } = "https://graph.microsoft.com/v1.0/";
+        public string BaseUrl { get; set; } = Constants.GraphBaseUrlV1;
 
         /// <summary>
         /// Space separated scopes used to call Microsoft Graph,
         /// for instance <c>user.read mail.read</c>.
         /// </summary>
-        public string? Scopes { get; set; } = "user.read";
+        public string? Scopes { get; set; } = Constants.UserReadScope;
     }
 }

--- a/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string AuthorityOrganizationsUSWithV2 = AuthorityOrganizationsUSTenant + "/v2.0";
         public const string AuthorityWithTenantSpecifiedWithV2 = AadInstance + "/" + TenantIdAsGuid + "/v2.0";
         public const string AadIssuer = AadInstance + "/" + TenantIdAsGuid + "/v2.0";
+        public const string GraphBaseUrlBeta = "https://graph.microsoft.com/beta";
 
         // B2C
         public const string B2CSignUpSignInUserFlow = "b2c_1_susi";
@@ -88,6 +89,7 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string InvalidScopeError = "The scope user.read is not valid.";
         public const string InvalidScopeErrorcode = "AADSTS70011";
         public const string InvalidScope = "invalid_scope";
+        public const string GraphScopes = "user.write user.read.all";
 
         // Constants for the lab
         public const string ConfidentialClientKeyVaultUri = "https://buildautomation.vault.azure.net/secrets/AzureADIdentityDivisionTestAgentSecret/";

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Identity.Web.Test
         };
 
         private Action<MicrosoftGraphOptions> _configureMicrosoftGraphOptions = (options) =>
-        {eUr
-            options.BaseUrl = TestConstants.GraphBaslBeta;
+        {
+            options.BaseUrl = TestConstants.GraphBaseUrlBeta;
             options.Scopes = TestConstants.GraphScopes;
         };
 
@@ -440,6 +440,60 @@ namespace Microsoft.Identity.Web.Test
                 Assert.Equal(Constants.GraphBaseUrlV1, msGraphOptions.Value.BaseUrl);
                 Assert.Equal(Constants.UserReadScope, msGraphOptions.Value.Scopes);
                 Assert.Equal(msGraphOptions.Value.BaseUrl, graphServiceClient.BaseUrl);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AddDownstreamWebApiOptionsTest(bool useDownstreamWebApiOptions)
+        {
+            Action<DownstreamWebApiOptions> configureDownstreamWebApiOptions = (options) =>
+           {
+               options.BaseUrl = TestConstants.GraphBaseUrlBeta;
+               options.Scopes = TestConstants.Scopes;
+               options.Tenant = TestConstants.TenantIdAsGuid;
+           };
+
+            var configMock = Substitute.For<IConfiguration>();
+            configMock.Configure().GetSection(ConfigSectionName).Returns(_configSection);
+
+            var services = new ServiceCollection();
+            var builder = services.AddAuthentication()
+                .AddMicrosoftIdentityWebApp(configMock, ConfigSectionName)
+                .EnableTokenAcquisitionToCallDownstreamApi()
+                .AddInMemoryTokenCaches();
+
+            if (useDownstreamWebApiOptions)
+            {
+                builder.AddDownstreamWebApi(ConfigSectionName, configureDownstreamWebApiOptions);
+            }
+            else
+            {
+                builder.AddDownstreamWebApi(ConfigSectionName, configMock);
+            }
+
+            var provider = services.BuildServiceProvider();
+            // Assert correct services added
+            Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<OpenIdConnectOptions>));
+            Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<MicrosoftIdentityOptions>));
+            Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<DownstreamWebApiOptions>));
+
+            // Assert properties set
+            var downstreamWebApiOptions = provider.GetRequiredService<IOptionsSnapshot<DownstreamWebApiOptions>>();
+            IDownstreamWebApi downstreamWebApi = provider.GetRequiredService<IDownstreamWebApi>();
+
+            if (useDownstreamWebApiOptions)
+            {
+                Assert.Equal(TestConstants.GraphBaseUrlBeta, downstreamWebApiOptions.Get(ConfigSectionName).BaseUrl);
+                Assert.Equal(TestConstants.Scopes, downstreamWebApiOptions.Get(ConfigSectionName).Scopes);
+                Assert.Equal(TestConstants.TenantIdAsGuid, downstreamWebApiOptions.Get(ConfigSectionName).Tenant);
+            }
+            else
+            {
+                Assert.Equal(Constants.GraphBaseUrlV1, downstreamWebApiOptions.Get(ConfigSectionName).BaseUrl);
+                Assert.Null(downstreamWebApiOptions.Get(ConfigSectionName).Scopes);
+                Assert.Null(downstreamWebApiOptions.Get(ConfigSectionName).Tenant);
             }
         }
 


### PR DESCRIPTION
we need to have more extensive integration tests, but we'll do that in the fundamentals section.