### PR TITLE
Use stable .NET 5, update actions versions.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -41,10 +41,10 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - name: Setup .NET 5.0.100-preview.7.20366.6
-      uses: actions/setup-dotnet@v1.5.0
+    - name: Setup .NET 5.0.100
+      uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 5.0.100-preview.7.20366.6
+        dotnet-version: 5.0.100
 
     - name: Build with .NET net5.0
       run: dotnet build Microsoft.Identity.Web-Source.sln -f net5.0 -p:FROM_GITHUB_ACTION=true --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,16 +12,16 @@ jobs:
         dotNetRunVersion: [netcoreapp3.1]
         solution: [Microsoft.Identity.Web.sln]
         include:
-          - DotNetInstallVersion: 5.0.100-preview.7.20366.6
+          - DotNetInstallVersion: 5.0.100
             DotNetRunVersion: net5.0
             Solution: Microsoft.Identity.Web-without-blasorwasm2-sample.sln
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.1
+      uses: actions/checkout@v2.3.4
 
     - name: Setup .NET ${{ matrix.dotNetInstallVersion }}
-      uses: actions/setup-dotnet@v1.5.0
+      uses: actions/setup-dotnet@v1.7.2
       with:
         dotnet-version: ${{ matrix.dotNetInstallVersion }}
 


### PR DESCRIPTION
- Use stable .NET 5.0 version.
- Update versions of GitHub actions, which also fixes some errors shown by GitHub [here](https://github.com/AzureAD/microsoft-identity-web/actions/runs/358191852).