### PR TITLE
Fix for Authorization header format in Graph calls

### DIFF
--- a/src/Microsoft.Identity.Web/MicrosoftGraph/TokenAcquisitionCredentialProvider.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftGraph/TokenAcquisitionCredentialProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Web
                 Constants.Authorization,
                 string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0}{1}",
+                    "{0} {1}",
                     Constants.Bearer,
                     await _tokenAcquisition.GetAccessTokenForUserAsync(_initialScopes).ConfigureAwait(false)));
         }


### PR DESCRIPTION
When adding Authorization header to Graph requests, space was missing, so requests weren't going through.