### PR TITLE
possible improvements to ms.id.web for net472

### DIFF
--- a/Classes depending on ASP.NET Core.dgml
+++ b/Classes depending on ASP.NET Core.dgml
@@ -1,0 +1,2099 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DirectedGraph DataVirtualized="True" Layout="Sugiyama" ZoomLevel="-1" xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+  <Nodes>
+    <Node Id="@10" Category="CodeSchema_Assembly" Bounds="125.576770468577,427.453179264681,133.396666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Azure.Core, Version=1.4.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\azure.core\1.4.1\lib\netstandard2.0\Azure.Core.dll" Group="Collapsed" Label="Azure.Core.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@100" Category="CodeSchema_Assembly" Bounds="-247.530377416127,390.503509642195,263.07,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Components, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Components.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Components.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@102" Category="CodeSchema_Assembly" Bounds="-539.810377416127,775.504609642195,358.996666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Authentication.OpenIdConnect, Version=3.1.8.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.authentication.openidconnect\3.1.8\lib\netcoreapp3.1\Microsoft.AspNetCore.Authentication.OpenIdConnect.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Authentication.OpenIdConnect.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@104" Category="CodeSchema_Assembly" Bounds="125.576770468576,940.453179264681,340.833333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.identitymodel.protocols.openidconnect\5.5.0\lib\netstandard2.0\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" Group="Collapsed" Label="Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@106" Category="CodeSchema_Assembly" Bounds="125.576770468578,859.453179264681,201.606666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Identity.Client, Version=4.22.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.identity.client\4.22.0\ref\netcoreapp2.1\Microsoft.Identity.Client.dll" Group="Collapsed" Label="Microsoft.Identity.Client.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@108" Category="CodeSchema_Assembly" Bounds="494.316770468578,481.453179264681,235.326666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Collections.Concurrent, Version=4.0.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Collections.Concurrent.dll" Group="Collapsed" Label="System.Collections.Concurrent.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@110" Category="CodeSchema_Assembly" Bounds="494.316770468578,589.453179264681,248.406666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.IdentityModel.Tokens.Jwt, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\system.identitymodel.tokens.jwt\5.5.0\lib\netstandard2.0\System.IdentityModel.Tokens.Jwt.dll" Group="Collapsed" Label="System.IdentityModel.Tokens.Jwt.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@112" Category="CodeSchema_Assembly" Bounds="-539.810377416127,390.503679642201,262.28,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.CookiePolicy, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.CookiePolicy.dll" Group="Collapsed" Label="Microsoft.AspNetCore.CookiePolicy.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@114" Category="CodeSchema_Assembly" Bounds="125.576770468576,589.453179264681,276.313333333334,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Caching.Memory, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Caching.Memory.dll" Group="Collapsed" Label="Microsoft.Extensions.Caching.Memory.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@116" Category="CodeSchema_Assembly" Bounds="125.576770468577,454.453179264681,148.66,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Azure.Identity, Version=1.2.3.0, Culture=neutral, PublicKeyToken=92742159e12e44c8" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\azure.identity\1.2.3\lib\netstandard2.0\Azure.Identity.dll" Group="Collapsed" Label="Azure.Identity.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@118" Category="CodeSchema_Namespace" Bounds="-1658.42990099791,-417.712689460002,3686.505,635.001" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="57" Group="Expanded" Label="Microsoft‎.Identity‎.Web" UseManualLocation="True" />
+    <Node Id="@12" Category="CodeSchema_Assembly" Bounds="125.576770468577,724.453179264681,254.363333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Identity.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Identity.Core.dll" Group="Collapsed" Label="Microsoft.Extensions.Identity.Core.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@120" Category="CodeSchema_Namespace" Bounds="-158.122126758057,247.288410539998,274.27,195.0004" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="3" Group="Expanded" Label="Microsoft‎.Identity‎.Web‎.InstanceDiscovery" UseManualLocation="True" />
+    <Node Id="@122" Category="CodeSchema_Namespace" Bounds="-312.510497892643,-807.805329158234,575.668748415499,360.092539698232" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="9" Group="Expanded" Label="Microsoft‎.Identity‎.Web‎.Resource" />
+    <Node Id="@123" Category="CodeSchema_Namespace" Bounds="-146.102499778507,238.743527832019,291.93,25" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Microsoft‎.Identity‎.Web‎.TokenCacheProviders" UseManualLocation="True" />
+    <Node Id="@124" Category="CodeSchema_Namespace" Bounds="10.0170308200705,183.743519685732,353.343333333333,25" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Microsoft‎.Identity‎.Web‎.TokenCacheProviders‎.Distributed" UseManualLocation="True" />
+    <Node Id="@125" Category="CodeSchema_Namespace" Bounds="-177.796568634187,96.4460704534656,348.913333333333,25" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Microsoft‎.Identity‎.Web‎.TokenCacheProviders‎.InMemory" UseManualLocation="True" />
+    <Node Id="@126" Category="CodeSchema_Namespace" Bounds="-354.076402513263,183.743524347219,334.093333333333,25" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Microsoft‎.Identity‎.Web‎.TokenCacheProviders‎.Session" UseManualLocation="True" />
+    <Node Id="@127" Category="CodeSchema_Class" Bounds="29.7815838561889,-712.763844406651,159.47,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AadIssuerValidator" />
+    <Node Id="@128" Category="CodeSchema_Class" Bounds="1806.61843233542,-267.713338400791,201.456666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AadIssuerValidatorOptions" />
+    <Node Id="@129" Category="CodeSchema_Class" Bounds="-841.733234331246,172.286661599209,160.126666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AccountExtensions" />
+    <Node Id="@130" Category="CodeSchema_Class" Bounds="-1028.51823433124,-212.713338400791,295.73,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AppServicesAuthenticationBuilderExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@131" Category="CodeSchema_Class" Bounds="11.8667656687544,172.286661599209,246.516666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AppServicesAuthenticationDefaults" />
+    <Node Id="@132" Category="CodeSchema_Class" Bounds="-977.126567664578,-157.713338400791,244.946666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AppServicesAuthenticationHandler">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@133" Category="CodeSchema_Class" Bounds="-770.296567664579,-102.713338400791,265.286666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AppServicesAuthenticationInformation" />
+    <Node Id="@134" Category="CodeSchema_Class" Bounds="-1046.19990099791,-102.713338400791,245.093333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AppServicesAuthenticationOptions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@135" Category="CodeSchema_Class" Bounds="-606.214900997912,-157.713338400791,293.123333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AppServicesAuthenticationTokenAcquisition">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@136" Category="CodeSchema_Class" Bounds="1043.01176566875,-267.713338400791,150.67,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AuthorityHelpers">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@137" Category="CodeSchema_Class" Bounds="1498.46009900209,-157.713338400791,213.773333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AuthorizeForScopesAttribute">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@138" Category="CodeSchema_Class" Bounds="693.046765668755,-267.713338400791,288.6,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="AzureADB2COpenIDConnectEventHandlers">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@139" Category="CodeSchema_Class" Bounds="19.3867656687549,-102.713338400791,153.92,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Base64UrlHelpers" />
+    <Node Id="@14" Category="CodeSchema_Assembly" Bounds="494.316770468577,913.453179264681,169.146666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Threading, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Threading.dll" Group="Collapsed" Label="System.Threading.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@140" Category="CodeSchema_Class" Bounds="372.965099002088,62.2866615992089,174.763333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="CertificateDescription" />
+    <Node Id="@141" Category="CodeSchema_Enum" Bounds="386.998432335422,117.286661599209,146.696666666667,25" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="CertificateSource" />
+    <Node Id="@142" Category="CodeSchema_Class" Bounds="-1014.88656766458,172.286661599209,143.153333333334,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ClaimConstants" />
+    <Node Id="@143" Category="CodeSchema_Class" Bounds="1192.09176566875,-47.7133384007913,196.51,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ClaimsPrincipalExtensions" />
+    <Node Id="@144" Category="CodeSchema_Class" Bounds="-452.913234331245,172.286661599209,179.063333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ClaimsPrincipalFactory" />
+    <Node Id="@145" Category="CodeSchema_Class" Bounds="-13.7265676645787,-157.713338400791,112.146666666667,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ClientInfo" />
+    <Node Id="@146" Category="CodeSchema_Class" Bounds="-1638.42990099791,172.286661599209,113.466666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Constants" />
+    <Node Id="@147" Category="CodeSchema_Class" Bounds="-243.849900997912,172.286661599209,225.716666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="CookiePolicyOptionsExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@148" Category="CodeSchema_Class" Bounds="59.7817656687549,-47.7133384007911,189.13,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="DefaultCertificateLoader" />
+    <Node Id="@149" Category="CodeSchema_Class" Bounds="-1240.51823433124,-157.713338400791,169.73,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="DownstreamWebApi" />
+    <Node Id="@150" Category="CodeSchema_Class" Bounds="-1304.32990099791,-212.713338400791,225.353333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="DownstreamWebApiExtensions" />
+    <Node Id="@151" Category="CodeSchema_Class" Bounds="-1638.42990099791,-157.713338400791,265.553333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="DownstreamWebApiGenericExtensions" />
+    <Node Id="@152" Category="CodeSchema_Class" Bounds="-1482.51156766458,-47.7133384007909,211.716666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="DownstreamWebApiOptions" />
+    <Node Id="@153" Category="CodeSchema_Class" Bounds="-1494.96323433125,172.286661599209,119.516666666666,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ErrorCodes" />
+    <Node Id="@154" Category="CodeSchema_Class" Bounds="1423.03509900209,-47.7133384007914,116.623333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Extensions" />
+    <Node Id="@155" Category="CodeSchema_Class" Bounds="343.598432335422,-47.7133384007911,181.496666666666,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="HttpContextExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@156" Category="CodeSchema_Interface" Bounds="275.343432335421,7.28666159920886,154.006666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ICertificateLoader" />
+    <Node Id="@157" Category="CodeSchema_Class" Bounds="-1292.88656766458,7.28666159920897,106.466666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="IdHelper" />
+    <Node Id="@158" Category="CodeSchema_Interface" Bounds="-1475.11490099791,-102.713338400791,172.923333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="IDownstreamWebApi" />
+    <Node Id="@159" Category="CodeSchema_Class" Bounds="-651.606567664579,172.286661599209,168.693333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="IDWebErrorMessage" />
+    <Node Id="@16" Category="CodeSchema_Assembly" Bounds="494.316770468578,562.453179264681,214.9,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Diagnostics.Debug, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Debug.dll" Group="Collapsed" Label="System.Diagnostics.Debug.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@160" Category="CodeSchema_Interface" Bounds="-292.475082810478,-712.763844446651,238.35,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="IJwtBearerMiddlewareDiagnostics">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@161" Category="CodeSchema_Class" Bounds="1321.31676566875,-102.713338400791,320.06,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="IncrementalConsentAndConditionalAccessHelper">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@162" Category="CodeSchema_Interface" Bounds="-292.475082810478,-602.763844406651,270.793333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="IOpenIdConnectMiddlewareDiagnostics">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@163" Category="CodeSchema_Class" Bounds="-126.580460091391,287.230295670394,211.186666666667,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="IssuerConfigurationRetriever" />
+    <Node Id="@164" Category="CodeSchema_Class" Bounds="-92.0837934247242,342.230295670394,142.193333333333,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="IssuerMetadata" />
+    <Node Id="@165" Category="CodeSchema_Interface" Bounds="-559.758234331245,7.28666159920886,154.21,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ITokenAcquisition">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@166" Category="CodeSchema_Interface" Bounds="-343.909900997912,-47.7133384007911,194.513333333334,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ITokenAcquisitionInternal">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@167" Category="CodeSchema_Class" Bounds="-290.878416143811,-767.763844466651,235.156666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="JwtBearerMiddlewareDiagnostics">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@168" Category="CodeSchema_Class" Bounds="-1345.44656766458,172.286661599209,132.53,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="LogMessages" />
+    <Node Id="@169" Category="CodeSchema_Class" Bounds="-76.7737934247241,397.230295670394,111.573333333333,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Metadata" />
+    <Node Id="@170" Category="CodeSchema_Class" Bounds="256.106765668755,-157.713338400791,354.48,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityAppCallsWebApiAuthenticationBuilder">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@171" Category="CodeSchema_Class" Bounds="234.958432335422,-102.713338400791,290.776666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityBaseAuthenticationBuilder" />
+    <Node Id="@172" Category="CodeSchema_Class" Bounds="1287.40676566875,-267.713338400791,329.88,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityBlazorServiceCollectionExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@173" Category="CodeSchema_Class" Bounds="1112.95509900209,-157.713338400791,354.783333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityConsentAndConditionalAccessHandler">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@174" Category="CodeSchema_Class" Bounds="-24.1250828104776,-767.763844426651,267.283333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityIssuerValidatorFactory" />
+    <Node Id="@175" Category="CodeSchema_Class" Bounds="491.578432335421,7.28666159920886,193.536666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityOptions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@176" Category="CodeSchema_Class" Bounds="1620.34843233542,-47.7133384007914,245.996666666666,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityOptionsValidation">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@177" Category="CodeSchema_Class" Bounds="1337.00343233542,-212.713338400791,230.686666666666,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityServiceHandler">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@178" Category="CodeSchema_Class" Bounds="519.251765668755,-212.713338400791,308.19,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebApiAuthenticationBuilder">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@179" Category="CodeSchema_Class" Bounds="1042.44009900209,-322.713338400791,363.813333333334,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebApiAuthenticationBuilderExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@18" Category="CodeSchema_Assembly" Bounds="-539.810377416127,610.504079642201,309.783333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Authentication.OAuth, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Authentication.OAuth.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Authentication.OAuth.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@180" Category="CodeSchema_Class" Bounds="256.343432335421,-267.713338400791,406.006666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@181" Category="CodeSchema_Class" Bounds="289.783432335421,-377.713338400791,339.126666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebApiServiceCollectionExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@182" Category="CodeSchema_Class" Bounds="-402.821567664579,-212.713338400791,312.336666666667,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebAppAuthenticationBuilder">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@183" Category="CodeSchema_Class" Bounds="-430.633234331245,-322.713338400791,367.96,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebAppAuthenticationBuilderExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@184" Category="CodeSchema_Class" Bounds="-215.729900997912,-267.713338400791,410.153333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebAppAuthenticationBuilderWithConfiguration" />
+    <Node Id="@185" Category="CodeSchema_Class" Bounds="-182.289900997912,-377.713338400791,343.273333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebAppServiceCollectionExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@186" Category="CodeSchema_Class" Bounds="619.746765668754,-47.7133384007913,303.2,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MicrosoftIdentityWebChallengeUserException" />
+    <Node Id="@187" Category="CodeSchema_Class" Bounds="-714.783234331245,-47.713338400791,242.26,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="MsalAspNetCoreHttpClientFactory" />
+    <Node Id="@188" Category="CodeSchema_Class" Bounds="-1182.91656766458,172.286661599209,138.03,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="OidcConstants" />
+    <Node Id="@189" Category="CodeSchema_Class" Bounds="-290.878416143811,-657.763844426651,267.6,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="OpenIdConnectMiddlewareDiagnostics">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@190" Category="CodeSchema_Class" Bounds="8.30652024277435,-657.757465604524,178.636666666667,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="RegisterValidAudience">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@191" Category="CodeSchema_Class" Bounds="-292.510497892643,-547.678087014649,257.013333333333,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="RolesRequiredHttpContextExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@192" Category="CodeSchema_Class" Bounds="-292.510497892643,-492.678083510546,266.25,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ScopesRequiredHttpContextExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@193" Category="CodeSchema_Class" Bounds="-251.056567664579,-157.713338400791,206.806666666667,25" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsFinal="True" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="ServiceCollectionExtensions">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@194" Category="CodeSchema_Class" Bounds="-162.161567664579,-102.713338400791,151.016666666667,25" CodeSchemaProperty_IsInternal="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="TokenAcquisition">
+      <Category Ref="Category1" />
+    </Node>
+    <Node Id="@195" Category="CodeSchema_Class" Bounds="-471.154900997912,62.2866615992089,193.003333333333,25" CodeSchemaProperty_IsPublic="True" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="TokenAcquisitionOptions" />
+    <Node Id="@2" Category="CodeSchema_Assembly" Bounds="494.316770468577,832.453179264681,220.276666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Text.Encodings.Web.dll" Group="Collapsed" Label="System.Text.Encodings.Web.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@20" Category="CodeSchema_Assembly" Bounds="494.316770468577,805.453179264681,205.326666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Security.Principal, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Security.Principal.dll" Group="Collapsed" Label="System.Security.Principal.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@22" Category="CodeSchema_Assembly" Bounds="494.316770468577,535.453179264681,212.543333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.ComponentModel, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.dll" Group="Collapsed" Label="System.ComponentModel.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@24" Category="CodeSchema_Assembly" Bounds="125.576770468577,535.453179264681,234.736666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Session, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Session.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Session.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@26" Category="CodeSchema_Assembly" Bounds="-243.687044082793,445.503609642195,273.043333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Authentication, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Authentication.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Authentication.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@28" Category="CodeSchema_Assembly" Bounds="-183.257044082794,665.504034642207,337.493333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Components.Authorization, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Components.Authorization.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Components.Authorization.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@30" Category="CodeSchema_Assembly" Bounds="494.316770468577,859.453179264681,162.446666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Text.Json, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Text.Json.dll" Group="Collapsed" Label="System.Text.Json.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@32" Category="CodeSchema_Assembly" Bounds="-539.810377416127,335.503579642201,218.88,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Http, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Http.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Http.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@34" Category="CodeSchema_Assembly" Bounds="125.576770468577,697.453179264681,210.386666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Http, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Http.dll" Group="Collapsed" Label="Microsoft.Extensions.Http.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@36" Category="CodeSchema_Assembly" Bounds="494.316770468577,643.453179264681,161.31,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Net.Http, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Net.Http.dll" Group="Collapsed" Label="System.Net.Http.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@38" Category="CodeSchema_Assembly" Bounds="494.316770468577,616.45317926468,138.096666666667,25.0000000000002" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Linq, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Linq.dll" Group="Collapsed" Label="System.Linq.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@4" Category="CodeSchema_Assembly" AssemblyTimestamp="11/02/2020 20:37:55" Bounds="-1678.42990099791,-847.805429158234,3726.505,1310.09433969823" CodeSchemaProperty_StrongName="Microsoft.Identity.Web, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae" DelayedChildNodesState="Incomplete" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="9" FilePath="$(bd795319-75b8-4251-ae92-8dd5a807c28e.OutputPath)" Group="Expanded" Label="Microsoft.Identity.Web.dll" UseManualLocation="True" />
+    <Node Id="@40" Category="CodeSchema_Assembly" Bounds="125.576770468578,643.453179264681,296.216666666666,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Configuration.Binder, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Configuration.Binder.dll" Group="Collapsed" Label="Microsoft.Extensions.Configuration.Binder.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@42" Category="CodeSchema_Assembly" Bounds="-539.810377416127,665.504179642201,326.553333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Authentication.JwtBearer, Version=3.1.8.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.authentication.jwtbearer\3.1.8\lib\netcoreapp3.1\Microsoft.AspNetCore.Authentication.JwtBearer.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Authentication.JwtBearer.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@44" Category="CodeSchema_Assembly" Bounds="-222.667044082794,555.503834642207,298.69,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Components.Server, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Components.Server.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Components.Server.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@46" Category="CodeSchema_Assembly" Bounds="-200.027044082793,610.503934642207,317.373333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Authentication.Cookies, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Authentication.Cookies.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Authentication.Cookies.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@48" Category="CodeSchema_Assembly" Bounds="-539.810377416127,445.503779642201,266.123333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Http.Features, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Http.Features.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Http.Features.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@50" Category="CodeSchema_Assembly" Bounds="125.576770468577,481.453179264681,259.556666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Azure.Security.KeyVault.Certificates, Version=4.1.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\azure.security.keyvault.certificates\4.1.0\lib\netstandard2.0\Azure.Security.KeyVault.Certificates.dll" Group="Collapsed" Label="Azure.Security.KeyVault.Certificates.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@52" Category="CodeSchema_Assembly" Bounds="494.316770468576,778.453179264681,320.466666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Security.Cryptography.X509Certificates, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.X509Certificates.dll" Group="Collapsed" Label="System.Security.Cryptography.X509Certificates.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@54" Category="CodeSchema_Assembly" Bounds="125.576770468578,832.453179264681,237.813333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Primitives, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Primitives.dll" Group="Collapsed" Label="Microsoft.Extensions.Primitives.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@56" Category="CodeSchema_Assembly" Bounds="494.316770468577,670.453179264681,188.736666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Net.Primitives, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Net.Primitives.dll" Group="Collapsed" Label="System.Net.Primitives.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@58" Category="CodeSchema_Assembly" Bounds="494.316770468577,940.453179264681,198.943333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Threading.Tasks, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.dll" Group="Collapsed" Label="System.Threading.Tasks.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@6" Category="CodeSchema_Assembly" Bounds="494.316770468577,697.453179264681,160.026666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Runtime, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Runtime.dll" Group="Collapsed" Label="System.Runtime.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@60" Category="CodeSchema_Assembly" Bounds="125.576770468578,913.453179264681,254.88,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.IdentityModel.Protocols, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.identitymodel.protocols\5.5.0\lib\netstandard2.0\Microsoft.IdentityModel.Protocols.dll" Group="Collapsed" Label="Microsoft.IdentityModel.Protocols.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@62" Category="CodeSchema_Assembly" Bounds="494.316770468579,751.453179264681,195,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Security.Claims, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Security.Claims.dll" Group="Collapsed" Label="System.Security.Claims.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@64" Category="CodeSchema_Assembly" Bounds="494.316770468577,427.453179264681,241.556666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.IdentityModel.Tokens, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.identitymodel.tokens\5.5.0\lib\netstandard2.0\Microsoft.IdentityModel.Tokens.dll" Group="Collapsed" Label="Microsoft.IdentityModel.Tokens.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@66" Category="CodeSchema_Assembly" Bounds="125.576770468577,886.453179264681,288.823333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.IdentityModel.JsonWebTokens, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.identitymodel.jsonwebtokens\5.5.0\lib\netstandard2.0\Microsoft.IdentityModel.JsonWebTokens.dll" Group="Collapsed" Label="Microsoft.IdentityModel.JsonWebTokens.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@68" Category="CodeSchema_Assembly" Bounds="494.316770468579,724.453179264681,218.25,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Runtime.Extensions, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Extensions.dll" Group="Collapsed" Label="System.Runtime.Extensions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@70" Category="CodeSchema_Assembly" Bounds="-539.810377416127,500.503879642201,277.103333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Http.Extensions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Http.Extensions.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Http.Extensions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@72" Category="CodeSchema_Assembly" Bounds="125.576770468576,778.453179264681,359.733333333334,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Options.ConfigurationExtensions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Options.ConfigurationExtensions.dll" Group="Collapsed" Label="Microsoft.Extensions.Options.ConfigurationExtensions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@74" Category="CodeSchema_Assembly" Bounds="494.316770468577,886.453179264681,240.483333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Text.RegularExpressions, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Text.RegularExpressions.dll" Group="Collapsed" Label="System.Text.RegularExpressions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@76" Category="CodeSchema_Assembly" Bounds="-232.707044082793,500.503734642207,285.503333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Mvc.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Mvc.Abstractions.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Mvc.Abstractions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@78" Category="CodeSchema_Assembly" Bounds="125.576770468576,751.453179264681,298.52,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Logging.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Logging.Abstractions.dll" Group="Collapsed" Label="Microsoft.Extensions.Logging.Abstractions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@8" Category="CodeSchema_Assembly" Bounds="-290.930377416127,335.503409642195,244.75,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Mvc.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Mvc.Core.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Mvc.Core.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@80" Category="CodeSchema_Assembly" Bounds="125.576770468576,562.453179264681,297.576666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Caching.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Caching.Abstractions.dll" Group="Collapsed" Label="Microsoft.Extensions.Caching.Abstractions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@82" Category="CodeSchema_Assembly" Bounds="-539.810377416127,720.504409642195,341.306666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Authentication.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Authentication.Abstractions.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Authentication.Abstractions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@84" Category="CodeSchema_Assembly" Bounds="125.576770468577,616.45317926468,327.786666666667,25.0000000000002" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Configuration.Abstractions.dll" Group="Collapsed" Label="Microsoft.Extensions.Configuration.Abstractions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@86" Category="CodeSchema_Assembly" Bounds="125.576770468577,670.453179264681,366.74,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.DependencyInjection.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.DependencyInjection.Abstractions.dll" Group="Collapsed" Label="Microsoft.Extensions.DependencyInjection.Abstractions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@88" Category="CodeSchema_Assembly" Bounds="-168.50371074946,720.504134642207,342.733333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.DataProtection.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.DataProtection.Abstractions.dll" Group="Collapsed" Label="Microsoft.AspNetCore.DataProtection.Abstractions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@90" Category="CodeSchema_Assembly" Bounds="-539.810377416127,555.503979642201,287.143333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.AspNetCore.Http.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.AspNetCore.Http.Abstractions.dll" Group="Collapsed" Label="Microsoft.AspNetCore.Http.Abstractions.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@92" Category="CodeSchema_Assembly" Bounds="494.316770468577,508.453179264681,173.663333333333,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="System.Collections, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.1.0\ref\netcoreapp3.1\System.Collections.dll" Group="Collapsed" Label="System.Collections.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@94" Category="CodeSchema_Assembly" Bounds="125.576770468577,805.453179264681,228.666666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Extensions.Options, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Extensions.Options.dll" Group="Collapsed" Label="Microsoft.Extensions.Options.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@96" Category="CodeSchema_Assembly" Bounds="494.316770468577,454.453179264681,220.196666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Microsoft.Net.Http.Headers, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\microsoft.aspnetcore.app.ref\3.1.2\ref\netcoreapp3.1\Microsoft.Net.Http.Headers.dll" Group="Collapsed" Label="Microsoft.Net.Http.Headers.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@98" Category="CodeSchema_Assembly" Bounds="125.576770468578,508.453179264681,238.756666666667,25" CodeSchemaProperty_IsExternal="True" CodeSchemaProperty_StrongName="Azure.Security.KeyVault.Secrets, Version=4.1.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8" DelayedChildNodesState="NotFetched" DelayedCrossGroupLinksState="Fetched" FilePath="C:\Users\jmprieur\.nuget\packages\azure.security.keyvault.secrets\4.1.0\lib\netstandard2.0\Azure.Security.KeyVault.Secrets.dll" Group="Collapsed" Label="Azure.Security.KeyVault.Secrets.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="ASP.NETCore" Category="Category1" Bounds="54.7863804738943,492.287228911611,112.963333333333,25" Group="Collapsed" Label="ASP.NET Core" UseManualLocation="True" />
+    <Node Id="Done" Category="Category1" Bounds="150.153545773709,247.286661599209,68.51,25" Group="Collapsed" UseManualLocation="True" />
+    <Node Id="_standardGraphExternalsGroup" Category="Externals" Bounds="197.749813807228,492.287228911611,86.99,25" Group="Collapsed" Label="Externals" LayoutSettings="List" UseManualLocation="True" />
+  </Nodes>
+  <Links>
+    <Link Source="@118" Target="@128" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@129" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@130" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@131" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@132" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@133" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@134" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@135" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@136" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@137" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@138" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@139" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@140" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@141" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@142" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@143" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@144" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@145" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@146" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@147" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@148" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@149" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@150" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@151" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@152" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@153" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@154" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@155" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@156" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@157" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@158" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@159" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@161" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@165" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@166" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@168" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@170" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@171" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@172" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@173" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@175" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@176" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@177" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@178" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@179" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@180" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@181" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@182" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@183" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@184" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@185" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@186" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@187" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@188" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@193" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@194" Category="Contains" FetchingParent="@118" />
+    <Link Source="@118" Target="@195" Category="Contains" FetchingParent="@118" />
+    <Link Source="@120" Target="@163" Category="Contains" FetchingParent="@120" />
+    <Link Source="@120" Target="@164" Category="Contains" FetchingParent="@120" />
+    <Link Source="@120" Target="@169" Category="Contains" FetchingParent="@120" />
+    <Link Source="@122" Target="@127" Category="Contains" FetchingParent="@122" />
+    <Link Source="@122" Target="@160" Category="Contains" FetchingParent="@122" />
+    <Link Source="@122" Target="@162" Category="Contains" FetchingParent="@122" />
+    <Link Source="@122" Target="@167" Category="Contains" FetchingParent="@122" />
+    <Link Source="@122" Target="@174" Category="Contains" FetchingParent="@122" />
+    <Link Source="@122" Target="@189" Category="Contains" FetchingParent="@122" />
+    <Link Source="@122" Target="@190" Category="Contains" FetchingParent="@122" />
+    <Link Source="@122" Target="@191" Category="Contains" FetchingParent="@122" />
+    <Link Source="@122" Target="@192" Category="Contains" FetchingParent="@122" />
+    <Link Source="@123" Target="@106" Category="References" Bounds="6.31858735571168,266.11914416787,243.782685508007,530.580645716395" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="21">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@123" Target="@16" Category="CodeSchema_AttributeUse" Bounds="30.303157423874,266.11914416787,566.661330015927,238.27024011088" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@123" Target="@58" Category="References" Bounds="12.7200469342545,266.11914416787,595.874055172474,613.303699816497" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="22">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@123" Target="@6" Category="References" Bounds="19.4602796594955,266.11914416787,561.70191469557,371.791208517295" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="71">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@124" Target="@114" Category="CodeSchema_Calls" Bounds="191.328051849729,211.11914416787,99.0036329606995,315.172386108017" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@124" Target="@123" Category="References" Bounds="50.9592726014126,208.752262576137,93.2715487429918,27.4583289493463" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="InheritsFrom" />
+    </Link>
+    <Link Source="@124" Target="@16" Category="CodeSchema_AttributeUse" Bounds="204.789797110043,211.11914416787,405.502951929037,291.505402935172" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@124" Target="@32" Category="CodeSchema_Calls" Bounds="-604.883968485232,-210.585863551559,267.229933483113,619.182209376498" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@124" Target="@58" Category="References" Bounds="195.25435169977,211.11914416787,419.115544364509,667.13781997875" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="21">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@124" Target="@6" Category="References" Bounds="198.899640409548,211.11914416787,391.061329272083,425.134857193852" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="66">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@124" Target="@80" Category="References" Bounds="192.070574486311,211.11914416787,107.698218824378,288.327685263748" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="InheritsFrom" />
+    </Link>
+    <Link Source="@124" Target="@86" Category="References" Bounds="191.90305997974,211.11914416787,142.714716499562,396.291076688746" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@124" Target="@94" Category="References" Bounds="189.298990522409,211.11914416787,80.5848785303205,530.860660135267" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@125" Target="@114" Category="CodeSchema_Calls" Bounds="5.96072844065107,123.821690274114,277.310487730436,403.638163745328" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@125" Target="@123" Category="References" Bounds="-3.05596640803179,121.454808682384,2.4372839419018,108.299732163126" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="InheritsFrom" />
+    </Link>
+    <Link Source="@125" Target="@16" Category="CodeSchema_AttributeUse" Bounds="16.8572474768818,123.821690274114,591.072020624762,379.196420262705" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@125" Target="@32" Category="CodeSchema_Calls" Bounds="-593.977890573632,-210.585863551559,661.411316928831,621.283613825613" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@125" Target="@6" Category="References" Bounds="11.3921001169962,123.821690274114,575.42326837307,513.066610754443" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="36">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@125" Target="@80" Category="References" Bounds="6.85245825459396,123.821690274114,285.81675532695,376.885075801281" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@125" Target="@86" Category="References" Bounds="5.70843747975358,123.821690274114,323.131559918048,484.568338002856" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@125" Target="@94" Category="References" Bounds="2.65922500320055,123.821690274114,261.680973729954,618.766967061572" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@126" Target="@123" Category="References" Bounds="-144.551604413171,208.752262576137,93.3073266330882,27.4591554619219" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="Implements" />
+      <Category Ref="InheritsFrom" />
+    </Link>
+    <Link Source="@126" Target="@14" Category="References" Bounds="-171.481966819988,211.11914416787,761.87657713695,641.959497506746" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@126" Target="@16" Category="CodeSchema_AttributeUse" Bounds="-154.410054199704,211.11914416787,749.112056366608,293.47578283391" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@126" Target="@22" Category="References" Bounds="-151.537342027997,211.11914416787,742.098584673562,266.714702099062" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10" />
+    <Link Source="@126" Target="@24" Category="References" Bounds="-166.704125273483,211.11914416787,415.66880505672,264.921580825287" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="16">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@126" Target="@32" Category="CodeSchema_Calls" Bounds="-585.733223153984,-210.585863551559,1018.03961712401,622.74905128153" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@126" Target="@48" Category="References" Bounds="-565.85883553798,-210.585863551559,1001.50062454609,732.134252213069" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="22">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@126" Target="@58" Category="References" Bounds="-171.788237144842,211.11914416787,777.447529442861,668.888937101301" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="21">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@126" Target="@6" Category="References" Bounds="-164.591335454617,211.11914416787,742.616876587527,427.27038594984" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="93">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@126" Target="@78" Category="References" Bounds="-174.217895965576,211.11914416787,463.918213282881,479.291893056572" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@126" Target="@86" Category="References" Bounds="-170.945366154384,211.11914416787,490.75988393774,399.080492649013" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="12">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@126" Target="@90" Category="References" Bounds="-558.046580989301,-210.585863551559,995.994836931289,841.636928646336" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="16">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@127" Target="@110" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@127" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="66">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_FieldRead" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@127" Target="@64" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="11">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@127" Target="@66" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@127" Target="@68" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@127" Target="@92" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@128" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@128" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@129" Target="@106" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@129" Target="@6" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@129" Target="@62" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@130" Target="@132" Category="References" Bounds="-874.744143422154,-187.713338400791,10.3354016297775,21.8633496014523" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@130" Target="@134" Category="References" Bounds="-987.2607421875,-187.713333129883,65.4346313476563,80.8791656494141" IsSourceVirtualized="True" Weight="4" />
+    <Link Source="@130" Target="@26" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@130" Target="@6" Category="References" Bounds="-1011.36374699934,-278.54617179453,1558.00460210783,971.240568923947" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@131" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@132" Target="@133" Category="CodeSchema_Calls" Bounds="-805.335052513063,-132.713338400791,109.639494702522,27.7888120213765" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@132" Target="@134" Category="References" Bounds="-900.933656993064,-132.713338400791,30.5986044800005,24.390191976812" IsSourceVirtualized="True" Weight="5" />
+    <Link Source="@132" Target="@2" Category="References" Bounds="-986.799983739291,-223.54607179453,1565.16779019816,1050.98440921836" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@132" Target="@26" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="InheritsFrom" />
+    </Link>
+    <Link Source="@132" Target="@38" Category="CodeSchema_Calls" Bounds="-982.745283256004,-223.54607179453,1515.55885886805,835.655955030325" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@132" Target="@48" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@132" Target="@54" Category="CodeSchema_Calls" Bounds="-990.962462160538,-223.54607179453,1214.18563331562,1050.11420786152" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@132" Target="@6" Category="References" Bounds="-984.541499579774,-223.54607179453,1530.27620838355,916.377773428599" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="17">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@132" Target="@62" Category="References" Bounds="-985.45010978867,-223.54607179453,1549.67324315421,970.225664563745" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@132" Target="@66" Category="CodeSchema_Calls" Bounds="-991.369202130459,-223.54607179453,1240.58810462721,1104.01847107826" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@132" Target="@78" Category="References" Bounds="-989.41235344908,-223.54607179453,1241.15325167035,969.46147613032" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@132" Target="@82" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@132" Target="@90" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@132" Target="@94" Category="References" Bounds="-990.646461841701,-223.54607179453,1208.91778964955,1023.18726935558" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@133" Target="@38" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@133" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="29">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@133" Target="@68" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7" />
+    <Link Source="@134" Target="@26" Category="InheritsFrom" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@135" Target="@106" Category="References" Bounds="-600.975108661118,-223.54577179453,812.490831856445,1075.81936891053" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="49">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@135" Target="@123" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@135" Target="@133" Category="CodeSchema_Calls" Bounds="-588.599817335774,-132.713338400791,88.4920375499833,27.3430453103881" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@135" Target="@16" Category="CodeSchema_AttributeUse" Bounds="-591.732060697814,-223.54577179453,1167.33517029574,780.996702029381" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10" />
+    <Link Source="@135" Target="@165" Category="Implements" Bounds="-473.364135742188,-132.713333129883,12.753662109375,130.865000128746" Weight="1" />
+    <Link Source="@135" Target="@187" Category="CodeSchema_Calls" Bounds="-546.951782226563,-132.713333129883,81.6273193359375,82.1976203918457" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@135" Target="@195" Category="References" Bounds="-454.8236888767,-132.713338400791,72.0973155780891,186.60481679035" IsSourceVirtualized="True" Weight="6" />
+    <Link Source="@135" Target="@34" Category="References" Bounds="-599.300464750124,-223.54577179453,812.975104106175,914.275659567823" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@135" Target="@48" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@135" Target="@54" Category="CodeSchema_Calls" Bounds="-600.529982721424,-223.54577179453,829.545183751246,1048.94204804143" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@135" Target="@58" Category="References" Bounds="-597.755655487898,-223.54577179453,1172.48000882494,1157.67789303525" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="33">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@135" Target="@6" Category="References" Bounds="-594.760830396556,-223.54577179453,1146.40326895162,915.385544944202" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="117">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_FieldRead" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@135" Target="@62" Category="References" Bounds="-595.387597380324,-223.54577179453,1165.25723397813,969.245956762058" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@135" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@136" Target="@175" Category="References" Bounds="594.148498535156,-242.713333129883,491.977966308594,241.319761276245" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@136" Target="@6" Category="References" Bounds="582.125970365937,-333.54607179453,380.803555519756,1022.56744835014" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="16">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@136" Target="@90" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@137" Target="@106" Category="CodeSchema_ReturnTypeLink" Bounds="246.918744462757,-223.54587179453,1193.80969531565,1076.97285351012" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@137" Target="@16" Category="CodeSchema_AttributeUse" Bounds="621.433133085937,-223.54587179453,820.006868720282,779.799341274307" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@137" Target="@161" Category="CodeSchema_Calls" Bounds="1517.75562144625,-132.713338400791,59.4093260406873,26.3509107438532" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@137" Target="@40" Category="CodeSchema_Calls" Bounds="297.415045657616,-223.54587179453,1140.62102097585,861.576807029118" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@137" Target="@48" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7" />
+    <Link Source="@137" Target="@54" Category="CodeSchema_Calls" Bounds="265.188174370943,-223.54587179453,1175.4035195414,1050.00554847684" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@137" Target="@6" Category="References" Bounds="592.092235796613,-223.54587179453,850.861031729451,914.412598576665" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="43">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@137" Target="@76" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="11">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@137" Target="@8" Category="InheritsFrom" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@137" Target="@82" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@137" Target="@84" Category="References" Bounds="313.53320499711,-223.54587179453,1124.21442775146,834.636531150683" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@137" Target="@86" Category="CodeSchema_Calls" Bounds="331.54978105144,-223.54587179453,1107.45209373811,888.3698410528" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@137" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="16">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@138" Target="@102" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@138" Target="@104" Category="CodeSchema_Calls" Bounds="302.343558373362,-333.54617179453,380.482390867309,1265.38289143972" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@138" Target="@16" Category="CodeSchema_AttributeUse" Bounds="603.74327601828,-333.54617179453,81.6900813225382,887.039623930061" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@138" Target="@175" Category="References" Bounds="594.148498535156,-242.713333129883,243.325744628906,241.319761276245" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@138" Target="@26" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="17">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@138" Target="@6" Category="References" Bounds="576.610222977782,-333.54617179453,108.645529054612,1022.05212297089" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="52">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@138" Target="@60" Category="CodeSchema_Calls" Bounds="260.181104318669,-333.54617179453,422.142731035535,1238.48296678637" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@138" Target="@68" Category="CodeSchema_Calls" Bounds="605.090312384927,-333.54617179453,80.5345734556613,1049.02810513829" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@138" Target="@82" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@138" Target="@90" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@138" Target="@92" Category="CodeSchema_Calls" Bounds="583.755047735115,-333.54617179453,101.309346203498,833.067521291114" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@139" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="32">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@139" Target="@68" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@140" Target="@141" Category="References" Bounds="460.346765668755,87.2866615992089,0,20.9999999999999" IsSourceVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@140" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="20" />
+    <Link Source="@140" Target="@52" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="9">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@140" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="85">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@141" Target="@6" Category="References" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@142" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="18" />
+    <Link Source="@143" Target="@12" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="12" />
+    <Link Source="@143" Target="@6" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="40">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@143" Target="@62" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10" />
+    <Link Source="@144" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@144" Target="@62" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@145" Target="@139" Category="CodeSchema_Calls" Bounds="54.619492941482,-132.713338400791,23.1492347345617,23.5779242666832" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@145" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@145" Target="@30" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@145" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="26">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@146" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="47" />
+    <Link Source="@147" Target="@112" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="15">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@147" Target="@48" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@147" Target="@6" Category="References" Bounds="-264.382012587572,106.45442820547,814.034971003436,585.744489484524" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="87">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@147" Target="@68" Category="CodeSchema_Calls" Bounds="-264.545531457849,106.45442820547,843.497353173486,612.711738803812" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@147" Target="@74" Category="CodeSchema_Calls" Bounds="-267.835941235467,106.45442820547,861.780621301603,773.987354272648" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="29" />
+    <Link Source="@147" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@148" Target="@10" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@148" Target="@116" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@148" Target="@140" Category="References" Bounds="172.196899414063,-22.7133388519287,203.907135009766,83.527364730835" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="20">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@148" Target="@156" Category="Implements" Bounds="199.346765668755,-22.7133384007911,98.8465798585155,27.4573832940321" Weight="1" />
+    <Link Source="@148" Target="@38" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@148" Target="@50" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@148" Target="@52" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="30">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@148" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="45">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@148" Target="@68" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@148" Target="@98" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@149" Target="@152" Category="References" Bounds="-1343.48247494381,-132.713338400791,162.715604248934,80.9896672732247" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="30">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@149" Target="@158" Category="Implements" Bounds="-1326.45278941598,-132.713338400791,117.845009630187,27.8174915436066" Weight="1" />
+    <Link Source="@149" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@149" Target="@165" Category="References" Bounds="-1139.66174316406,-132.713333129883,572.938110351563,139.696917533875" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@149" Target="@175" Category="References" Bounds="-1070.78820800781,-138.566192626953,1553.45407104492,149.349702835083" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@149" Target="@30" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@149" Target="@36" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="69">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@149" Target="@58" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="25">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@149" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="115">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@149" Target="@62" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@149" Target="@94" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@150" Target="@149" Category="References" Bounds="-1183.47141614943,-187.713338400791,14.7074310641142,22.4696863479522" IsSourceVirtualized="True" Weight="2" />
+    <Link Source="@150" Target="@152" Category="References" Bounds="-1335.58666992188,-187.713333129883,121.147338867188,136.755352020264" IsSourceVirtualized="True" Weight="3" />
+    <Link Source="@150" Target="@158" Category="References" Bounds="-1358.40888104512,-187.713338400791,144.369283077514,80.612290043282" IsSourceVirtualized="True" Weight="2" />
+    <Link Source="@150" Target="@170" Category="References" Bounds="-1123.82946777344,-187.713333129883,1444.76153564453,28.9206695556641" IsSourceVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@150" Target="@171" Category="CodeSchema_Calls" Bounds="-1123.82946777344,-187.713333129883,1451.76062011719,82.5281143188477" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@150" Target="@34" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@150" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@150" Target="@72" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@150" Target="@84" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@150" Target="@94" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@151" Target="@152" Category="References" Bounds="-1502.36791992188,-132.713333129883,75.1488037109375,82.4293823242188" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="23">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@151" Target="@158" Category="References" Bounds="-1479.06232524034,-132.713338400791,55.6732365133082,26.171179557538" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="18">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@151" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="14" />
+    <Link Source="@151" Target="@30" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@151" Target="@36" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="66">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@151" Target="@58" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="54">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@151" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="185">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@151" Target="@62" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="12" />
+    <Link Source="@152" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="18" />
+    <Link Source="@152" Target="@195" Category="References" Bounds="-1272.68335652983,-23.7994795603164,793.571303135197,87.1186061326062" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@152" Target="@36" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@152" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="61">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_FieldRead" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@153" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@154" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@155" Target="@110" Category="References" Bounds="289.335463152338,-113.54577179453,319.672036339976,694.825120405254" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@155" Target="@6" Category="References" Bounds="287.931784752462,-113.54577179453,279.094707623658,802.500710597814" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="9">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@155" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@156" Target="@140" Category="References" Bounds="376.892220214209,32.2866615992089,50.8891688156638,25.9157804153843" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@157" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="22">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_FieldRead" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@157" Target="@74" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@158" Target="@152" Category="References" Bounds="-1385.92596160397,-77.7133384007909,4.62695086850363,21.20685814731" IsSourceVirtualized="True" Weight="3" />
+    <Link Source="@158" Target="@36" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@158" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="9">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@158" Target="@62" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@159" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="33" />
+    <Link Source="@160" Target="@42" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@161" Target="@106" Category="References" Bounds="246.001107898653,-168.54577179453,1071.47558760983,1021.79014241309" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@161" Target="@143" Category="CodeSchema_Calls" Bounds="1342.40442741659,-77.7133384007914,95.533247343074,27.5095738422465" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@161" Target="@154" Category="CodeSchema_Calls" Bounds="1481.34676566875,-77.7133384007914,0,21" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@161" Target="@38" Category="CodeSchema_Calls" Bounds="581.393953687049,-168.54577179453,737.350778537514,778.467120787453" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@161" Target="@6" Category="References" Bounds="590.763649332015,-168.54577179453,729.211255317482,859.13968023762" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="17">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@161" Target="@62" Category="References" Bounds="607.131875298656,-168.54577179453,713.680596991169,912.910848193489" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@161" Target="@82" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@162" Target="@102" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@163" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@163" Target="@164" Category="References" Bounds="-20.9871267580575,312.230295670394,3.5527136788005E-15,21" IsSourceVirtualized="True" Weight="10" />
+    <Link Source="@163" Target="@30" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@163" Target="@58" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@163" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="27">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@163" Target="@60" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="Implements" />
+    </Link>
+    <Link Source="@164" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7" />
+    <Link Source="@164" Target="@169" Category="References" Bounds="-20.9871267580575,367.230295670394,2.8421709430404E-14,21" IsSourceVirtualized="True" Weight="6" />
+    <Link Source="@164" Target="@30" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@164" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="21">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@164" Target="@92" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@165" Target="@106" Category="References" Bounds="-622.01841480191,-58.54547179453,830.937665560467,911.35039935488" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@165" Target="@195" Category="References" Bounds="-458.107779785791,32.2866615992089,50.8891688156634,25.9157804153843" IsSourceVirtualized="True" Weight="3" />
+    <Link Source="@165" Target="@6" Category="References" Bounds="-614.085390744285,-58.5454717945301,1161.52789914398,751.113862211047" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="18">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@165" Target="@62" Category="References" Bounds="-615.073702781981,-58.54547179453,1181.1115624714,804.932562461787" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@165" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@166" Target="@102" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@166" Target="@165" Category="Implements" Bounds="-419.764801187075,-22.7133384007911,119.475203219466,27.8437973604689" Weight="1" />
+    <Link Source="@166" Target="@6" Category="References" Bounds="-382.885811337479,-113.54557179453,935.863619757114,805.131536292663" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@167" Target="@16" Category="CodeSchema_AttributeUse" Bounds="-315.918665419473,-833.632532690635,904.628964155429,1388.54721739923" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8" />
+    <Link Source="@167" Target="@160" Category="Implements" Bounds="-173.300082810478,-742.763844466651,0,20.50000002" Weight="1" />
+    <Link Source="@167" Target="@42" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="31">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@167" Target="@58" Category="References" Bounds="-317.685134913391,-833.632532690635,901.006325823367,1766.07111151875" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="28">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@167" Target="@6" Category="References" Bounds="-316.845575030779,-833.632532690635,879.458982353259,1523.29379880125" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="100">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@167" Target="@78" Category="References" Bounds="-319.412746048677,-833.632532690635,586.46226589694,1576.65271594012" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@168" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10" />
+    <Link Source="@169" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7" />
+    <Link Source="@169" Target="@30" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@169" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="27">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@169" Target="@92" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@170" Target="@114" Category="References" Bounds="264.217034538744,-223.54597179453,18.0862934218555,804.003776306258" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@170" Target="@123" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@170" Target="@124" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@170" Target="@125" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@170" Target="@126" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@170" Target="@171" Category="InheritsFrom" Bounds="398.984206004098,-132.713338400791,22.3171051192019,23.1592600293606" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="15">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@170" Target="@22" Category="References" Bounds="287.654724843367,-223.54597179453,304.480648748466,750.6614596107" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@170" Target="@24" Category="References" Bounds="244.031571498793,-223.54597179453,37.9209427408106,750.012981576426" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="9">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@170" Target="@32" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@170" Target="@38" Category="CodeSchema_Calls" Bounds="286.642034878149,-223.54597179453,269.886865764022,831.441190606033" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@170" Target="@48" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@170" Target="@6" Category="References" Bounds="286.43950212836,-223.54597179453,281.383297102415,912.401198208976" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="17">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@170" Target="@84" Category="References" Bounds="282.684021510542,-223.54597179453,6.61494026480034,831.001785127964" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@170" Target="@86" Category="References" Bounds="282.943090944543,-223.54597179453,25.3870419570329,885.005200642601" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@170" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@170" Target="@94" Category="CodeSchema_Calls" Bounds="240.780297549203,-223.54597179453,41.2981214341254,1020.00886769546" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@171" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@171" Target="@6" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8" />
+    <Link Source="@171" Target="@84" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@171" Target="@86" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@172" Target="@173" Category="References" Bounds="1300.05847167969,-242.713333129883,103.82763671875,76.8561706542969" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@172" Target="@177" Category="References" Bounds="1452.34676566875,-242.713338400791,0,21" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@172" Target="@44" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@172" Target="@6" Category="CodeSchema_AttributeUse" Bounds="588.043420903695,-333.54607179453,704.932512487442,1023.58933202622" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@172" Target="@86" Category="CodeSchema_Calls" Bounds="327.253513159635,-333.54607179453,962.272742914723,997.524216208667" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@173" Target="@100" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@173" Target="@143" Category="CodeSchema_Calls" Bounds="1290.34676566875,-132.713338400791,2.27373675443232E-13,76.0000000000001" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@173" Target="@16" Category="CodeSchema_AttributeUse" Bounds="615.030218692531,-223.54587179453,516.264891871822,778.500804802889" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@173" Target="@161" Category="CodeSchema_Calls" Bounds="1333.75585657785,-132.713338400791,95.5332473430738,27.5095738422464" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@173" Target="@186" Category="CodeSchema_Calls" Bounds="839.128458445895,-132.713338400791,392.241034495587,83.1339379470417" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@173" Target="@22" Category="References" Bounds="614.280837374368,-223.54587179453,516.710009454266,751.585001128525" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@173" Target="@38" Category="CodeSchema_Calls" Bounds="576.681575131313,-223.54587179453,554.5760871964,832.511156632758" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@173" Target="@6" Category="References" Bounds="586.415462958035,-223.54587179453,545.700060564689,913.275522282737" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="56">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_FieldRead" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@173" Target="@62" Category="References" Bounds="602.987587625494,-223.54587179453,529.749844116352,967.10802557124" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@173" Target="@82" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@173" Target="@86" Category="CodeSchema_Calls" Bounds="326.279737288184,-223.54587179453,802.006679396512,887.324543661252" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@173" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="16">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@173" Target="@92" Category="CodeSchema_Calls" Bounds="595.712417158948,-223.54587179453,534.650915441878,724.758848210634" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@174" Target="@108" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@174" Target="@127" Category="References" Bounds="109.516583856189,-742.763844426651,5.6843418860808E-14,21.0000000200001" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@174" Target="@128" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@174" Target="@163" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@174" Target="@164" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@174" Target="@169" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="9">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@174" Target="@34" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@174" Target="@38" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@174" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="46">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@174" Target="@60" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@174" Target="@94" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@175" Target="@102" Category="InheritsFrom" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@175" Target="@140" Category="References" Bounds="497.706634911577,32.2866615992089,61.5492216662689,26.446931184725" IsSourceVirtualized="True" Weight="9" />
+    <Link Source="@175" Target="@16" Category="CodeSchema_AttributeUse" Bounds="440.761414261834,-58.54567179453,155.611573842873,612.278504801818" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="21" />
+    <Link Source="@175" Target="@38" Category="CodeSchema_Calls" Bounds="439.830597033542,-58.54567179453,119.696743926045,666.143065917192" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@175" Target="@6" Category="References" Bounds="439.773145368057,-58.54567179453,130.816134012028,747.136061469646" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="87">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@176" Target="@102" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@176" Target="@106" Category="CodeSchema_Calls" Bounds="250.759342235591,-113.54567179453,1324.71341860477,967.692364849849" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@176" Target="@140" Category="References" Bounds="556.695535183111,-24.7512101924947,1064.62477147433,91.2772602199349" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@176" Target="@175" Category="References" Bounds="694.107849121094,-22.7133388519287,953.198425292969,38.2554130554199" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@176" Target="@6" Category="References" Bounds="596.511128128953,-113.54567179453,980.848316816732,805.290266978121" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="17">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@176" Target="@94" Category="Implements" Bounds="265.201992457043,-113.54567179453,1309.47107666543,913.850556968513" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_FieldRead" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@177" Target="@100" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@177" Target="@16" Category="CodeSchema_AttributeUse" Bounds="617.524818824211,-278.54597179453,673.958422238302,834.001432244588" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="9" />
+    <Link Source="@177" Target="@173" Category="References" Bounds="1335.68718397808,-187.713338400791,79.8413998724977,27.1066481048604" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@177" Target="@28" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="14">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@177" Target="@44" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="InheritsFrom" />
+    </Link>
+    <Link Source="@177" Target="@58" Category="References" Bounds="605.351255790745,-278.54597179453,689.12117290419,1211.17903125517" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@177" Target="@6" Category="References" Bounds="588.701681094897,-278.54597179453,703.801252935054,968.720292589281" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="33">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@178" Target="@106" Category="References" Bounds="231.785018034298,-278.54607179453,287.615880947179,1129.28002605535" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@178" Target="@155" Category="CodeSchema_Calls" Bounds="470.256164550781,-187.713333129883,194.617248535156,136.298728942871" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@178" Target="@16" Category="CodeSchema_AttributeUse" Bounds="523.727447782371,-278.54607179453,76.0769036367908,832.038986782787" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8" />
+    <Link Source="@178" Target="@170" Category="CodeSchema_Calls" Bounds="496.664811080963,-187.713338400791,122.136500042337,27.9896145930356" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@178" Target="@171" Category="InheritsFrom" Bounds="482.596710205078,-187.713333129883,182.276702880859,83.7322845458984" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@178" Target="@175" Category="References" Bounds="596.41990463612,-187.713338400791,72.0973155780895,186.60481679035" IsSourceVirtualized="True" Weight="6" />
+    <Link Source="@178" Target="@193" Category="CodeSchema_Calls" Bounds="-61.2041816711426,-191.415176391602,580.62739944458,33.1882476806641" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@178" Target="@22" Category="References" Bounds="523.746672906749,-278.54607179453,74.8464526283466,805.04024696395" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@178" Target="@26" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@178" Target="@32" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@178" Target="@42" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="25">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@178" Target="@58" Category="References" Bounds="523.299991546308,-278.54607179453,69.2586746058525,1210.0163066211" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@178" Target="@6" Category="References" Bounds="523.230691616111,-278.54607179453,49.9886156893551,967.013601077103" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="54">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@178" Target="@84" Category="References" Bounds="294.848016148462,-278.54607179453,224.569192948569,886.277309949072" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@178" Target="@86" Category="References" Bounds="313.616747010141,-278.54607179453,206.226018953306,940.210584463454" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@178" Target="@94" Category="CodeSchema_Calls" Bounds="245.319182806682,-278.54607179453,274.079199964099,1075.28044609279" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@179" Target="@127" Category="CodeSchema_FunctionPointer" Bounds="2.97255541546575,-775.6662231031,1034.88870346151,362.12005130857" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@179" Target="@128" Category="References" Bounds="1379.57403839603,-297.713338400791,418.110582665194,33.6692270081781" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@179" Target="@136" Category="CodeSchema_Calls" Bounds="1150.42632458614,-297.713338400791,49.8295319917052,25.8549458447527" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@179" Target="@148" Category="CodeSchema_Calls" Bounds="257.852447509766,-297.713348388672,892.546966552734,253.71928024292" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@179" Target="@16" Category="CodeSchema_AttributeUse" Bounds="611.726588260771,-388.54617179453,455.815193473114,942.898831356618" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@179" Target="@160" Category="References" Bounds="-270.607168072232,-776.212981431127,1299.40521968706,362.666809636598" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@179" Target="@167" Category="References" Bounds="-276.234547048034,-830.901579571447,1310.56694076351,417.355407776917" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@179" Target="@174" Category="References" Bounds="-1.57826743523367,-830.301721682294,1043.85384976883,416.755549887764" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@179" Target="@175" Category="References" Bounds="594.148498535156,-297.713348388672,556.250915527344,296.319776535034" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="15">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@179" Target="@176" Category="References" Bounds="1234.00891113281,-297.713348388672,487.631958007813,244.24462890625" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@179" Target="@178" Category="CodeSchema_Calls" Bounds="805.283081054688,-297.713348388672,345.116333007813,84.0899353027344" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@179" Target="@180" Category="CodeSchema_Calls" Bounds="642.187231534687,-297.713338400791,408.295897770431,29.3546070292468" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@179" Target="@190" Category="CodeSchema_Calls" Bounds="-2.47975381838314,-721.066792846219,1034.0332206877,307.520621051689" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@179" Target="@22" Category="References" Bounds="610.833318093699,-388.54617179453,456.521021327707,915.946752890756" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@179" Target="@26" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="18">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@179" Target="@32" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@179" Target="@34" Category="CodeSchema_Calls" Bounds="245.692118820052,-388.54617179453,818.409804270332,1078.83143362418" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@179" Target="@38" Category="CodeSchema_Calls" Bounds="573.552020923759,-388.54617179453,493.840525114422,996.936935821183" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@179" Target="@40" Category="CodeSchema_Calls" Bounds="288.575647974991,-388.54617179453,775.549337822097,1024.82506290592" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@179" Target="@42" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="36">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@179" Target="@58" Category="References" Bounds="601.2239008489,-388.54617179453,467.931191654636,1320.51855551665" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@179" Target="@6" Category="References" Bounds="583.636271816052,-388.54617179453,484.331081903286,1077.79248207584" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="75">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@179" Target="@62" Category="References" Bounds="600.425270530509,-388.54617179453,467.990074173886,1131.68478720975" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="18">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@179" Target="@64" Category="CodeSchema_Calls" Bounds="626.217676430125,-388.54617179453,440.55220987718,808.099696860188" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8" />
+    <Link Source="@179" Target="@84" Category="References" Bounds="304.437574294511,-388.54617179453,759.631008783221,997.84064065328" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@179" Target="@86" Category="CodeSchema_Calls" Bounds="322.951777447032,-388.54617179453,741.815438182496,1051.64726382802" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@179" Target="@94" Category="References" Bounds="253.539425450424,-388.54617179453,811.496352251986,1186.57285732923" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="9">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@180" Target="@106" Category="References" Bounds="227.829786222734,-333.54617179453,79.9110925962755,1184.02212802696" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@180" Target="@170" Category="CodeSchema_ReturnTypeLink" Bounds="438.371540208661,-242.713338400791,18.0206800055484,76.2413384850123" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@180" Target="@171" Category="CodeSchema_Calls" Bounds="245.972579956055,-242.713333129883,182.845352172852,137.892036437988" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@180" Target="@175" Category="References" Bounds="467.360443115234,-242.713333129883,145.772430419922,241.131039381027" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@180" Target="@178" Category="InheritsFrom" Bounds="507.983129305118,-242.713338400791,107.526293647973,27.6352623861614" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@180" Target="@40" Category="CodeSchema_Calls" Bounds="274.433752316991,-333.54617179453,33.7153954881463,968.007154023209" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@180" Target="@42" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@180" Target="@6" Category="References" Bounds="311.73017664743,-333.54617179453,257.257876205341,1022.27382188397" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@180" Target="@84" Category="References" Bounds="289.891566531598,-333.54617179453,18.4478963031389,941.003429014497" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@180" Target="@86" Category="References" Bounds="308.588919533345,-333.54617179453,0.350282039962678,995.0017005577" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@181" Target="@179" Category="CodeSchema_Calls" Bounds="626.11093205507,-353.223757810925,415.395367747751,29.8650264393808" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@181" Target="@180" Category="CodeSchema_ReturnTypeLink" Bounds="459.346765668754,-352.713338400791,3.41060513164848E-13,76" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@181" Target="@26" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@181" Target="@6" Category="References" Bounds="311.43341692588,-443.54617179453,258.047866706019,1132.22671789366" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_AttributeUse" />
+    </Link>
+    <Link Source="@181" Target="@84" Category="References" Bounds="289.848843519968,-443.54617179453,18.5154636809831,1051.00309628037" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@181" Target="@86" Category="References" Bounds="308.588494549547,-443.54617179453,0.35143799584165,1105.00170045518" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@182" Target="@102" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="42">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@182" Target="@106" Category="References" Bounds="-390.710893348889,-278.54587179453,606.132394880828,1130.0702361816" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@182" Target="@133" Category="CodeSchema_Calls" Bounds="-500.195617675781,-187.713333129883,244.476760864258,84.2075424194336" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@182" Target="@135" Category="References" Bounds="-402.529966906869,-187.713338400791,107.467641666533,27.7498605242221" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@182" Target="@145" Category="References" Bounds="-180.971416149427,-187.713338400791,159.391165628745,30.3339588566815" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@182" Target="@16" Category="CodeSchema_AttributeUse" Bounds="-382.993127694083,-278.54587179453,963.536489494802,835.106856269506" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10" />
+    <Link Source="@182" Target="@165" Category="References" Bounds="-461.076568603516,-187.713333129883,202.622192382813,189.173723816872" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@182" Target="@166" Category="References" Bounds="-253.443389892578,-187.713333129883,5.74053955078125,131.010711669922" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@182" Target="@170" Category="CodeSchema_Calls" Bounds="-94.1962356024062,-187.882257621253,364.026841865772,29.4433475038492" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@182" Target="@171" Category="InheritsFrom" Bounds="-109.468566894531,-187.713333129883,436.9189453125,82.3907928466797" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@182" Target="@175" Category="References" Bounds="-109.468566894531,-187.713333129883,594.827239990234,194.42223072052" IsSourceVirtualized="True" Weight="7" />
+    <Link Source="@182" Target="@193" Category="CodeSchema_Calls" Bounds="-224.153234331245,-187.713338400791,46.1325845149059,25.6292136193923" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@182" Target="@22" Category="References" Bounds="-382.54655588592,-278.54587179453,961.377029984994,808.209927274286" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@182" Target="@26" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@182" Target="@32" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@182" Target="@38" Category="CodeSchema_Calls" Bounds="-384.361416819693,-278.54587179453,928.172039562452,888.776885542164" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@182" Target="@58" Category="References" Bounds="-387.455645751935,-278.54587179453,965.675793940987,1211.96256153238" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="23">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@182" Target="@6" Category="References" Bounds="-385.280812834098,-278.54587179453,941.207354237963,969.543771569481" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="105">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@182" Target="@60" Category="CodeSchema_Calls" Bounds="-390.734795867932,-278.54587179453,632.8286583294,1184.0639227578" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@182" Target="@62" Category="References" Bounds="-385.694735267697,-278.54587179453,959.634732000324,1023.43608819769" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@182" Target="@84" Category="References" Bounds="-388.082810613224,-278.54587179453,662.835886526568,887.78969464302" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@182" Target="@86" Category="References" Bounds="-388.350270051029,-278.54587179453,682.948085790316,941.715656967923" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@182" Target="@90" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@182" Target="@94" Category="CodeSchema_Calls" Bounds="-390.23192845987,-278.54587179453,618.474091684342,1076.19817862568" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@183" Target="@102" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="104">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@104" Category="CodeSchema_Calls" Bounds="-391.014002970903,-388.54607179453,676.503567141877,1320.99095984509" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@183" Target="@127" Category="CodeSchema_FunctionPointer" Bounds="-386.002492701243,-771.992327434786,327.27543334352,358.446255640256" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@183" Target="@130" Category="CodeSchema_Calls" Bounds="-799.740258774866,-297.713338400791,481.041569898166,83.4614711179785" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@183" Target="@133" Category="CodeSchema_Calls" Bounds="-631.84130859375,-297.713348388672,352.728057861328,186.320869445801" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@183" Target="@136" Category="CodeSchema_Calls" Bounds="-62.6732330322266,-304.135284423828,1100.21290588379,36.3470764160156" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@183" Target="@138" Category="References" Bounds="-62.6964836120605,-302.231719970703,786.571483612061,34.1282653808594" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@157" Category="CodeSchema_Calls" Bounds="-1215.61633300781,-297.713348388672,924.102783203125,299.630464315414" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@183" Target="@16" Category="CodeSchema_AttributeUse" Bounds="-384.618598130527,-388.54607179453,967.150280966814,944.712759147492" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@183" Target="@162" Category="References" Bounds="-393.41783532081,-660.05994682286,78.8380099384259,246.51387502833" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@174" Category="References" Bounds="-387.412795411317,-826.611728727171,330.541271081885,413.065656932641" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@175" Category="References" Bounds="-243.305938720703,-297.713348388672,728.664611816406,304.422245979309" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="18">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@176" Category="References" Bounds="-72.3911285400391,-297.713348388672,1684.18165588379,252.310264587402" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@183" Target="@18" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@182" Category="CodeSchema_Calls" Bounds="-246.653234331245,-297.713338400791,1.13686837721616E-13,76" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@183" Target="@184" Category="CodeSchema_Calls" Bounds="-193.016870694882,-297.713338400791,119.962154246193,27.9572817099179" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@183" Target="@189" Category="References" Bounds="-394.073997441072,-714.937631237432,80.5675949474272,301.391559442902" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@183" Target="@22" Category="References" Bounds="-384.270035314125,-388.54607179453,965.190962612008,917.799771315015" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@183" Target="@26" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="72">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@34" Category="CodeSchema_Calls" Bounds="-390.347696557563,-388.54607179453,609.620281327181,1078.16722374208" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@183" Target="@40" Category="CodeSchema_Calls" Bounds="-389.479109547662,-388.54607179453,650.403827810849,1024.40364711968" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@183" Target="@46" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@58" Category="References" Bounds="-388.264790931567,-388.54607179453,967.586302770544,1321.73953122678" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="16">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@6" Category="References" Bounds="-386.482265580686,-388.54607179453,943.953927745374,1079.22725913791" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="122">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@183" Target="@60" Category="CodeSchema_Calls" Bounds="-391.288583217748,-388.54607179453,634.217329332595,1293.92017214448" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@183" Target="@64" Category="CodeSchema_Calls" Bounds="-382.366303542351,-388.54607179453,975.48897533028,810.251074269944" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@183" Target="@82" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@183" Target="@84" Category="References" Bounds="-389.0795038297,-388.54607179453,665.22023235549,997.513878368575" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@183" Target="@86" Category="CodeSchema_Calls" Bounds="-389.270171844559,-388.54607179453,685.15812883153,1051.4612104138" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@183" Target="@94" Category="References" Bounds="-390.880157481657,-388.54607179453,620.085032219308,1186.02589391013" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="14">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@184" Target="@106" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@184" Target="@133" Category="CodeSchema_Calls" Bounds="-500.195617675781,-242.713333129883,478.320283889771,139.207542419434" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@184" Target="@170" Category="CodeSchema_ReturnTypeLink" Bounds="39.8013111233002,-242.713338400791,334.355016713251,82.8357023388685" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@184" Target="@171" Category="CodeSchema_Calls" Bounds="14.6179933547974,-242.713333129883,313.313158988953,137.528114318848" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@184" Target="@175" Category="References" Bounds="6.1849479675293,-242.713333129883,496.830249786377,248.547719955444" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@184" Target="@182" Category="InheritsFrom" Bounds="-183.764801187075,-242.713338400791,119.475203219466,27.8437973604689" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@184" Target="@34" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@184" Target="@40" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@184" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@184" Target="@84" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@184" Target="@86" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@185" Target="@183" Category="CodeSchema_Calls" Bounds="-184.251752213802,-352.713338400791,119.962154246193,27.9572817099179" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@185" Target="@184" Category="CodeSchema_ReturnTypeLink" Bounds="-10.6532343312453,-352.713338400791,1.95399252334028E-14,76" IsSourceVirtualized="True" Weight="1" />
+    <Link Source="@185" Target="@26" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@185" Target="@6" Category="References" Bounds="-153.527996938267,-443.54617179453,715.167837187274,1133.39030662973" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_AttributeUse" />
+    </Link>
+    <Link Source="@185" Target="@84" Category="References" Bounds="-156.220954739191,-443.54617179453,437.042817375227,1051.69075220407" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@185" Target="@86" Category="References" Bounds="-156.253479786399,-443.54617179453,456.603000206765,1105.6831024405" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@186" Target="@106" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@186" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@186" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="24">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+      <Category Ref="InheritsFrom" />
+    </Link>
+    <Link Source="@187" Target="@106" Category="Implements" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@187" Target="@157" Category="CodeSchema_Calls" Bounds="-1177.45234389366,-24.9701985941824,463.488776561157,39.4611187474669" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@187" Target="@34" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@187" Target="@36" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@188" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@189" Target="@102" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="72">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@189" Target="@104" Category="References" Bounds="-303.372022402896,-723.632332690635,591.867173308003,1655.61311924073" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@189" Target="@16" Category="CodeSchema_AttributeUse" Bounds="-299.168404246486,-723.632332690635,887.132665742066,1278.69323239754" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="20" />
+    <Link Source="@189" Target="@162" Category="Implements" Bounds="-157.078416143811,-632.763844426651,2.8421709430404E-14,20.50000002" Weight="1" />
+    <Link Source="@189" Target="@58" Category="References" Bounds="-301.168207204067,-723.632332690635,884.046032211831,1656.1482117091" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="70">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@189" Target="@6" Category="References" Bounds="-300.215168609128,-723.632332690635,862.232724022844,1413.40466345299" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="257">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@189" Target="@78" Category="References" Bounds="-302.985301920175,-723.632332690635,569.708047693491,1466.69851585987" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="25">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@190" Target="@102" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@190" Target="@110" Category="CodeSchema_Calls" Bounds="-46.8629779563877,-723.632332690635,655.071180587216,1305.04431028609" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@190" Target="@16" Category="CodeSchema_AttributeUse" Bounds="-46.8934926606456,-723.632332690635,638.394583713864,1278.0364452624" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@190" Target="@175" Category="References" Bounds="-43.9144988891198,-723.632332690635,466.932689378292,632.844581807089" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@190" Target="@38" Category="CodeSchema_Calls" Bounds="-47.4921291875558,-723.632332690635,601.507632674698,1331.88555075385" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@190" Target="@6" Category="References" Bounds="-47.7135568642138,-723.632332690635,613.037371072063,1412.83158886862" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="38">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@190" Target="@62" Category="References" Bounds="-47.7630898444157,-723.632332690635,630.650696285311,1466.81967096431" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@190" Target="@64" Category="References" Bounds="-46.03511229908,-723.632332690635,649.581846840441,1143.26275404504" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="12">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@191" Target="@38" Category="CodeSchema_Calls" Bounds="-306.019765333976,-613.546475298633,855.478855545375,1222.62789439505" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@191" Target="@6" Category="References" Bounds="-306.44745093242,-613.546475298633,867.472730388451,1303.50948486714" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="31">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@191" Target="@62" Category="References" Bounds="-306.613366176688,-613.546475298633,885.360787373473,1357.46365653412" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="15">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@191" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="11">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@192" Target="@38" Category="CodeSchema_Calls" Bounds="-301.048667543481,-558.54647179453,850.018039768154,1167.72563756095" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3" />
+    <Link Source="@192" Target="@6" Category="References" Bounds="-301.517021798526,-558.54647179453,862.102778527279,1248.59586428135" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="14">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@192" Target="@62" Category="References" Bounds="-301.702396573376,-558.54647179453,880.035347296443,1302.54453379352" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@192" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="12">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@193" Target="@165" Category="References" Bounds="-449.200645149516,-132.713338400791,276.168622939482,136.023351597059" IsSourceVirtualized="True" Weight="4" />
+    <Link Source="@193" Target="@166" Category="References" Bounds="-229.382551746643,-132.713338400791,70.4793174153976,78.3103526837755" IsSourceVirtualized="True" Weight="7">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@193" Target="@194" Category="References" Bounds="-133.789597967609,-132.713338400791,26.5885312751519,23.9732659038253" IsSourceVirtualized="True" Weight="2" />
+    <Link Source="@193" Target="@22" Category="References" Bounds="-284.081896366265,-223.54577179453,863.553744768532,753.085993142614" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5" />
+    <Link Source="@193" Target="@32" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@193" Target="@38" Category="CodeSchema_Calls" Bounds="-285.962023044651,-223.54577179453,830.521588693383,833.625480288096" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2" />
+    <Link Source="@193" Target="@6" Category="References" Bounds="-286.88344629571,-223.54577179453,843.578831066078,914.386374161671" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="24">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@193" Target="@86" Category="References" Bounds="-290.154308622014,-223.54577179453,585.877653162058,886.492902063437" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="18">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@194" Target="@102" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="10">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@104" Category="CodeSchema_Calls" Bounds="-231.535759275752,-168.54567179453,517.818704925401,1100.85717133244" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@106" Category="References" Bounds="-231.909841668093,-168.54567179453,449.156545740865,1019.76473507821" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="279">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@110" Category="References" Bounds="-223.751140741225,-168.54567179453,821.966312477743,751.926453890996" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="5">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@123" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@143" Category="CodeSchema_Calls" Bounds="-39.3561210632324,-77.7133407592773,1222.45487594604,38.2859230041504" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@194" Target="@148" Category="CodeSchema_Calls" Bounds="-31.880507058518,-77.7133384007911,122.680141507157,27.9975426676084" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@155" Category="CodeSchema_Calls" Bounds="-11.5418252944946,-80.760986328125,346.351548194885,35.8886413574219" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@16" Category="CodeSchema_AttributeUse" Bounds="-223.540135097349,-168.54567179453,804.744833874076,724.977272871469" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="24" />
+    <Link Source="@194" Target="@165" Category="Implements" Bounds="-453.812591552734,-81.105712890625,291.916519165039,83.4828886985779" Weight="1" />
+    <Link Source="@194" Target="@166" Category="Implements" Bounds="-201.305575274213,-77.7133384007911,78.288704579331,26.911742199145" Weight="1" />
+    <Link Source="@194" Target="@175" Category="References" Bounds="-11.5035638809204,-80.8537673950195,496.862236976624,87.5626649856567" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="22">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@176" Category="CodeSchema_Calls" Bounds="-39.3561210632324,-77.7133407592773,1700.30619430542,28.4915351867676" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@186" Category="CodeSchema_Calls" Bounds="-39.3561210632324,-77.7133407592773,650.175090789795,33.7451705932617" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@187" Category="CodeSchema_Calls" Bounds="-469.478455565966,-82.02723005067,307.364186079968,33.3432549001938" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@195" Category="References" Bounds="-332.536743164063,-77.7133407592773,237.412826538086,136.86837387085" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="23">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@22" Category="References" Bounds="-223.04643882859,-168.54567179453,802.475596493595,698.094197608534" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="3">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@26" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4" />
+    <Link Source="@194" Target="@28" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="11">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@34" Category="References" Bounds="-230.847229665205,-168.54567179453,450.862703679339,858.034128057194" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@38" Category="CodeSchema_Calls" Bounds="-225.057774221081,-168.54567179453,769.737743182452,778.600914540428" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@194" Target="@48" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="2">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@52" Category="References" Bounds="-225.944744315483,-168.54567179453,862.939015216809,940.370091202345" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@54" Category="CodeSchema_Calls" Bounds="-231.544399670282,-168.54567179453,466.330597082828,992.855003841397" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@58" Category="References" Bounds="-228.253189998048,-168.54567179453,807.558715689316,1101.7423434801" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="96">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@6" Category="References" Bounds="-226.027370836732,-168.54567179453,782.908180999227,859.348226626071" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="398">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_FieldRead" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@194" Target="@62" Category="References" Bounds="-226.446814340927,-168.54567179453,801.358829623154,913.236375327828" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="24" />
+    <Link Source="@194" Target="@68" Category="CodeSchema_Calls" Bounds="-225.965914643354,-168.54567179453,811.879126907382,886.364494645806" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@70" Category="CodeSchema_Calls" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@194" Target="@78" Category="References" Bounds="-230.639666159528,-168.54567179453,494.411635749631,912.088893215207" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@90" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="22">
+      <Category Ref="CodeSchema_Calls" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@194" Target="@92" Category="CodeSchema_Calls" Bounds="-222.839937560095,-168.54567179453,782.581068492095,671.142273701473" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="6" />
+    <Link Source="@194" Target="@94" Category="References" Bounds="-231.442945809273,-168.54567179453,461.500442498535,965.880544744298" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_Calls" />
+    </Link>
+    <Link Source="@194" Target="@96" Category="CodeSchema_FieldRead" Bounds="-221.176495149185,-168.54567179453,802.220795804399,617.511465773587" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="1" />
+    <Link Source="@195" Target="@16" Category="CodeSchema_AttributeUse" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="8" />
+    <Link Source="@195" Target="@6" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="36">
+      <Category Ref="CodeSchema_AttributeUse" />
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@195" Target="@92" Category="References" IsSourceVirtualized="True" IsTargetVirtualized="True" Weight="4">
+      <Category Ref="CodeSchema_ReturnTypeLink" />
+    </Link>
+    <Link Source="@4" Target="@10" Category="CodeMap_ExternalReference" Bounds="177.296298545325,371.454487391277,10.3229263917937,47.2087853452314" />
+    <Link Source="@4" Target="@100" Category="CodeMap_ExternalReference" Bounds="-292.775173768998,-20.5232635515586,153.671153056414,483.805272690879" />
+    <Link Source="@4" Target="@102" Category="CodeMap_ExternalReference" Bounds="-534.772441159281,-20.5232635515586,377.479468863189,869.128642849131" />
+    <Link Source="@4" Target="@104" Category="CodeMap_ExternalReference" Bounds="172.816302847886,371.454487391277,118.664255391495,560.196406717985" />
+    <Link Source="@4" Target="@106" Category="CodeMap_ExternalReference" Bounds="143.080848155343,371.454487391277,79.7412974776684,479.123157507971" />
+    <Link Source="@4" Target="@108" Category="CodeMap_ExternalReference" Bounds="520.929997010141,371.454487391277,76.3905681428473,102.777738935417" />
+    <Link Source="@4" Target="@110" Category="CodeMap_ExternalReference" Bounds="466.38981059407,371.454487391277,138.922743622233,210.48955025637" />
+    <Link Source="@4" Target="@112" Category="CodeMap_ExternalReference" Bounds="-577.189651867785,-20.5232635515586,369.042592699669,485.219473019074" />
+    <Link Source="@4" Target="@114" Category="CodeMap_ExternalReference" Bounds="203.951332988817,371.454487391277,54.2806802642651,209.289276041042" />
+    <Link Source="@4" Target="@116" Category="CodeMap_ExternalReference" Bounds="178.804164314364,371.454487391277,16.3986516900972,74.2130281401791" />
+    <Link Source="@4" Target="@118" Category="Contains" FetchingParent="@4" />
+    <Link Source="@4" Target="@12" Category="CodeMap_ExternalReference" Bounds="174.433432362231,371.454487391277,73.7604796786034,344.200835628585" />
+    <Link Source="@4" Target="@120" Category="Contains" FetchingParent="@4" />
+    <Link Source="@4" Target="@122" Category="Contains" FetchingParent="@4" />
+    <Link Source="@4" Target="@14" Category="CodeMap_ExternalReference" Bounds="329.120089183555,371.454487391277,240.443210464287,533.795102117735" />
+    <Link Source="@4" Target="@16" Category="CodeMap_ExternalReference" Bounds="467.203610622041,371.454487391277,121.333586007336,183.493840857861" />
+    <Link Source="@4" Target="@18" Category="CodeMap_ExternalReference" Bounds="-557.299640304895,-20.5232635515586,382.969058665249,704.476228450966" />
+    <Link Source="@4" Target="@2" Category="CodeMap_ExternalReference" Bounds="365.136386923054,371.454487391277,228.941181227638,452.968698020357" />
+    <Link Source="@4" Target="@20" Category="CodeMap_ExternalReference" Bounds="368.806298662389,371.454487391277,217.690514491109,425.986853469983" />
+    <Link Source="@4" Target="@22" Category="CodeMap_ExternalReference" Bounds="480.339368661963,371.454487391277,106.665527042493,156.563179915009" />
+    <Link Source="@4" Target="@24" Category="CodeMap_ExternalReference" Bounds="198.60803128028,371.454487391277,39.0043935654972,155.272228613606" />
+    <Link Source="@4" Target="@26" Category="CodeMap_ExternalReference" Bounds="-284.695217173031,-20.5232635515586,151.318643502825,538.718391607784" />
+    <Link Source="@4" Target="@28" Category="CodeMap_ExternalReference" Bounds="-195.501601820072,-20.5232635515586,87.8527393812156,758.443247695952" />
+    <Link Source="@4" Target="@30" Category="CodeMap_ExternalReference" Bounds="341.009537375325,371.454487391277,224.85432558037,479.851414249567" />
+    <Link Source="@4" Target="@32" Category="CodeMap_ExternalReference" Bounds="-597.137358099125,-20.5232635515585,372.642262170361,430.577564313424" />
+    <Link Source="@4" Target="@34" Category="CodeMap_ExternalReference" Bounds="163.751199996429,371.454487391277,62.7961067920372,317.172414068124" />
+    <Link Source="@4" Target="@36" Category="CodeMap_ExternalReference" Bounds="411.180282798455,371.454487391277,152.104621446226,264.201294766027" />
+    <Link Source="@4" Target="@38" Category="CodeMap_ExternalReference" Bounds="414.006803168909,371.454487391277,137.592290059279,237.215861107918" />
+    <Link Source="@4" Target="@40" Category="CodeMap_ExternalReference" Bounds="201.125174008291,371.454487391277,67.147709058596,263.280203960988" />
+    <Link Source="@4" Target="@42" Category="CodeMap_ExternalReference" Bounds="-549.682202148208,-20.5232635515586,381.728871178513,759.342360986861" />
+    <Link Source="@4" Target="@44" Category="CodeMap_ExternalReference" Bounds="-252.479581635121,-20.5232635515586,131.323886099696,648.562284651179" />
+    <Link Source="@4" Target="@46" Category="CodeMap_ExternalReference" Bounds="-221.530222098112,-20.5232635515586,108.00553542434,703.487601537008" />
+    <Link Source="@4" Target="@48" Category="CodeMap_ExternalReference" Bounds="-576.322027713461,-20.5232635515586,377.703331848485,540.008044442403" />
+    <Link Source="@4" Target="@50" Category="CodeMap_ExternalReference" Bounds="220.490556082689,371.454487391277,28.8433506531439,101.344795981129" />
+    <Link Source="@4" Target="@52" Category="CodeMap_ExternalReference" Bounds="412.312205451445,371.454487391277,230.519320609223,399.20712482174" />
+    <Link Source="@4" Target="@54" Category="CodeMap_ExternalReference" Bounds="156.196890800611,371.454487391277,84.3061985307502,452.153520651865" />
+    <Link Source="@4" Target="@56" Category="CodeMap_ExternalReference" Bounds="409.939402629726,371.454487391277,167.09362505105,291.194908607506" />
+    <Link Source="@4" Target="@58" Category="CodeMap_ExternalReference" Bounds="330.569678344336,371.454487391277,253.849215071874,560.801910366201" />
+    <Link Source="@4" Target="@6" Category="CodeSchema_AttributeUse" Bounds="390.260497522339,371.454487391277,172.972921680066,318.09441658958" IsTargetVirtualized="True" Weight="20">
+      <Category Ref="CodeMap_ExternalReference" />
+    </Link>
+    <Link Source="@4" Target="@60" Category="CodeMap_ExternalReference" Bounds="152.639088065755,371.454487391277,96.511734128492,533.144975496333" />
+    <Link Source="@4" Target="@62" Category="CodeMap_ExternalReference" Bounds="382.833405195639,371.454487391277,198.098092040251,372.056920451803" />
+    <Link Source="@4" Target="@64" Category="CodeMap_ExternalReference" Bounds="560.08628629734,371.454487391277,39.3356270658383,48.9836269406264" />
+    <Link Source="@4" Target="@66" Category="CodeMap_ExternalReference" Bounds="164.747570294136,371.454487391277,100.986139700301,506.174981247003" />
+    <Link Source="@4" Target="@68" Category="CodeMap_ExternalReference" Bounds="399.522278740517,371.454487391277,192.560554913936,345.141519549584" />
+    <Link Source="@4" Target="@70" Category="CodeMap_ExternalReference" Bounds="-571.838937263063,-20.5232635515586,382.110392212974,594.811012334269" />
+    <Link Source="@4" Target="@72" Category="CodeMap_ExternalReference" Bounds="199.496049683711,371.454487391277,100.586637230436,398.27503089183" />
+    <Link Source="@4" Target="@74" Category="CodeMap_ExternalReference" Bounds="355.614608140038,371.454487391277,248.841811258896,506.921964298238" />
+    <Link Source="@4" Target="@76" Category="CodeMap_ExternalReference" Bounds="-268.360606067811,-20.5232635515586,141.588814193902,593.628741757994" />
+    <Link Source="@4" Target="@78" Category="CodeMap_ExternalReference" Bounds="184.621284814487,371.454487391277,85.3263276561776,371.229752531792" />
+    <Link Source="@4" Target="@8" Category="CodeMap_ExternalReference" Bounds="-343.036829128363,-20.5232635515585,185.912599574105,429.124579645855" />
+    <Link Source="@4" Target="@80" Category="CodeMap_ExternalReference" Bounds="217.405792351854,371.454487391277,51.0347593789078,182.334132680244" />
+    <Link Source="@4" Target="@82" Category="CodeMap_ExternalReference" Bounds="-542.97919311404,-20.5232635515586,380.536430610432,814.230081972231" />
+    <Link Source="@4" Target="@84" Category="CodeMap_ExternalReference" Bounds="217.399021240081,371.454487391277,66.1467427813836,236.334109426795" />
+    <Link Source="@4" Target="@86" Category="CodeMap_ExternalReference" Bounds="220.355762907078,371.454487391277,82.5740306171162,290.344327144028" />
+    <Link Source="@4" Target="@88" Category="CodeMap_ExternalReference" Bounds="-178.640072490538,-20.5232635515586,74.7268554864334,813.42131033389" />
+    <Link Source="@4" Target="@90" Category="CodeMap_ExternalReference" Bounds="-567.700535939281,-20.5232635515585,385.589154711964,649.643862304369" />
+    <Link Source="@4" Target="@92" Category="CodeMap_ExternalReference" Bounds="479.488496206762,371.454487391277,88.0992409545784,129.558684545328" />
+    <Link Source="@4" Target="@94" Category="CodeMap_ExternalReference" Bounds="156.470997330284,371.454487391277,79.4499505116294,425.15418843971" />
+    <Link Source="@4" Target="@96" Category="CodeMap_ExternalReference" Bounds="531.842106299695,371.454487391277,57.6286388562154,75.8352993660739" />
+    <Link Source="@4" Target="@98" Category="CodeMap_ExternalReference" Bounds="205.766628360355,371.454487391277,33.629813036656,128.295168278871" />
+    <Link Source="@4" Target="Done" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@100" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@102" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@112" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@18" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@26" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@28" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@32" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@42" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@44" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@46" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@48" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@70" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@76" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@8" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@82" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@88" Category="Contains" />
+    <Link Source="ASP.NETCore" Target="@90" Category="Contains" />
+    <Link Source="Done" Target="@123" Category="Contains" />
+    <Link Source="Done" Target="@124" Category="Contains" />
+    <Link Source="Done" Target="@125" Category="Contains" />
+    <Link Source="Done" Target="@126" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@10" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@104" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@106" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@108" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@110" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@114" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@116" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@12" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@14" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@16" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@2" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@20" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@22" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@24" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@30" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@34" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@36" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@38" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@40" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@50" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@52" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@54" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@56" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@58" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@6" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@60" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@62" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@64" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@66" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@68" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@72" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@74" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@78" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@80" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@84" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@86" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@92" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@94" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@96" Category="Contains" />
+    <Link Source="_standardGraphExternalsGroup" Target="@98" Category="Contains" />
+  </Links>
+  <Categories>
+    <Category Id="Category1" Label="Category 1" Background="#FFE51400" IsTag="True" />
+    <Category Id="CodeMap_ExternalReference" Label="External Reference" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Referenced By" OutgoingActionLabel="References" />
+    <Category Id="CodeSchema_Assembly" Label="Assembly" BasedOn="File" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="CodeSchema_Assembly" NavigationActionLabel="Assemblies" />
+    <Category Id="CodeSchema_AttributeUse" Label="Uses Attribute" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Used by" OutgoingActionLabel="Uses Attribute" />
+    <Category Id="CodeSchema_Calls" Label="Calls" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Called By" OutgoingActionLabel="Calls" />
+    <Category Id="CodeSchema_Class" Label="Class" BasedOn="CodeSchema_Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Class" NavigationActionLabel="Classes" />
+    <Category Id="CodeSchema_Enum" Label="Enum" BasedOn="CodeSchema_Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Enum" NavigationActionLabel="Enums" />
+    <Category Id="CodeSchema_FieldRead" Label="Field Read" BasedOn="CodeSchema_FieldReference" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Read By" OutgoingActionLabel="Reads Fields" />
+    <Category Id="CodeSchema_FieldReference" Label="Field Reference" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Referenced By" OutgoingActionLabel="References Fields" />
+    <Category Id="CodeSchema_FunctionPointer" Label="Function Pointer" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Function Pointers" OutgoingActionLabel="Function Pointers" />
+    <Category Id="CodeSchema_Interface" Label="Interface" BasedOn="CodeSchema_Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Interface" NavigationActionLabel="Interfaces" />
+    <Category Id="CodeSchema_Namespace" Label="Namespace" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Type" Icon="CodeSchema_Namespace" NavigationActionLabel="Namespaces" />
+    <Category Id="CodeSchema_ReturnTypeLink" Label="Return" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Return types" OutgoingActionLabel="Return types" />
+    <Category Id="CodeSchema_Type" Label="Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Class" NavigationActionLabel="Types" />
+    <Category Id="Contains" Label="Contains" Description="Whether the source of the link contains the target object" CanBeDataDriven="False" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Contained By" IsContainment="True" OutgoingActionLabel="Contains" />
+    <Category Id="Externals" Label="Externals" CanBeDataDriven="True" IsProviderRoot="False" NavigationActionLabel="Externals" />
+    <Category Id="File" Label="File" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="File" NavigationActionLabel="Files" />
+    <Category Id="FileSystem.Category.FileOfType.dll" BasedOn="CodeSchema_Assembly" CanBeDataDriven="True" IsProviderRoot="False" />
+    <Category Id="Implements" Label="Implements" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Implemented by" OutgoingActionLabel="Implements" />
+    <Category Id="InheritsFrom" Label="Inherits From" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Inherited By" OutgoingActionLabel="Inherits From" />
+    <Category Id="References" Label="References" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Referenced By" OutgoingActionLabel="References" />
+  </Categories>
+  <Properties>
+    <Property Id="AssemblyTimestamp" DataType="System.DateTime" />
+    <Property Id="Background" Label="Background" Description="The background color" DataType="System.Windows.Media.Brush" />
+    <Property Id="Bounds" DataType="System.Windows.Rect" />
+    <Property Id="CanBeDataDriven" Label="CanBeDataDriven" Description="CanBeDataDriven" DataType="System.Boolean" />
+    <Property Id="CanLinkedNodesBeDataDriven" Label="CanLinkedNodesBeDataDriven" Description="CanLinkedNodesBeDataDriven" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsAbstract" Label="Is Abstract" Description="Flag to indicate member is 'Abstract' does not provide a full implementation" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsExternal" Label="Is External" Description="Flag indicating whether this node is considered external" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsFinal" Label="Is Final" Description="Flag to indicate the member is 'Final' and cannot be derived from" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsInternal" Label="Is Internal" Description="Flag to indicate the method is 'Internal'" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsPublic" Label="Is Public" Description="Flag to indicate the scope is Public" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_StrongName" Label="StrongName" Description="StrongName" DataType="System.String" />
+    <Property Id="DataVirtualized" Label="Data Virtualized" Description="If true, the graph can contain nodes and links that represent data for virtualized nodes/links (i.e. not actually created in the graph)." DataType="System.Boolean" />
+    <Property Id="DefaultAction" Label="DefaultAction" Description="DefaultAction" DataType="System.String" />
+    <Property Id="DelayedChildNodesState" Label="Delayed Child Nodes State" Description="Unspecified if the delayed child nodes state is not specified. NotFetched if the group contains child nodes that are not fetched into the graph yet. Fetched if the group has all its delayed child nodes already fetched." DataType="Microsoft.VisualStudio.GraphModel.DelayedDataState" />
+    <Property Id="DelayedCrossGroupLinksState" Label="Delayed Cross-Group Links State" Description="Unspecified if the delayed cross-group links state is not specified. NotFetched if delayed cross-group links on this node are not fetched into the graph yet. Fetched if all delayed cross-group links have already fetched." DataType="Microsoft.VisualStudio.GraphModel.DelayedDataState" />
+    <Property Id="Expression" DataType="System.String" />
+    <Property Id="FetchedChildrenCount" DataType="System.Int32" />
+    <Property Id="FetchingParent" DataType="Microsoft.VisualStudio.GraphModel.GraphNodeId" />
+    <Property Id="FilePath" Label="File Path" Description="File Path" DataType="System.String" />
+    <Property Id="Group" Label="Group" Description="Display the node as a group" DataType="Microsoft.VisualStudio.GraphModel.GraphGroupStyle" />
+    <Property Id="GroupLabel" DataType="System.String" />
+    <Property Id="Icon" Label="Icon" Description="Icon" DataType="System.String" />
+    <Property Id="IncomingActionLabel" Label="IncomingActionLabel" Description="IncomingActionLabel" DataType="System.String" />
+    <Property Id="IsContainment" DataType="System.Boolean" />
+    <Property Id="IsEnabled" DataType="System.Boolean" />
+    <Property Id="IsProviderRoot" Label="IsProviderRoot" Description="IsProviderRoot" DataType="System.Boolean" />
+    <Property Id="IsSourceVirtualized" Label="Link Source Virtualized" Description="If true, the link source end contains data for virtualized nodes/links (i.e. not actually created in the graph)." DataType="System.Boolean" />
+    <Property Id="IsTag" DataType="System.Boolean" />
+    <Property Id="IsTargetVirtualized" Label="Link Target Virtualized" Description="If true, the link target end contains data for virtualized nodes/links (i.e. not actually created in the graph)." DataType="System.Boolean" />
+    <Property Id="Label" Label="Label" Description="Displayable label of an Annotatable object" DataType="System.String" />
+    <Property Id="Layout" DataType="System.String" />
+    <Property Id="LayoutSettings" DataType="Microsoft.VisualStudio.Diagrams.View.GroupLayoutStyle" />
+    <Property Id="NavigationActionLabel" Label="NavigationActionLabel" Description="NavigationActionLabel" DataType="System.String" />
+    <Property Id="OutgoingActionLabel" Label="OutgoingActionLabel" Description="OutgoingActionLabel" DataType="System.String" />
+    <Property Id="TargetType" DataType="System.Type" />
+    <Property Id="UseManualLocation" DataType="System.Boolean" />
+    <Property Id="Value" DataType="System.String" />
+    <Property Id="ValueLabel" DataType="System.String" />
+    <Property Id="Visibility" Label="Visibility" Description="Defines whether a node in the graph is visible or not" DataType="System.Windows.Visibility" />
+    <Property Id="Weight" Label="Weight" Description="Weight" DataType="System.Double" />
+    <Property Id="ZoomLevel" DataType="System.String" />
+  </Properties>
+  <QualifiedNames>
+    <Name Id="Assembly" Label="Assembly" ValueType="Uri" />
+    <Name Id="Namespace" Label="Namespace" ValueType="System.String" />
+    <Name Id="Type" Label="Type" ValueType="System.Object" />
+  </QualifiedNames>
+  <IdentifierAliases>
+    <Alias n="1" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Text.Encodings.Web.dll" />
+    <Alias n="2" Id="(@1)" />
+    <Alias n="3" Uri="Assembly=$(bd795319-75b8-4251-ae92-8dd5a807c28e.OutputPathUri)" />
+    <Alias n="4" Id="(@3)" />
+    <Alias n="5" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Runtime.dll" />
+    <Alias n="6" Id="(@5)" />
+    <Alias n="7" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Mvc.Core.dll" />
+    <Alias n="8" Id="(@7)" />
+    <Alias n="9" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/azure.core/1.4.1/lib/netstandard2.0/Azure.Core.dll" />
+    <Alias n="10" Id="(@9)" />
+    <Alias n="11" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Identity.Core.dll" />
+    <Alias n="12" Id="(@11)" />
+    <Alias n="13" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Threading.dll" />
+    <Alias n="14" Id="(@13)" />
+    <Alias n="15" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Diagnostics.Debug.dll" />
+    <Alias n="16" Id="(@15)" />
+    <Alias n="17" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Authentication.OAuth.dll" />
+    <Alias n="18" Id="(@17)" />
+    <Alias n="19" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Security.Principal.dll" />
+    <Alias n="20" Id="(@19)" />
+    <Alias n="21" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.ComponentModel.dll" />
+    <Alias n="22" Id="(@21)" />
+    <Alias n="23" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Session.dll" />
+    <Alias n="24" Id="(@23)" />
+    <Alias n="25" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Authentication.dll" />
+    <Alias n="26" Id="(@25)" />
+    <Alias n="27" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Components.Authorization.dll" />
+    <Alias n="28" Id="(@27)" />
+    <Alias n="29" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Text.Json.dll" />
+    <Alias n="30" Id="(@29)" />
+    <Alias n="31" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Http.dll" />
+    <Alias n="32" Id="(@31)" />
+    <Alias n="33" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Http.dll" />
+    <Alias n="34" Id="(@33)" />
+    <Alias n="35" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Net.Http.dll" />
+    <Alias n="36" Id="(@35)" />
+    <Alias n="37" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Linq.dll" />
+    <Alias n="38" Id="(@37)" />
+    <Alias n="39" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Configuration.Binder.dll" />
+    <Alias n="40" Id="(@39)" />
+    <Alias n="41" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.authentication.jwtbearer/3.1.8/lib/netcoreapp3.1/Microsoft.AspNetCore.Authentication.JwtBearer.dll" />
+    <Alias n="42" Id="(@41)" />
+    <Alias n="43" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Components.Server.dll" />
+    <Alias n="44" Id="(@43)" />
+    <Alias n="45" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Authentication.Cookies.dll" />
+    <Alias n="46" Id="(@45)" />
+    <Alias n="47" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Http.Features.dll" />
+    <Alias n="48" Id="(@47)" />
+    <Alias n="49" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/azure.security.keyvault.certificates/4.1.0/lib/netstandard2.0/Azure.Security.KeyVault.Certificates.dll" />
+    <Alias n="50" Id="(@49)" />
+    <Alias n="51" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Security.Cryptography.X509Certificates.dll" />
+    <Alias n="52" Id="(@51)" />
+    <Alias n="53" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Primitives.dll" />
+    <Alias n="54" Id="(@53)" />
+    <Alias n="55" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Net.Primitives.dll" />
+    <Alias n="56" Id="(@55)" />
+    <Alias n="57" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Threading.Tasks.dll" />
+    <Alias n="58" Id="(@57)" />
+    <Alias n="59" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.identitymodel.protocols/5.5.0/lib/netstandard2.0/Microsoft.IdentityModel.Protocols.dll" />
+    <Alias n="60" Id="(@59)" />
+    <Alias n="61" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Security.Claims.dll" />
+    <Alias n="62" Id="(@61)" />
+    <Alias n="63" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.identitymodel.tokens/5.5.0/lib/netstandard2.0/Microsoft.IdentityModel.Tokens.dll" />
+    <Alias n="64" Id="(@63)" />
+    <Alias n="65" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.identitymodel.jsonwebtokens/5.5.0/lib/netstandard2.0/Microsoft.IdentityModel.JsonWebTokens.dll" />
+    <Alias n="66" Id="(@65)" />
+    <Alias n="67" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Runtime.Extensions.dll" />
+    <Alias n="68" Id="(@67)" />
+    <Alias n="69" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Http.Extensions.dll" />
+    <Alias n="70" Id="(@69)" />
+    <Alias n="71" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Options.ConfigurationExtensions.dll" />
+    <Alias n="72" Id="(@71)" />
+    <Alias n="73" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Text.RegularExpressions.dll" />
+    <Alias n="74" Id="(@73)" />
+    <Alias n="75" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Mvc.Abstractions.dll" />
+    <Alias n="76" Id="(@75)" />
+    <Alias n="77" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Logging.Abstractions.dll" />
+    <Alias n="78" Id="(@77)" />
+    <Alias n="79" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Caching.Abstractions.dll" />
+    <Alias n="80" Id="(@79)" />
+    <Alias n="81" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Authentication.Abstractions.dll" />
+    <Alias n="82" Id="(@81)" />
+    <Alias n="83" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Configuration.Abstractions.dll" />
+    <Alias n="84" Id="(@83)" />
+    <Alias n="85" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <Alias n="86" Id="(@85)" />
+    <Alias n="87" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.DataProtection.Abstractions.dll" />
+    <Alias n="88" Id="(@87)" />
+    <Alias n="89" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Http.Abstractions.dll" />
+    <Alias n="90" Id="(@89)" />
+    <Alias n="91" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Collections.dll" />
+    <Alias n="92" Id="(@91)" />
+    <Alias n="93" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Options.dll" />
+    <Alias n="94" Id="(@93)" />
+    <Alias n="95" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Net.Http.Headers.dll" />
+    <Alias n="96" Id="(@95)" />
+    <Alias n="97" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/azure.security.keyvault.secrets/4.1.0/lib/netstandard2.0/Azure.Security.KeyVault.Secrets.dll" />
+    <Alias n="98" Id="(@97)" />
+    <Alias n="99" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.Components.dll" />
+    <Alias n="100" Id="(@99)" />
+    <Alias n="101" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.authentication.openidconnect/3.1.8/lib/netcoreapp3.1/Microsoft.AspNetCore.Authentication.OpenIdConnect.dll" />
+    <Alias n="102" Id="(@101)" />
+    <Alias n="103" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.identitymodel.protocols.openidconnect/5.5.0/lib/netstandard2.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" />
+    <Alias n="104" Id="(@103)" />
+    <Alias n="105" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.identity.client/4.22.0/ref/netcoreapp2.1/Microsoft.Identity.Client.dll" />
+    <Alias n="106" Id="(@105)" />
+    <Alias n="107" Uri="Assembly=file:///C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/System.Collections.Concurrent.dll" />
+    <Alias n="108" Id="(@107)" />
+    <Alias n="109" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/system.identitymodel.tokens.jwt/5.5.0/lib/netstandard2.0/System.IdentityModel.Tokens.Jwt.dll" />
+    <Alias n="110" Id="(@109)" />
+    <Alias n="111" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.AspNetCore.CookiePolicy.dll" />
+    <Alias n="112" Id="(@111)" />
+    <Alias n="113" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/microsoft.aspnetcore.app.ref/3.1.2/ref/netcoreapp3.1/Microsoft.Extensions.Caching.Memory.dll" />
+    <Alias n="114" Id="(@113)" />
+    <Alias n="115" Uri="Assembly=file:///C:/Users/jmprieur/.nuget/packages/azure.identity/1.2.3/lib/netstandard2.0/Azure.Identity.dll" />
+    <Alias n="116" Id="(@115)" />
+    <Alias n="117" Id="Namespace=Microsoft.Identity.Web" />
+    <Alias n="118" Id="(@3 @117)" />
+    <Alias n="119" Id="Namespace=Microsoft.Identity.Web.InstanceDiscovery" />
+    <Alias n="120" Id="(@3 @119)" />
+    <Alias n="121" Id="Namespace=Microsoft.Identity.Web.Resource" />
+    <Alias n="122" Id="(@3 @121)" />
+    <Alias n="123" Id="(@3 Namespace=Microsoft.Identity.Web.TokenCacheProviders)" />
+    <Alias n="124" Id="(@3 Namespace=Microsoft.Identity.Web.TokenCacheProviders.Distributed)" />
+    <Alias n="125" Id="(@3 Namespace=Microsoft.Identity.Web.TokenCacheProviders.InMemory)" />
+    <Alias n="126" Id="(@3 Namespace=Microsoft.Identity.Web.TokenCacheProviders.Session)" />
+    <Alias n="127" Id="(@3 @121 Type=AadIssuerValidator)" />
+    <Alias n="128" Id="(@3 @117 Type=AadIssuerValidatorOptions)" />
+    <Alias n="129" Id="(@3 @117 Type=AccountExtensions)" />
+    <Alias n="130" Id="(@3 @117 Type=AppServicesAuthenticationBuilderExtensions)" />
+    <Alias n="131" Id="(@3 @117 Type=AppServicesAuthenticationDefaults)" />
+    <Alias n="132" Id="(@3 @117 Type=AppServicesAuthenticationHandler)" />
+    <Alias n="133" Id="(@3 @117 Type=AppServicesAuthenticationInformation)" />
+    <Alias n="134" Id="(@3 @117 Type=AppServicesAuthenticationOptions)" />
+    <Alias n="135" Id="(@3 @117 Type=AppServicesAuthenticationTokenAcquisition)" />
+    <Alias n="136" Id="(@3 @117 Type=AuthorityHelpers)" />
+    <Alias n="137" Id="(@3 @117 Type=AuthorizeForScopesAttribute)" />
+    <Alias n="138" Id="(@3 @117 Type=AzureADB2COpenIDConnectEventHandlers)" />
+    <Alias n="139" Id="(@3 @117 Type=Base64UrlHelpers)" />
+    <Alias n="140" Id="(@3 @117 Type=CertificateDescription)" />
+    <Alias n="141" Id="(@3 @117 Type=CertificateSource)" />
+    <Alias n="142" Id="(@3 @117 Type=ClaimConstants)" />
+    <Alias n="143" Id="(@3 @117 Type=ClaimsPrincipalExtensions)" />
+    <Alias n="144" Id="(@3 @117 Type=ClaimsPrincipalFactory)" />
+    <Alias n="145" Id="(@3 @117 Type=ClientInfo)" />
+    <Alias n="146" Id="(@3 @117 Type=Constants)" />
+    <Alias n="147" Id="(@3 @117 Type=CookiePolicyOptionsExtensions)" />
+    <Alias n="148" Id="(@3 @117 Type=DefaultCertificateLoader)" />
+    <Alias n="149" Id="(@3 @117 Type=DownstreamWebApi)" />
+    <Alias n="150" Id="(@3 @117 Type=DownstreamWebApiExtensions)" />
+    <Alias n="151" Id="(@3 @117 Type=DownstreamWebApiGenericExtensions)" />
+    <Alias n="152" Id="(@3 @117 Type=DownstreamWebApiOptions)" />
+    <Alias n="153" Id="(@3 @117 Type=ErrorCodes)" />
+    <Alias n="154" Id="(@3 @117 Type=Extensions)" />
+    <Alias n="155" Id="(@3 @117 Type=HttpContextExtensions)" />
+    <Alias n="156" Id="(@3 @117 Type=ICertificateLoader)" />
+    <Alias n="157" Id="(@3 @117 Type=IdHelper)" />
+    <Alias n="158" Id="(@3 @117 Type=IDownstreamWebApi)" />
+    <Alias n="159" Id="(@3 @117 Type=IDWebErrorMessage)" />
+    <Alias n="160" Id="(@3 @121 Type=IJwtBearerMiddlewareDiagnostics)" />
+    <Alias n="161" Id="(@3 @117 Type=IncrementalConsentAndConditionalAccessHelper)" />
+    <Alias n="162" Id="(@3 @121 Type=IOpenIdConnectMiddlewareDiagnostics)" />
+    <Alias n="163" Id="(@3 @119 Type=IssuerConfigurationRetriever)" />
+    <Alias n="164" Id="(@3 @119 Type=IssuerMetadata)" />
+    <Alias n="165" Id="(@3 @117 Type=ITokenAcquisition)" />
+    <Alias n="166" Id="(@3 @117 Type=ITokenAcquisitionInternal)" />
+    <Alias n="167" Id="(@3 @121 Type=JwtBearerMiddlewareDiagnostics)" />
+    <Alias n="168" Id="(@3 @117 Type=LogMessages)" />
+    <Alias n="169" Id="(@3 @119 Type=Metadata)" />
+    <Alias n="170" Id="(@3 @117 Type=MicrosoftIdentityAppCallsWebApiAuthenticationBuilder)" />
+    <Alias n="171" Id="(@3 @117 Type=MicrosoftIdentityBaseAuthenticationBuilder)" />
+    <Alias n="172" Id="(@3 @117 Type=MicrosoftIdentityBlazorServiceCollectionExtensions)" />
+    <Alias n="173" Id="(@3 @117 Type=MicrosoftIdentityConsentAndConditionalAccessHandler)" />
+    <Alias n="174" Id="(@3 @121 Type=MicrosoftIdentityIssuerValidatorFactory)" />
+    <Alias n="175" Id="(@3 @117 Type=MicrosoftIdentityOptions)" />
+    <Alias n="176" Id="(@3 @117 Type=MicrosoftIdentityOptionsValidation)" />
+    <Alias n="177" Id="(@3 @117 Type=MicrosoftIdentityServiceHandler)" />
+    <Alias n="178" Id="(@3 @117 Type=MicrosoftIdentityWebApiAuthenticationBuilder)" />
+    <Alias n="179" Id="(@3 @117 Type=MicrosoftIdentityWebApiAuthenticationBuilderExtensions)" />
+    <Alias n="180" Id="(@3 @117 Type=MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration)" />
+    <Alias n="181" Id="(@3 @117 Type=MicrosoftIdentityWebApiServiceCollectionExtensions)" />
+    <Alias n="182" Id="(@3 @117 Type=MicrosoftIdentityWebAppAuthenticationBuilder)" />
+    <Alias n="183" Id="(@3 @117 Type=MicrosoftIdentityWebAppAuthenticationBuilderExtensions)" />
+    <Alias n="184" Id="(@3 @117 Type=MicrosoftIdentityWebAppAuthenticationBuilderWithConfiguration)" />
+    <Alias n="185" Id="(@3 @117 Type=MicrosoftIdentityWebAppServiceCollectionExtensions)" />
+    <Alias n="186" Id="(@3 @117 Type=MicrosoftIdentityWebChallengeUserException)" />
+    <Alias n="187" Id="(@3 @117 Type=MsalAspNetCoreHttpClientFactory)" />
+    <Alias n="188" Id="(@3 @117 Type=OidcConstants)" />
+    <Alias n="189" Id="(@3 @121 Type=OpenIdConnectMiddlewareDiagnostics)" />
+    <Alias n="190" Id="(@3 @121 Type=RegisterValidAudience)" />
+    <Alias n="191" Id="(@3 @121 Type=RolesRequiredHttpContextExtensions)" />
+    <Alias n="192" Id="(@3 @121 Type=ScopesRequiredHttpContextExtensions)" />
+    <Alias n="193" Id="(@3 @117 Type=ServiceCollectionExtensions)" />
+    <Alias n="194" Id="(@3 @117 Type=TokenAcquisition)" />
+    <Alias n="195" Id="(@3 @117 Type=TokenAcquisitionOptions)" />
+  </IdentifierAliases>
+  <Styles>
+    <Style TargetType="Node" GroupLabel="Category 1" ValueLabel="Has category">
+      <Condition Expression="HasCategory('Category1')" />
+      <Setter Property="Background" Value="#FFE51400" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Results" ValueLabel="True">
+      <Condition Expression="HasCategory('QueryResult')" />
+      <Setter Property="Background" Value="#FFBCFFBE" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Test Project" ValueLabel="Test Project">
+      <Condition Expression="HasCategory('CodeMap_TestProject')" />
+      <Setter Property="Icon" Value="CodeMap_TestProject" />
+      <Setter Property="Background" Value="#FF307A69" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Web Project" ValueLabel="Web Project">
+      <Condition Expression="HasCategory('CodeMap_WebProject')" />
+      <Setter Property="Icon" Value="CodeMap_WebProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Windows Store Project" ValueLabel="Windows Store Project">
+      <Condition Expression="HasCategory('CodeMap_WindowsStoreProject')" />
+      <Setter Property="Icon" Value="CodeMap_WindowsStoreProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Phone Project" ValueLabel="Phone Project">
+      <Condition Expression="HasCategory('CodeMap_PhoneProject')" />
+      <Setter Property="Icon" Value="CodeMap_PhoneProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Portable Library" ValueLabel="Portable Library">
+      <Condition Expression="HasCategory('CodeMap_PortableLibraryProject')" />
+      <Setter Property="Icon" Value="CodeMap_PortableLibraryProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="WPF Project" ValueLabel="WPF Project">
+      <Condition Expression="HasCategory('CodeMap_WpfProject')" />
+      <Setter Property="Icon" Value="CodeMap_WpfProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="VSIX Project" ValueLabel="VSIX Project">
+      <Condition Expression="HasCategory('CodeMap_VsixProject')" />
+      <Setter Property="Icon" Value="CodeMap_VsixProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Modeling Project" ValueLabel="Modeling Project">
+      <Condition Expression="HasCategory('CodeMap_ModelingProject')" />
+      <Setter Property="Icon" Value="CodeMap_ModelingProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Assembly" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Assembly')" />
+      <Setter Property="Background" Value="#FF094167" />
+      <Setter Property="Stroke" Value="#FF094167" />
+      <Setter Property="Icon" Value="CodeSchema_Assembly" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Namespace" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Namespace')" />
+      <Setter Property="Background" Value="#FF0E619A" />
+      <Setter Property="Stroke" Value="#FF0E619A" />
+      <Setter Property="Icon" Value="CodeSchema_Namespace" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Interface" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Interface')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Interface" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Struct" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Struct')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Struct" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Enumeration" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Enum')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Enum" />
+      <Setter Property="LayoutSettings" Value="List" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Delegate" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Delegate')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Delegate" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Class" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Type')" />
+      <Setter Property="Background" Value="#FF0E70C0" />
+      <Setter Property="Stroke" Value="#FF0E70C0" />
+      <Setter Property="Icon" Value="CodeSchema_Class" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Property" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Property')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Property" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Method" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Method') Or HasCategory('CodeSchema_CallStackUnresolvedMethod')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Method" />
+      <Setter Property="LayoutSettings" Value="List" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Event" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Event')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Event" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Field" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Field')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Field" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Out Parameter" ValueLabel="Has category">
+      <Condition Expression="CodeSchemaProperty_IsOut = 'True'" />
+      <Setter Property="Icon" Value="CodeSchema_OutParameter" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Parameter" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Parameter')" />
+      <Setter Property="Icon" Value="CodeSchema_Parameter" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Local Variable" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_LocalExpression')" />
+      <Setter Property="Icon" Value="CodeSchema_LocalExpression" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Externals" ValueLabel="Has category">
+      <Condition Expression="HasCategory('Externals')" />
+      <Setter Property="Background" Value="#FF424242" />
+      <Setter Property="Stroke" Value="#FF424242" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Inherits From" ValueLabel="True">
+      <Condition Expression="HasCategory('InheritsFrom')" />
+      <Setter Property="Stroke" Value="#FF00A600" />
+      <Setter Property="StrokeDashArray" Value="2 0" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Implements" ValueLabel="True">
+      <Condition Expression="HasCategory('Implements')" />
+      <Setter Property="Stroke" Value="#8000A600" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Calls" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_Calls')" />
+      <Setter Property="Stroke" Value="#FFFF00FF" />
+      <Setter Property="StrokeDashArray" Value="2 0" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Function Pointer" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FunctionPointer')" />
+      <Setter Property="Stroke" Value="#FFFF00FF" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Field Read" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FieldRead')" />
+      <Setter Property="Stroke" Value="#FF00AEEF" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Field Write" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FieldWrite')" />
+      <Setter Property="Stroke" Value="#FF00AEEF" />
+      <Setter Property="DrawArrow" Value="true" />
+      <Setter Property="IsHidden" Value="false" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Inherits From" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('InheritsFrom') And Target.HasCategory('CodeSchema_Class')" />
+      <Setter Property="TargetDecorator" Value="OpenArrow" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Implements" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('Implements') And Target.HasCategory('CodeSchema_Interface')" />
+      <Setter Property="TargetDecorator" Value="OpenArrow" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Comment Link" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="Source.HasCategory('Comment')" />
+      <Setter Property="Stroke" Value="#FFE5C365" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Cursor Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsCursorLocation" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Disabled Breakpoint Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="DisabledBreakpointCount" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Enabled Breakpoint Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="EnabledBreakpointCount" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Instruction Pointer Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsInstructionPointerLocation" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Current Callstack Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsCurrentCallstackFrame" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Return" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeSchema_ReturnTypeLink')" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="References" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('References')" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Uses Attribute" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeSchema_AttributeUse')" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Solution Folder" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeMap_SolutionFolder')" />
+      <Setter Property="Background" Value="#FFDEBA83" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Project Reference" ValueLabel="Project Reference">
+      <Condition Expression="HasCategory('CodeMap_ProjectReference')" />
+      <Setter Property="Stroke" Value="#9A9A9A" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="External Reference" ValueLabel="External Reference">
+      <Condition Expression="HasCategory('CodeMap_ExternalReference')" />
+      <Setter Property="Stroke" Value="#9A9A9A" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+  </Styles>
+  <Paths>
+    <Path Id="bd795319-75b8-4251-ae92-8dd5a807c28e.OutputPath" Value="C:\gh\microsoft-identity-web\src\Microsoft.Identity.Web\bin\Debug\netcoreapp3.1\Microsoft.Identity.Web.dll" />
+    <Path Id="bd795319-75b8-4251-ae92-8dd5a807c28e.OutputPathUri" Value="file:///C:/gh/microsoft-identity-web/src/Microsoft.Identity.Web/bin/Debug/netcoreapp3.1/Microsoft.Identity.Web.dll" />
+  </Paths>
+</DirectedGraph>

--- a/src/Microsoft.Identity.Web/CertificateManagement/DefaultCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web/CertificateManagement/DefaultCertificateLoader.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Web
             }
 
             // Parse the secret ID and version to retrieve the private key.
-            string[] segments = certificate.SecretId.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            string[] segments = certificate.SecretId.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             if (segments.Length != 3)
             {
                 throw new InvalidOperationException(string.Format(


### PR DESCRIPTION
This enables the certificates to be added to the net472 target if we want to later
(to avoid losing this change)

Also committing the DGML graph showing which classes could be exposed to net472 (with time, not a priority)