### PR TITLE
Do not require scopes for app only tokens

### DIFF
--- a/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionAuthenticationProvider.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionAuthenticationProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Identity.Web
                 appOnly = msalAuthProviderOption.AppOnly ?? appOnly;
             }
 
-            if (scopes == null)
+            if (!appOnly && scopes == null)
             {
                 throw new ArgumentNullException(
                     Constants.Scopes,


### PR DESCRIPTION
scopes are ignored anyway for an app-only requests, there is no reason to require them.