### PR TITLE
Adding the missing NuGet packages to the release build

### DIFF
--- a/build/build.md
+++ b/build/build.md
@@ -25,6 +25,8 @@
 - [template-pack-and-sign-all-nugets.yaml](template-pack-and-sign-all-nugets.yaml)
   - [template-pack-and-sign-nuget.yaml](template-pack-and-sign-nuget.yaml) `('$(Build.SourcesDirectory)\src\Microsoft.Identity.Web')`
   - [template-pack-and-sign-nuget.yaml](template-pack-and-sign-nuget.yaml) `('$(Build.SourcesDirectory)\src\Microsoft.Identity.Web.UI')`
+  - [template-pack-and-sign-nuget.yaml](template-pack-and-sign-nuget.yaml) `('$(Build.SourcesDirectory)\src\Microsoft.Identity.Web.MicrosoftGraph')`
+  - [template-pack-and-sign-nuget.yaml](template-pack-and-sign-nuget.yaml) `('$(Build.SourcesDirectory)\src\Microsoft.Identity.Web.MicrosoftGraphBeta')`
   - [template-pack-and-sign-nuget.yaml](template-pack-and-sign-nuget.yaml) `('$(Build.SourcesDirectory)\ProjectTemplates')`
   - 'Copy Files from `$(Build.SourcesDirectory)` to: `$(Build.ArtifactStagingDirectory)\packages'`
   - Sign Packages `'('$(Build.ArtifactStagingDirectory)\packages')`

--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -21,6 +21,20 @@ steps:
     ProjectRootPath: '$(Build.SourcesDirectory)\src\Microsoft.Identity.Web.UI'
     AssemblyName: 'Microsoft.Identity.Web.UI*'
 
+# Pack and sign Microsoft.Identity.Web.UI
+- template: template-pack-and-sign-nuget.yaml
+  parameters:
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
+    ProjectRootPath: '$(Build.SourcesDirectory)\src\Microsoft.Identity.Web.MicrosoftGraph'
+    AssemblyName: 'Microsoft.Identity.Web.MicrosoftGraph*'
+
+# Pack and sign Microsoft.Identity.Web.UI
+- template: template-pack-and-sign-nuget.yaml
+  parameters:
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
+    ProjectRootPath: '$(Build.SourcesDirectory)\src\Microsoft.Identity.Web.MicrosoftGraphBeta'
+    AssemblyName: 'Microsoft.Identity.Web.MicrosoftGraphBeta*'
+
 # Pack and sign Microsoft.Identity.Web.ProjectTemplates
 - template: template-pack-and-sign-nuget.yaml
   parameters:


### PR DESCRIPTION
The release build does not produce NuGet packages for the Microsoft.Identity.Web.Microsoft.Graph and Microsoft.Identity.Web.Microsoft.Graph 

This PR adds this ability 