### PR TITLE
set response type to just idToken for web app only scenario in b2c

### DIFF
--- a/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
+++ b/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
@@ -32,9 +32,17 @@ namespace Microsoft.Identity.Web
                 !string.IsNullOrEmpty(userFlow) &&
                 !string.Equals(userFlow, defaultUserFlow, StringComparison.OrdinalIgnoreCase))
             {
-                context.ProtocolMessage.ResponseType = OpenIdConnectResponseType.CodeIdToken;
                 context.ProtocolMessage.IssuerAddress = BuildIssuerAddress(context, defaultUserFlow, userFlow);
                 context.Properties.Items.Remove(OidcConstants.PolicyKey);
+
+                if (!Options.HasClientCredentials)
+                {
+                    context.ProtocolMessage.ResponseType = OpenIdConnectResponseType.IdToken;
+                }
+                else
+                {
+                    context.ProtocolMessage.ResponseType = OpenIdConnectResponseType.CodeIdToken;
+                }
             }
 
             return Task.CompletedTask;

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1105,6 +1105,12 @@
             Is considered B2C if the attribute SignUpSignInPolicyId is defined.
             </summary>
         </member>
+        <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.HasClientCredentials">
+            <summary>
+            Is considered to have client credentials if the attribute ClientCertificates
+            or ClientSecret is defined.
+            </summary>
+        </member>
         <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.ClientCertificates">
             <summary>
             Description of the certificates used to prove the identity of the Web app or Web API.

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -54,6 +55,15 @@ namespace Microsoft.Identity.Web
         internal bool IsB2C
         {
             get => !string.IsNullOrWhiteSpace(DefaultUserFlow);
+        }
+
+        /// <summary>
+        /// Is considered to have client credentials if the attribute ClientCertificates
+        /// or ClientSecret is defined.
+        /// </summary>
+        internal bool HasClientCredentials
+        {
+            get => !string.IsNullOrWhiteSpace(ClientSecret) || (ClientCertificates != null && ClientCertificates.Any());
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string B2CInstance = "https://fabrikamb2c.b2clogin.com";
         public const string B2CInstance2 = "https://catb2c.b2clogin.com";
         public const string B2CCustomDomainInstance = "https://catsAreAmazing.com";
+        public const string ClientSecret = "catsarecool";
 
         public const string B2CAuthority = B2CInstance + "/" + B2CTenant + "/" + B2CSignUpSignInUserFlow;
         public const string B2CAuthorityWithV2 = B2CAuthority + "/v2.0";

--- a/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
@@ -26,10 +26,17 @@ namespace Microsoft.Identity.Web.Test
             _authScheme = new AuthenticationScheme(OpenIdConnectDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme, typeof(OpenIdConnectHandler));
         }
 
-        [Fact]
-        public async void OnRedirectToIdentityProvider_CustomUserFlow_UpdatesContext()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async void OnRedirectToIdentityProvider_CustomUserFlow_UpdatesContext(bool hasClientCredentials)
         {
             var options = new MicrosoftIdentityOptions() { SignUpSignInPolicyId = DefaultUserFlow };
+            if (hasClientCredentials)
+            {
+                options.ClientSecret = TestConstants.ClientSecret;
+            }
+
             var handler = new AzureADB2COpenIDConnectEventHandlers(OpenIdConnectDefaults.AuthenticationScheme, options);
             var httpContext = HttpContextUtilities.CreateHttpContext();
             var authProperties = new AuthenticationProperties();
@@ -46,9 +53,16 @@ namespace Microsoft.Identity.Web.Test
             await handler.OnRedirectToIdentityProvider(context).ConfigureAwait(false);
 
             Assert.Equal(TestConstants.Scopes, context.ProtocolMessage.Scope);
-            Assert.Equal(OpenIdConnectResponseType.CodeIdToken, context.ProtocolMessage.ResponseType);
             Assert.Equal(_customIssuer, context.ProtocolMessage.IssuerAddress, true);
             Assert.False(context.Properties.Items.ContainsKey(OidcConstants.PolicyKey));
+            if (hasClientCredentials)
+            {
+                Assert.Equal(OpenIdConnectResponseType.CodeIdToken, context.ProtocolMessage.ResponseType);
+            }
+            else
+            {
+                Assert.Equal(OpenIdConnectResponseType.IdToken, context.ProtocolMessage.ResponseType);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
fix for https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/issues/399

and for https://github.com/AzureAD/microsoft-identity-web/issues/467
