### PR TITLE
Fixes redirect URL in Web.UI for B2C user flows.

### DIFF
--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -9,6 +10,7 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
 {
@@ -42,9 +44,9 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         public IActionResult SignIn([FromRoute] string scheme)
         {
             scheme ??= OpenIdConnectDefaults.AuthenticationScheme;
-            var redirectUrl = Url.Content("~/");
+
             return Challenge(
-                new AuthenticationProperties { RedirectUri = redirectUrl },
+                new AuthenticationProperties { RedirectUri = GetRedirectUrl(HttpContext.Request.Headers[HeaderNames.Referer]) },
                 scheme);
         }
 
@@ -120,8 +122,7 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         {
             scheme ??= OpenIdConnectDefaults.AuthenticationScheme;
 
-            var redirectUrl = Url.Content("~/");
-            var properties = new AuthenticationProperties { RedirectUri = redirectUrl };
+            var properties = new AuthenticationProperties { RedirectUri = GetRedirectUrl(HttpContext.Request.Headers[HeaderNames.Referer]) };
             properties.Items[Constants.Policy] = _options.Value?.ResetPasswordPolicyId;
             return Challenge(properties, scheme);
         }
@@ -141,10 +142,11 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
                 return Challenge(scheme);
             }
 
-            var redirectUrl = Url.Content("~/");
-            var properties = new AuthenticationProperties { RedirectUri = redirectUrl };
+            var properties = new AuthenticationProperties { RedirectUri = GetRedirectUrl(HttpContext.Request.Headers[HeaderNames.Referer]) };
             properties.Items[Constants.Policy] = _options.Value?.EditProfilePolicyId;
             return Challenge(properties, scheme);
         }
+
+        private string GetRedirectUrl(string referrer) => string.IsNullOrEmpty(referrer) ? Url.Content("~/") : new Uri(referrer).LocalPath;
     }
 }

--- a/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
+++ b/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Web
             // ', error_uri: 'error_uri is null'.
             else if (context.Failure is OpenIdConnectProtocolException && context.Failure.Message.Contains(ErrorCodes.AccessDenied))
             {
-                context.Response.Redirect($"{context.Request.PathBase}/");
+                context.Response.Redirect(context.Properties.RedirectUri);
             }
             else
             {

--- a/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
+++ b/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Web
             // ', error_uri: 'error_uri is null'.
             else if (context.Failure is OpenIdConnectProtocolException && context.Failure.Message.Contains(ErrorCodes.AccessDenied))
             {
-                context.Response.Redirect(context.Properties.RedirectUri);
+                context.Response.Redirect(context.Properties.RedirectUri ?? $"{context.Request.PathBase}/");
             }
             else
             {


### PR DESCRIPTION
Attempt to fix #620.

**Issue:** After the Reset Password, Edit Profile, and Sign Up B2C user flows, we redirect to the root page. So if the user is on a non-root page, they will be redirected to root, and not the page they were on before triggering the flow.

**Fix:** After the challenge, redirect to the URL from 'Referer' header.

**Repro steps / request order with the current PR:**

Start with an unauthenticated user.

**Normal sign-in:**
1. Go to /TodoList/Create.
2. Redirected to tenant.b2clogin.com and B2C Sign In form is shown.
3. Enter credentials and sign in.
4. Redirected to tenant.b2clogin.com.
5. Redirected to /TodoList/Create.


**Sign-up, cancel, sign in:**
1. Go to /TodoList/Create.
2. Redirected to tenant.b2clogin.com and B2C Sign In form is shown.
3. Click Sign up.
4. Redirected to tenant.b2clogin.com and B2C Sign Up form is shown.
5. Click Cancel.
6. OnRemoteFailure event is hit because of `AccessDenied` error.
	- `context.Properties.RedirectUri` is `/TodoList/Create`.
	- We redirect to `RedirectUri`.
	https://github.com/AzureAD/microsoft-identity-web/blob/062ffb020091d2c95edd10a50504c8bcdb750c3f/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs#L83
7. Redirected to /TodoList/Create.
8. Because still not authenticated, redirected to tenant.b2clogin.com and B2C Sign In form is shown.
9. Enter credentials and sign in.
10. Redirected to tenant.b2clogin.com.
11. Redirected to /TodoList/Create.

**Forgot password, cancel, sign in:**
1. Go to /TodoList/Create.
2. Redirected to tenant.b2clogin.com and B2C Sign In form is shown.
3. Click Forgot your password.
4. OnRemoteFailure event is hit because of B2CPaswordReset error.
	- `context.Properties.RedirectUri` is `/TodoList/Create`.
	- We redirect to `Microsoft/Account/ResetPassword`.
	https://github.com/AzureAD/microsoft-identity-web/blob/062ffb020091d2c95edd10a50504c8bcdb750c3f/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs#L72
5. `ResetPassword` actions send an auth Challenge.
	- Referer is tenant.b2clogin.com at this point.
6. Redirected to tenant.b2clogin.com and B2C Password Reset form is shown.
7. Click Cancel.
8. OnRemoteFailure event is hit because of `AccessDenied` error.
	- `context.Properties.RedirectUri` is `/`.
	- We redirect to `RedirectUri`.
9. Because still not authenticated, redirected to tenant.b2clogin.com and B2C Sign In form is shown.
10. Enter credentials and sign in.
11. Redirected to tenant.b2clogin.com.
12. Redirected to /.


On step 4 here we lose the previous page URL.