### PR TITLE
Removing existing authorization token 

### DIFF
--- a/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionCredentialProvider.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionCredentialProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Web
         /// <returns>A Task (as this is an async method).</returns>
         public async Task AuthenticateRequestAsync(HttpRequestMessage request)
         {
-            // In case of a retry there already can be a authorization header; replace it with new one to avoid using expired token
+            // In case of a retry there is already an authorization header; replace it with new one to avoid using expired token
             if (request.Headers.Contains(Constants.Authorization))
             {
                 request.Headers.Remove(Constants.Authorization);

--- a/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionCredentialProvider.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionCredentialProvider.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Identity.Web
         /// <returns>A Task (as this is an async method).</returns>
         public async Task AuthenticateRequestAsync(HttpRequestMessage request)
         {
+            // In case of a retry there already can be a authorization header; replace it with new one to avoid using expired token
+            if (request.Headers.Contains(Constants.Authorization))
+            {
+                request.Headers.Remove(Constants.Authorization);
+            }
+
             request.Headers.Add(
                 Constants.Authorization,
                 string.Format(


### PR DESCRIPTION
fixing bug #673 

I tried to leave it as much intact as is with the string format but personally i like this syntax more but not sure if I am missing something with the string format

```
request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token");
```