### PR TITLE
Removes a double /tfp in B2C web apps calling web APIs when instance ends in /tfp/

### DIFF
--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -150,6 +150,9 @@ namespace Microsoft.Identity.Web
                 {
                     string? userFlow = context.Principal?.GetUserFlowId();
                     var authority = $"{_applicationOptions.Instance}{ClaimConstants.Tfp}/{_microsoftIdentityOptions.Domain}/{userFlow ?? _microsoftIdentityOptions.DefaultUserFlow}";
+                    
+                    // Consider the case where the authority in the config ends with /tfp
+                    authority = authority.Replace("/tfp/tfp", "/tfp");
                     builder.WithB2CAuthority(authority);
                 }
 


### PR DESCRIPTION
For a b2C web app **that calls a web API**, if the developer provides the tfp in the authority in the appsettings.json, the sign-in part of the Oauth code flow works, but Microsoft.Identity.Web adds a second /tfp in the authority, and MSAL fails.

```Json
{
  "AzureAdB2C": {
    "Instance": "https://login.microsoftonline.com/tfp/",
```

This PR provides a work around for this case (and only this case).

This is an issue because the ASP.NET Core templates do that.

Not sure if we want to add a unit test?