### PR TITLE
Update installation of .NET Core as the build agents have a breaking …

### DIFF
--- a/build/template-install-dotnet-core.yaml
+++ b/build/template-install-dotnet-core.yaml
@@ -3,11 +3,6 @@
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .Net Core SDK 5'
-  inputs:
-    version: 5.0.100-preview.7.20366.6
-    includePreviewVersions: true # Required for preview versions
-- task: UseDotNet@2
   displayName: 'Use .Net Core SDK 3.1.101'
   inputs:
     version: 3.1.101


### PR DESCRIPTION
…change

Discovered in build: https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=678153&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=2b20c7d0-7587-5b0f-aadc-b456e6f0b807&l=387

Info: Azure Pipelines hosted agents have been updated and now contain .Net 5.x SDK/Runtime along with the older .Net Core version which are currently lts. Unless you have locked down a SDK version for your project(s), 5.x SDK might be picked up which might have breaking behavior as compared to previous versions. 

You can learn more about the breaking changes here: https://docs.microsoft.com/en-us/dotnet/core/tools/ and https://docs.microsoft.com/en-us/dotnet/core/compatibility/ . To learn about more such changes and troubleshoot, refer here: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/dotnet-core-cli?view=azure-devops#troubleshooting
##[error]Dotnet command failed with non-zero exit code on the following projects : D:\a\1\s\Microsoft.Identity.Web.sln