### PR TITLE
Add support for tenant selection when using AppOnly Microsoft Graph

### DIFF
--- a/src/Microsoft.Identity.Web.MicrosoftGraph/BaseRequestExtensions.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/BaseRequestExtensions.cs
@@ -30,10 +30,15 @@ namespace Microsoft.Identity.Web
         /// <typeparam name="T">Type of the request.</typeparam>
         /// <param name="baseRequest">Request.</param>
         /// <param name="appOnly">Should the permissions be app only or not.</param>
+        /// <param name="tenant">Tenant ID or domain for which we want to make the call..</param>
         /// <returns></returns>
-        public static T WithAppOnly<T>(this T baseRequest, bool appOnly = true) where T : IBaseRequest
+        public static T WithAppOnly<T>(this T baseRequest, bool appOnly = true, string? tenant = null) where T : IBaseRequest
         {
-            return SetParameter(baseRequest, options => options.AppOnly = appOnly);
+            return SetParameter(baseRequest, options =>
+            {
+                options.AppOnly = appOnly;
+                options.Tenant = tenant;
+            });
         }
 
         private static T SetParameter<T>(T baseRequest, Action<TokenAcquisitionAuthenticationProviderOption> action) where T : IBaseRequest

--- a/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionAuthenticationProvider.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionAuthenticationProvider.cs
@@ -33,11 +33,13 @@ namespace Microsoft.Identity.Web
             // Default options to settings provided during intialization
             var scopes = _initialOptions.Scopes;
             bool appOnly = _initialOptions.AppOnly ?? false;
+            string? tenant = _initialOptions.Tenant ?? null;
             // Extract per-request options from the request if present
             TokenAcquisitionAuthenticationProviderOption? msalAuthProviderOption = GetMsalAuthProviderOption(request);
             if (msalAuthProviderOption != null) {
                 scopes = msalAuthProviderOption.Scopes ?? scopes;
                 appOnly = msalAuthProviderOption.AppOnly ?? appOnly;
+                tenant = msalAuthProviderOption.Tenant ?? tenant;
             }
 
             if (!appOnly && scopes == null)
@@ -50,7 +52,7 @@ namespace Microsoft.Identity.Web
             string token;
             if (appOnly)
             {
-                token = await _tokenAcquisition.GetAccessTokenForAppAsync(Constants.DefaultGraphScope).ConfigureAwait(false);
+                token = await _tokenAcquisition.GetAccessTokenForAppAsync(Constants.DefaultGraphScope, tenant).ConfigureAwait(false);
             }
             else
             {

--- a/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionAuthenticationProviderOption.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionAuthenticationProviderOption.cs
@@ -6,5 +6,6 @@ namespace Microsoft.Identity.Web
     {
         public string[]? Scopes { get; set; }
         public bool? AppOnly { get; set; }
+        public string? Tenant { get; set; }
     }
 }


### PR DESCRIPTION
When using AppOnly call with multi-tenant application, you won't be able to obtain the token for target tenant due to not being able to choose the tenant. This pull request adds support to explicitly choose tenant when obtaining an app-only token like this:

```csharp
var organization = await _microsoftGraph.Organization
    .Request()
    .WithAppOnly(tenant: "thenetw.org") // or tenantId
    .GetAsync();
```