### PR TITLE
Fixes the login_hint and domain_hint challenge

### DIFF
--- a/build/template-install-dotnet-core.yaml
+++ b/build/template-install-dotnet-core.yaml
@@ -5,7 +5,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .Net Core SDK 5'
   inputs:
-    version: 5.0.0
+    version: 5.0.100
 - task: UseDotNet@2
   displayName: 'Use .Net Core SDK 3.1.404'
   inputs:

--- a/build/template-install-dotnet-core.yaml
+++ b/build/template-install-dotnet-core.yaml
@@ -3,7 +3,11 @@
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .Net Core SDK 3.1.101'
+  displayName: 'Use .Net Core SDK 5'
   inputs:
-    version: 3.1.101
+    version: 5.0.0
+- task: UseDotNet@2
+  displayName: 'Use .Net Core SDK 3.1.404'
+  inputs:
+    version: 3.1.404
     

--- a/build/template-install-nuget.yaml
+++ b/build/template-install-nuget.yaml
@@ -3,6 +3,6 @@
 
 steps:
 - task: NuGetToolInstaller@1
-  displayName: 'Use NuGet latest'
+  displayName: 'Use NuGet 4.8'
   inputs:
-    checkLatest: true
+    versionSpec: 4.8

--- a/build/template-install-nuget.yaml
+++ b/build/template-install-nuget.yaml
@@ -2,7 +2,7 @@
 # Run Nuget Tool Installer
 
 steps:
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.6.2'
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet latest'
   inputs:
-    versionSpec: 4.6.2
+    checkLatest: true

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -71,12 +71,15 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
             Dictionary<string, string?> properties = new Dictionary<string, string?>
             {
                 { Constants.Scope, scope },
-                { Constants.LoginHint, loginHint },
-                { Constants.DomainHint, domainHint },
                 { Constants.Claims, claims },
                 { Constants.Policy, policy },
             };
-            AuthenticationProperties authenticationProperties = new AuthenticationProperties(properties);
+            Dictionary<string, object> parameters = new Dictionary<string, object>
+            {
+                { Constants.LoginHint, loginHint },
+                { Constants.DomainHint, domainHint },
+            };
+            AuthenticationProperties authenticationProperties = new AuthenticationProperties(properties, parameters);
             authenticationProperties.RedirectUri = redirectUri;
 
             return Challenge(

--- a/src/Microsoft.Identity.Web/Constants/Constants.cs
+++ b/src/Microsoft.Identity.Web/Constants/Constants.cs
@@ -120,5 +120,9 @@ namespace Microsoft.Identity.Web
         internal const string XReturnUrl = "x-ReturnUrl";
         internal const string XRequestedWith = "X-Requested-With";
         internal const string XmlHttpRequest = "XMLHttpRequest";
+
+        // AccountController.Challenge parameters
+        internal const string LoginHintParameter = "loginHint";
+        internal const string DomainHintParameter = "domainHint";
     }
 }

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1262,6 +1262,14 @@
             <param name="builder">Service side blazor builder.</param>
             <returns>The builder.</returns>
         </member>
+        <member name="M:Microsoft.Identity.Web.MicrosoftIdentityBlazorServiceCollectionExtensions.AddMicrosoftIdentityConsentHandler(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Add the incremental consent and conditional access handler for
+            web app pages, Razor pages, controllers, views, etc...
+            </summary>
+            <param name="services">Service collection.</param>
+            <returns>The service collection.</returns>
+        </member>
         <member name="T:Microsoft.Identity.Web.MicrosoftIdentityConsentAndConditionalAccessHandler">
             <summary>
             Handler for Blazor specific APIs to handle incremental consent

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityCircuitHandler.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityCircuitHandler.cs
@@ -224,8 +224,8 @@ namespace Microsoft.Identity.Web
             }
 
             string url = $"{BaseUri}/{Constants.BlazorChallengeUri}{redirectUri}"
-                + $"&{Constants.Scope}={string.Join(" ", effectiveScopes!)}&{Constants.LoginHint}={User.GetLoginHint()}"
-                + $"&{Constants.DomainHint}={User.GetDomainHint()}&{Constants.Claims}={claims}"
+                + $"&{Constants.Scope}={string.Join(" ", effectiveScopes!)}&{Constants.LoginHintParameter}={User.GetLoginHint()}"
+                + $"&{Constants.DomainHintParameter}={User.GetDomainHint()}&{Constants.Claims}={claims}"
                 + $"&{OidcConstants.PolicyKey}={userflow}";
 
             if (IsBlazorServer)

--- a/tests/IntegrationTests/WebAppUiTests/WebAppUiTests.csproj
+++ b/tests/IntegrationTests/WebAppUiTests/WebAppUiTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="85.0.4183.8700" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="87.0.4280.2000" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fixes the login_hint and domain_hint challenge.
This is a complement to the fix done in https://github.com/AzureAD/microsoft-identity-web/issues/798, which was not sufficient

The issue was:
- after fixing #800, `MicrosoftIdentityConsentAndConditionalAccessHandler.ChallengeUser` was now calling `AccountController.Challenge` with the `login_hint` and `domain_hint` parameters names (that is the **OIDC** parameter names), whereas the name of the **method** parameters are `loginHint` and `domainHint`. Added 2 new constants in `Constants` for these two method parameters names.
- The `AccountController.Challenge` method was sending the `login_hint` and `domaint_hint` to the STS as **properties** whereas they should be **parameters** (this is a very subtle behavior of the OpenIdConnectMessage)

Tested on Caleb's application. The user is no longer requested to sign-in.
We probably need to check on the tests samples, but this should really improve the SSO experience