### PR TITLE
fix webapi2-b2c default su_si value

### DIFF
--- a/ProjectTemplates/configuration.json
+++ b/ProjectTemplates/configuration.json
@@ -3,7 +3,6 @@
         "B2C_Instance": "https://fabrikamb2c.b2clogin.com",
         "B2C_Domain": "fabrikamb2c.onmicrosoft.com",
         "B2C_Authority": "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
-        "B2C_DefaultPolicy": "b2c_1_susi",
 
         "B2C_Client_ClientId": "fdb91ff5-5ce6-41f3-bdbd-8267c817015d",
         "B2C_Client_ClientSecret": "[Copy the client secret added to the app from the Azure portal]",
@@ -210,10 +209,6 @@
                         {
                             "Property": "AzureAdB2C:Authority",
                             "SetFrom": "B2C_Authority"
-                        },
-                        {
-                            "Property": "AzureAdB2C:SignUpSignInPolicyId",
-                            "SetFrom": "B2C_DefaultPolicy"
                         }
                     ]
                 },

--- a/ProjectTemplates/templates/WebApi-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/.template.config/template.json
@@ -75,7 +75,7 @@
     "SignUpSignInPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "",
+      "defaultValue": "b2c_1_susi",
       "replaces": "MySignUpSignInPolicyId",
       "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
     },


### PR DESCRIPTION
@jmprieur i think we could release the template package & rerun that, but not run a new overall release build. 