### PR TITLE
doing logs via default logging

### DIFF
--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Identity.Web
                         .WithHttpClientFactory(_httpClientFactory)
                         .WithLogging(
                             Log,
-                            ConvertMicrosoftExtensionsLogLevelToMsal(),
+                            ConvertMicrosoftExtensionsLogLevelToMsal(_logger),
                             enablePiiLogging: _applicationOptions.EnablePiiLogging);
 
                 // The redirect URI is not needed for OBO
@@ -765,31 +765,27 @@ namespace Microsoft.Identity.Web
             }
         }
 
-        private Client.LogLevel? ConvertMicrosoftExtensionsLogLevelToMsal()
+        private Client.LogLevel? ConvertMicrosoftExtensionsLogLevelToMsal(ILogger logger)
         {
-            var configuration = _serviceProvider.GetRequiredService<IConfiguration>();
-            Microsoft.Extensions.Logging.LogLevel loglevel = configuration.GetValue<Microsoft.Extensions.Logging.LogLevel>("Logging:LogLevel:Microsoft.Identity.Web");
-
-            switch (loglevel)
+            if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Information)
+               || logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug)
+               || logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
             {
-                case Microsoft.Extensions.Logging.LogLevel.Trace:
-                    return Client.LogLevel.Info;
-                case Microsoft.Extensions.Logging.LogLevel.Debug:
-                    return Client.LogLevel.Info;
-                case Microsoft.Extensions.Logging.LogLevel.Information:
-                    return Client.LogLevel.Info;
-                case Microsoft.Extensions.Logging.LogLevel.Warning:
-                    return Client.LogLevel.Warning;
-                case Microsoft.Extensions.Logging.LogLevel.Error:
-                    return Client.LogLevel.Error;
-                case Microsoft.Extensions.Logging.LogLevel.Critical:
-                    return Client.LogLevel.Error;
-                case Microsoft.Extensions.Logging.LogLevel.None:
-                    return null;
-                default:
-                    throw new InvalidEnumArgumentException(nameof(Microsoft.Extensions.Logging.LogLevel.Error));
+                return Client.LogLevel.Info;
+            }
+            else if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Warning))
+            {
+                return Client.LogLevel.Warning;
+            }
+            else if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Error)
+                || logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Critical))
+            {
+                return Client.LogLevel.Error;
+            }
+            else
+            {
+                return null;
             }
         }
-
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Identity.Web.Test
             };
 
             services.AddTokenAcquisition();
+            services.AddLogging();
             services.AddTransient(
                 provider => Options.Create(_microsoftIdentityOptions));
             services.AddTransient(

--- a/tests/WebAppCallsMicrosoftGraph/appsettings.json
+++ b/tests/WebAppCallsMicrosoftGraph/appsettings.json
@@ -5,9 +5,9 @@
         "TenantId": "7f58f645-c190-4ce5-9de4-e2b7acd2a6ab",
         "ClientId": "56c9a633-236e-45ee-9af1-a53d9811fbd6",
         // To call an API
-        "ClientSecret": "[client-secret]",
+        "ClientSecret": "secret-goes-here",
+        //"EnablePiiLogging": true,
         "CallbackPath": "/signin-oidc"
-        //"EnablePiiLogging": true
     },
 
     "GraphBeta": {
@@ -19,12 +19,8 @@
         "LogLevel": {
             "Default": "Information",
             "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
-        },
-        "Console": {
-            "LogLevel": {
-                "Default": "Information"
-            }
+            "Microsoft.Hosting.Lifetime": "Information",
+            "Microsoft.Identity.Web":  "Information"
         }
     },
     "AllowedHosts": "*"

--- a/tests/WebAppCallsMicrosoftGraph/appsettings.json
+++ b/tests/WebAppCallsMicrosoftGraph/appsettings.json
@@ -5,8 +5,9 @@
         "TenantId": "7f58f645-c190-4ce5-9de4-e2b7acd2a6ab",
         "ClientId": "56c9a633-236e-45ee-9af1-a53d9811fbd6",
         // To call an API
-        "ClientSecret": "[secret-from-portal]",
+        "ClientSecret": "[client-secret]",
         "CallbackPath": "/signin-oidc"
+        //"EnablePiiLogging": true
     },
 
     "GraphBeta": {
@@ -19,6 +20,11 @@
             "Default": "Information",
             "Microsoft": "Warning",
             "Microsoft.Hosting.Lifetime": "Information"
+        },
+        "Console": {
+            "LogLevel": {
+                "Default": "Information"
+            }
         }
     },
     "AllowedHosts": "*"


### PR DESCRIPTION
Pros:
- define the loglevel in the regular logs, 
```csharp
"Logging": {
        "LogLevel": {
            "Microsoft.Identity.Web": "Information",
...
```
and we pick it up: 
```csharp
loglevel = configuration.GetValue<Microsoft.Extensions.Logging.LogLevel>("Logging:LogLevel:Microsoft.Identity.Web");
```
- using natural logging system for asp .net

Cons:
- seems to be mapping to a default of `Trace` even with nothing selected. We would not want MSAL logs on all the time, as this is expensive. We'd have to figure out a different option if they want logs, but not MSAL logs.
- mapping between `Microsoft.Extensions.Logging.LogLevel` and `Client.LogLevel`, and the enum values are different
- if enabling pii logs, devs will have to set this value `"EnablePiiLogging": true` in appsettings.json
