### PR TITLE
allow for separate sign up and sign in user flows

### DIFF
--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/dotnetcli.host.json
@@ -13,8 +13,16 @@
       "shortName": ""
     },
     "SignUpSignInPolicyId": {
-      "longName": "susi-policy-id",
-      "shortName": "ssp"
+        "longName": "susi-policy-id",
+        "shortName": "ssp"
+    },
+    "SignUpPolicyId": {
+        "longName": "signup-policy-id",
+        "shortName": "sup"
+    },
+    "SignInPolicyId": {
+      "longName": "signin-policy-id",
+      "shortName": "sip"
     },
     "ResetPasswordPolicyId": {
       "longName": "reset-password-policy-id",

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
@@ -215,11 +215,25 @@
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_susi",
+        "replaces": "MySignUpSignInPolicyId",
+        "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignUpPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_signup",
+        "replaces": "MySignUpPolicyId",
+        "description": "The sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignInPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "b2c_1_susi",
-      "replaces": "MySignUpSignInPolicyId",
-      "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+      "defaultValue": "b2c_1_signin",
+      "replaces": "MySignInPolicyId",
+      "description": "The sign-in policy ID for this project (use with IndividualB2C auth)."
     },
     "SignedOutCallbackPath": {
         "type": "parameter",

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/dotnetcli.host.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/dotnetcli.host.json
@@ -26,8 +26,16 @@
       "shortName": ""
     },
     "SignUpSignInPolicyId": {
-      "longName": "susi-policy-id",
-      "shortName": "ssp"
+        "longName": "susi-policy-id",
+        "shortName": "ssp"
+    },
+    "SignUpPolicyId": {
+        "longName": "signup-policy-id",
+        "shortName": "sup"
+    },
+    "SignInPolicyId": {
+      "longName": "signin-policy-id",
+      "shortName": "sip"
     },
     "OrgReadAccess": {
       "longName": "org-read-access",

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -341,11 +341,25 @@
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_susi",
+        "replaces": "MySignUpSignInPolicyId",
+        "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignUpPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_signup",
+        "replaces": "MySignUpPolicyId",
+        "description": "The sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignInPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "b2c_1_susi",
-      "replaces": "MySignUpSignInPolicyId",
-      "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+      "defaultValue": "b2c_1_signin",
+      "replaces": "MySignInPolicyId",
+      "description": "The sign-in policy ID for this project (use with IndividualB2C auth)."
     },
     "AADInstance": {
       "type": "parameter",

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
@@ -13,8 +13,16 @@
       "shortName": ""
     },
     "SignUpSignInPolicyId": {
-      "longName": "susi-policy-id",
-      "shortName": "ssp"
+        "longName": "susi-policy-id",
+        "shortName": "ssp"
+    },
+    "SignUpPolicyId": {
+        "longName": "signup-policy-id",
+        "shortName": "sup"
+    },
+    "SignInPolicyId": {
+      "longName": "signin-policy-id",
+      "shortName": "sip"
     },
     "ResetPasswordPolicyId": {
       "longName": "reset-password-policy-id",

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/template.json
@@ -139,11 +139,25 @@
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_susi",
+        "replaces": "MySignUpSignInPolicyId",
+        "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignUpPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_signup",
+        "replaces": "MySignUpPolicyId",
+        "description": "The sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignInPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "b2c_1_susi",
-      "replaces": "MySignUpSignInPolicyId",
-      "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+      "defaultValue": "b2c_1_signin",
+      "replaces": "MySignInPolicyId",
+      "description": "The sign-in policy ID for this project (use with IndividualB2C auth)."
     },
     "SignedOutCallbackPath": {
         "type": "parameter",

--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -13,8 +13,16 @@
       "shortName": ""
     },
     "SignUpSignInPolicyId": {
-      "longName": "susi-policy-id",
-      "shortName": "ssp"
+        "longName": "susi-policy-id",
+        "shortName": "ssp"
+    },
+    "SignUpPolicyId": {
+        "longName": "signup-policy-id",
+        "shortName": "sup"
+    },
+    "SignInPolicyId": {
+      "longName": "signin-policy-id",
+      "shortName": "sip"
     },
     "ResetPasswordPolicyId": {
       "longName": "reset-password-policy-id",

--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
@@ -135,11 +135,25 @@
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_susi",
+        "replaces": "MySignUpSignInPolicyId",
+        "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignUpPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_signup",
+        "replaces": "MySignUpPolicyId",
+        "description": "The sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignInPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "b2c_1_susi",
-      "replaces": "MySignUpSignInPolicyId",
-      "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+      "defaultValue": "b2c_1_signin",
+      "replaces": "MySignInPolicyId",
+      "description": "The sign-in policy ID for this project (use with IndividualB2C auth)."
     },
     "SignedOutCallbackPath": {
         "type": "parameter",

--- a/ProjectTemplates/templates/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -13,8 +13,16 @@
       "shortName": ""
     },
     "SignUpSignInPolicyId": {
-      "longName": "susi-policy-id",
-      "shortName": "ssp"
+        "longName": "susi-policy-id",
+        "shortName": "ssp"
+    },
+    "SignUpPolicyId": {
+        "longName": "signup-policy-id",
+        "shortName": "sup"
+    },
+    "SignInPolicyId": {
+      "longName": "signin-policy-id",
+      "shortName": "sip"
     },
     "OrgReadAccess": {
       "longName": "org-read-access",

--- a/ProjectTemplates/templates/WebApi-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/.template.config/template.json
@@ -73,11 +73,25 @@
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_susi",
+        "replaces": "MySignUpSignInPolicyId",
+        "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignUpPolicyId": {
+        "type": "parameter",
+        "datatype": "string",
+        "defaultValue": "b2c_1_signup",
+        "replaces": "MySignUpPolicyId",
+        "description": "The sign-up policy ID for this project (use with IndividualB2C auth)."
+    },
+    "SignInPolicyId": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "b2c_1_susi",
-      "replaces": "MySignUpSignInPolicyId",
-      "description": "The sign-in and sign-up policy ID for this project (use with IndividualB2C auth)."
+      "defaultValue": "b2c_1_signin",
+      "replaces": "MySignInPolicyId",
+      "description": "The sign-in policy ID for this project (use with IndividualB2C auth)."
     },
     "AADInstance": {
       "type": "parameter",

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
             properties.Items[Constants.Policy] = _options.Value?.SignUpSignInPolicyId;
             return Challenge(properties, scheme);
         }
-
+        
         /// <summary>
         /// Challenges the user.
         /// </summary>

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         /// Handles user sign up.
         /// </summary>
         /// <param name="scheme">Authentication scheme.</param>
-        /// <returns>Challenge generating a redirect to Azure AD to sign up in the user.</returns>
+        /// <returns>Challenge generating a redirect to Azure AD to sign up the user.</returns>
         [HttpGet("{scheme?}")]
         public IActionResult SignUp([FromRoute] string scheme)
         {
@@ -71,7 +71,7 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         /// Handles user sign in with an option to sign up.
         /// </summary>
         /// <param name="scheme">Authentication scheme.</param>
-        /// <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
+        /// <returns>Challenge generating a redirect to Azure AD to sign in or sign up the user.</returns>
         [HttpGet("{scheme?}")]
         public IActionResult SignUpSignIn([FromRoute] string scheme)
         {
@@ -93,7 +93,7 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         /// <param name="domainHint">Domain hint.</param>
         /// <param name="claims">Claims.</param>
         /// <param name="policy">AAD B2C policy.</param>
-        /// <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
+        /// <returns>Challenge generating a redirect to Azure AD.</returns>
         [HttpGet("{scheme?}")]
         public IActionResult Challenge(
             string redirectUri,

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -44,9 +44,44 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         {
             scheme ??= OpenIdConnectDefaults.AuthenticationScheme;
             var redirectUrl = Url.Content("~/");
-            return Challenge(
-                new AuthenticationProperties { RedirectUri = redirectUrl },
-                scheme);
+            var properties = new AuthenticationProperties { RedirectUri = redirectUrl };
+            // I'm assuming this line wasn't here before because the default policy was already SignInSignUp
+            // I would argue that this method should however handle the 'sign in' only policy
+            // What happens if the user hasn't specified a SignInPolicyId? Is this handled nicely?
+            properties.Items[Constants.Policy] = _options.Value?.SignInPolicyId;
+            return Challenge(properties, scheme);
+        }
+
+        /// <summary>
+        /// Handles user sign up.
+        /// </summary>
+        /// <param name="scheme">Authentication scheme.</param>
+        /// <returns>Challenge generating a redirect to Azure AD to sign up in the user.</returns>
+        [HttpGet("{scheme?}")]
+        public IActionResult SignUp([FromRoute] string scheme)
+        {
+            scheme ??= OpenIdConnectDefaults.AuthenticationScheme;
+            var redirectUrl = Url.Content("~/");
+            var properties = new AuthenticationProperties { RedirectUri = redirectUrl };
+            properties.Items[Constants.Policy] = _options.Value?.SignUpPolicyId;
+            return Challenge(properties, scheme);
+        }
+
+        /// <summary>
+        /// Handles user sign in with an option to sign up.
+        /// </summary>
+        /// <param name="scheme">Authentication scheme.</param>
+        /// <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
+        [HttpGet("{scheme?}")]
+        public IActionResult SignUpSignIn([FromRoute] string scheme)
+        {
+            scheme ??= OpenIdConnectDefaults.AuthenticationScheme;
+            var redirectUrl = Url.Content("~/");
+            var properties = new AuthenticationProperties { RedirectUri = redirectUrl };
+            // Even if this is the default, I still think we should explictly specify the option here
+            // Should there even be a 'default'?
+            properties.Items[Constants.Policy] = _options.Value?.SignUpSignInPolicyId;
+            return Challenge(properties, scheme);
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
+++ b/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
@@ -28,14 +28,14 @@
             Handles user sign up.
             </summary>
             <param name="scheme">Authentication scheme.</param>
-            <returns>Challenge generating a redirect to Azure AD to sign up in the user.</returns>
+            <returns>Challenge generating a redirect to Azure AD to sign up the user.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.SignUpSignIn(System.String)">
             <summary>
             Handles user sign in with an option to sign up.
             </summary>
             <param name="scheme">Authentication scheme.</param>
-            <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
+            <returns>Challenge generating a redirect to Azure AD to sign in or sign up the user.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.Challenge(System.String,System.String,System.String,System.String,System.String,System.String)">
             <summary>
@@ -47,7 +47,7 @@
             <param name="domainHint">Domain hint.</param>
             <param name="claims">Claims.</param>
             <param name="policy">AAD B2C policy.</param>
-            <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
+            <returns>Challenge generating a redirect to Azure AD.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.SignOut(System.String)">
             <summary>

--- a/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
+++ b/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
@@ -23,6 +23,20 @@
             <param name="scheme">Authentication scheme.</param>
             <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
         </member>
+        <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.SignUp(System.String)">
+            <summary>
+            Handles user sign up.
+            </summary>
+            <param name="scheme">Authentication scheme.</param>
+            <returns>Challenge generating a redirect to Azure AD to sign up in the user.</returns>
+        </member>
+        <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.SignUpSignIn(System.String)">
+            <summary>
+            Handles user sign in with an option to sign up.
+            </summary>
+            <param name="scheme">Authentication scheme.</param>
+            <returns>Challenge generating a redirect to Azure AD to sign in the user.</returns>
+        </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers.AccountController.Challenge(System.String,System.String,System.String,System.String,System.String,System.String)">
             <summary>
             Challenges the user.

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Identity.Web
 
             if (options.IsB2C)
             {
+                // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
+                // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
                 var userFlow = options.DefaultUserFlow;
                 return new Uri(baseUri, new PathString($"{pathBase}/{domain}/{userFlow}/v2.0")).ToString();
             }

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Identity.Web
             {
                 // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
                 // B2C userflow would no longer necessarily be just DefaultUserFlow, which is SignUpSignInPolicyId
+                // should there even be a 'default' user flow? what if we arn't using SignUpSignIn?
                 var userFlow = options.DefaultUserFlow;
                 return new Uri(baseUri, new PathString($"{pathBase}/{domain}/{userFlow}/v2.0")).ToString();
             }

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Web
             if (options.IsB2C)
             {
                 // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
-                // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
+                // B2C userflow would no longer necessarily be just DefaultUserFlow, which is SignUpSignInPolicyId
                 var userFlow = options.DefaultUserFlow;
                 return new Uri(baseUri, new PathString($"{pathBase}/{domain}/{userFlow}/v2.0")).ToString();
             }

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
@@ -60,8 +60,6 @@ namespace Microsoft.Identity.Web
             string? userflow;
             if (_microsoftIdentityOptions.IsB2C && string.IsNullOrEmpty(effectiveOptions.UserFlow))
             {
-                // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
-                // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
                 userflow = _microsoftIdentityOptions.DefaultUserFlow;
             }
             else

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Identity.Web
             string? userflow;
             if (_microsoftIdentityOptions.IsB2C && string.IsNullOrEmpty(effectiveOptions.UserFlow))
             {
+                // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
+                // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
                 userflow = _microsoftIdentityOptions.DefaultUserFlow;
             }
             else

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1352,6 +1352,16 @@
             Gets or sets the reset password user flow name for B2C, e.g. B2C_1_password_reset.
             </summary>
         </member>
+        <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.SignUpPolicyId">
+            <summary>
+            Gets or sets the sign up user flow name for B2C, e.g. b2c_1_signup.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.SignInPolicyId">
+            <summary>
+            Gets or sets the sign in user flow name for B2C, e.g. b2c_1_signin.
+            </summary>
+        </member>
         <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.DefaultUserFlow">
             <summary>
             Gets the default user flow (which is signUpsignIn).

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -43,6 +43,16 @@ namespace Microsoft.Identity.Web
         public string? ResetPasswordPolicyId { get; set; }
 
         /// <summary>
+        /// Gets or sets the sign up user flow name for B2C, e.g. b2c_1_signup.
+        /// </summary>
+        public string? SignUpPolicyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sign in user flow name for B2C, e.g. b2c_1_signin.
+        /// </summary>
+        public string? SignInPolicyId { get; set; }
+
+        /// <summary>
         /// Gets the default user flow (which is signUpsignIn).
         /// </summary>
         public string? DefaultUserFlow => SignUpSignInPolicyId;

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -62,6 +62,10 @@ namespace Microsoft.Identity.Web
         /// </summary>
         internal bool IsB2C
         {
+            // is this still the right thing to do if we are now allowing for a separate sign up and sign in user flow?
+            // maybe it should now instead be:
+            // "Is considered B2C if the attribute SignUpSignInPolicyId or both SignUpPolicyID and SignInPolicyID are defined"
+            // what is the minimum requirement to be 'B2C'?
             get => !string.IsNullOrWhiteSpace(DefaultUserFlow);
         }
 

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Identity.Web
                 {
                     string? userFlow = context.Principal?.GetUserFlowId();
                     // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
-                    // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
+                    // B2C userflow would no longer necessarily be just DefaultUserFlow, which is SignUpSignInPolicyId
                     var authority = $"{_applicationOptions.Instance}{ClaimConstants.Tfp}/{_microsoftIdentityOptions.Domain}/{userFlow ?? _microsoftIdentityOptions.DefaultUserFlow}";
                     builder.WithB2CAuthority(authority);
                 }
@@ -495,7 +495,7 @@ namespace Microsoft.Identity.Web
                 if (_microsoftIdentityOptions.IsB2C)
                 {
                     // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
-                    // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
+                    // B2C userflow would no longer necessarily be just DefaultUserFlow, which is SignUpSignInPolicyId
                     authority = $"{_applicationOptions.Instance}{ClaimConstants.Tfp}/{_microsoftIdentityOptions.Domain}/{_microsoftIdentityOptions.DefaultUserFlow}";
                     builder.WithB2CAuthority(authority);
                 }
@@ -671,7 +671,7 @@ namespace Microsoft.Identity.Web
             if (_microsoftIdentityOptions.IsB2C)
             {
                 // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
-                // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
+                // B2C userflow would no longer necessarily be just DefaultUserFlow, which is SignUpSignInPolicyId
                 string b2cAuthority = application.Authority.Replace(
                     new Uri(application.Authority).PathAndQuery,
                     $"/{ClaimConstants.Tfp}/{_microsoftIdentityOptions.Domain}/{userFlow ?? _microsoftIdentityOptions.DefaultUserFlow}");

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -152,6 +152,8 @@ namespace Microsoft.Identity.Web
                 if (_microsoftIdentityOptions.IsB2C)
                 {
                     string? userFlow = context.Principal?.GetUserFlowId();
+                    // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
+                    // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
                     var authority = $"{_applicationOptions.Instance}{ClaimConstants.Tfp}/{_microsoftIdentityOptions.Domain}/{userFlow ?? _microsoftIdentityOptions.DefaultUserFlow}";
                     builder.WithB2CAuthority(authority);
                 }
@@ -492,6 +494,8 @@ namespace Microsoft.Identity.Web
 
                 if (_microsoftIdentityOptions.IsB2C)
                 {
+                    // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
+                    // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
                     authority = $"{_applicationOptions.Instance}{ClaimConstants.Tfp}/{_microsoftIdentityOptions.Domain}/{_microsoftIdentityOptions.DefaultUserFlow}";
                     builder.WithB2CAuthority(authority);
                 }
@@ -666,6 +670,8 @@ namespace Microsoft.Identity.Web
             // Acquire an access token as a B2C authority
             if (_microsoftIdentityOptions.IsB2C)
             {
+                // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
+                // B2C userflow would no longer necessarily be just DefualtUserFlow, which is SignUpSignInPolicyId
                 string b2cAuthority = application.Authority.Replace(
                     new Uri(application.Authority).PathAndQuery,
                     $"/{ClaimConstants.Tfp}/{_microsoftIdentityOptions.Domain}/{userFlow ?? _microsoftIdentityOptions.DefaultUserFlow}");

--- a/tests/B2CWebAppCallsWebApi/Client/appsettings.json
+++ b/tests/B2CWebAppCallsWebApi/Client/appsettings.json
@@ -5,6 +5,9 @@
         "Domain": "fabrikamb2c.onmicrosoft.com",
         "SignedOutCallbackPath": "/signout/B2C_1_susi",
         "SignUpSignInPolicyId": "b2c_1_susi_v3",
+        // proposed separate sign up and sign in policies
+        "SignUpPolicyId": "b2c_1_signup",
+        "SignInPolicyId": "b2c_1_signin",
         "ResetPasswordPolicyId": "b2c_1_reset_v3",
         "EditProfilePolicyId": "b2c_1_edit_profile", // Optional profile editing policy
         "ClientSecret": "secret-goes-here",

--- a/tests/B2CWebAppCallsWebApi/TodoListService/appsettings.json
+++ b/tests/B2CWebAppCallsWebApi/TodoListService/appsettings.json
@@ -1,14 +1,17 @@
 {
-  "AzureAdB2C": {
-    "Instance": "https://fabrikamb2c.b2clogin.com",
-    "ClientId": "90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6",
-    "Domain": "fabrikamb2c.onmicrosoft.com",
-    "SignedOutCallbackPath": "/signout/B2C_1_susi",
-    "SignUpSignInPolicyId": "b2c_1_susi",
-    "ResetPasswordPolicyId": "b2c_1_reset",
-    "EditProfilePolicyId": "b2c_1_edit_profile" // Optional profile editing policy
-    //"CallbackPath": "/signin/B2C_1_sign_up_in"  // defaults to /signin-oidc
-  },
+    "AzureAdB2C": {
+        "Instance": "https://fabrikamb2c.b2clogin.com",
+        "ClientId": "90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6",
+        "Domain": "fabrikamb2c.onmicrosoft.com",
+        "SignedOutCallbackPath": "/signout/B2C_1_susi",
+        "SignUpSignInPolicyId": "b2c_1_susi",
+        // proposed separate sign up and sign in policies
+        "SignUpPolicyId": "b2c_1_signup",
+        "SignInPolicyId": "b2c_1_signin",
+        "ResetPasswordPolicyId": "b2c_1_reset",
+        "EditProfilePolicyId": "b2c_1_edit_profile" // Optional profile editing policy
+        //"CallbackPath": "/signin/B2C_1_sign_up_in"  // defaults to /signin-oidc
+    },
   "Kestrel": {
     "Endpoints": {
       "Http": {

--- a/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Identity.Web.Test
             {
                 Domain = TestConstants.B2CTenant,
                 Instance = TestConstants.B2CInstance,
+                // 'DefaultUserFlow' is used below
+                // should this test be somehow dynamically linked to what 'DefaultUserFlow' actully is?
+                // currently it is SignUpSignIn, but what if this is changed?
                 SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow,
             };
             string expectedResult = $"{options.Instance}/{options.Domain}/{options.DefaultUserFlow}/v2.0";

--- a/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Identity.Web.Test
         [InlineData(false)]
         public async void OnRedirectToIdentityProvider_CustomUserFlow_UpdatesContext(bool hasClientCredentials)
         {
+            // what if DefaultUserFlow is changed to not be SignUpSignInPolicyId?
             var options = new MicrosoftIdentityOptions() { SignUpSignInPolicyId = DefaultUserFlow };
             if (hasClientCredentials)
             {
@@ -68,6 +69,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public async void OnRedirectToIdentityProvider_DefaultUserFlow_DoesntUpdateContext()
         {
+            // what if DefaultUserFlow is changed to not be SignUpSignInPolicyId?
             var options = new MicrosoftIdentityOptions() { SignUpSignInPolicyId = DefaultUserFlow };
             var handler = new AzureADB2COpenIDConnectEventHandlers(OpenIdConnectDefaults.AuthenticationScheme, options);
             var httpContext = HttpContextUtilities.CreateHttpContext();

--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Identity.Web.Test
         {
             var options = new MicrosoftIdentityOptions()
             {
+                // this may need to change if 'isb2c' is changed to also allow for separate signup and signin user flows
                 SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow,
             };
 
@@ -32,6 +33,7 @@ namespace Microsoft.Identity.Web.Test
 
             Assert.False(options.IsB2C);
 
+            // this may need to change if 'isb2c' is changed to also allow for separate signup and signin user flows
             options.SignUpSignInPolicyId = string.Empty;
 
             Assert.False(options.IsB2C);
@@ -66,6 +68,7 @@ namespace Microsoft.Identity.Web.Test
 
             if (optionsName == AzureAdB2C)
             {
+                // this may need to change if separate signup and signin user flows are allowed
                 microsoftIdentityOptions.SignUpSignInPolicyId = signUpSignInPolicyId;
                 microsoftIdentityOptions.Domain = domain;
             }

--- a/tests/Microsoft.Identity.Web.Test/Resource/RegisterValidAudienceTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RegisterValidAudienceTests.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Identity.Web.Test.Resource
 
             if (isB2C)
             {
+                // this may need to change if 'IsB2C' is changed to also allow for separate signup and signin user flows
                 _options.SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow;
             }
 

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Identity.Web.Test
         {
             _microsoftIdentityOptions = new MicrosoftIdentityOptions
             {
+                // this may need to change if separate signup and signin user flows are allowed
                 SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow,
                 Domain = TestConstants.B2CTenant,
             };

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -222,6 +222,7 @@ namespace Microsoft.Identity.Web.Test
                 options.Instance = TestConstants.B2CInstance;
                 options.TenantId = TestConstants.TenantIdAsGuid;
                 options.ClientId = TestConstants.ClientId;
+                // this may need to change if 'isb2c' is changed to also allow for separate signup and signin user flows
                 options.SignUpSignInPolicyId = TestConstants.B2CSignUpSignInUserFlow;
                 options.Domain = TestConstants.B2CTenant;
             };
@@ -723,6 +724,7 @@ namespace Microsoft.Identity.Web.Test
 
             if (includeB2cConfig)
             {
+                // this may need to change if separate signup and signin user flows are allowed
                 configAsDictionary.Add($"{configSectionName}:SignUpSignInPolicyId", TestConstants.B2CSignUpSignInUserFlow);
                 configAsDictionary[$"{configSectionName}:Instance"] = TestConstants.B2CInstance;
                 configAsDictionary[$"{configSectionName}:Domain"] = TestConstants.B2CTenant;

--- a/tests/blazorserver2-b2c-callswebapi/appsettings.json
+++ b/tests/blazorserver2-b2c-callswebapi/appsettings.json
@@ -6,6 +6,8 @@
         "CallbackPath": "/signin-oidc",
         "SignedOutCallbackPath ": "/signout-callback-oidc",
         "SignUpSignInPolicyId": "b2c_1_susi_v3",
+        "SignUpPolicyId": "b2c_1_signup",
+        "SignInPolicyId": "b2c_1_signin",
         "ResetPasswordPolicyId": "b2c_1_reset_v3",
         "EditProfilePolicyId": "b2c_1_edit_profile", // Optional profile editing policy
         "EnablePiiLogging": true,

--- a/tests/blazorwasm2-b2c-hosted/Server/appsettings.json
+++ b/tests/blazorwasm2-b2c-hosted/Server/appsettings.json
@@ -3,7 +3,9 @@
         "Instance": "https://fabrikamb2c.b2clogin.com/",
         "ClientId": "93733604-cc77-4a3c-a604-87084dd55348",
         "Domain": "fabrikamb2c.onmicrosoft.com",
-        "SignUpSignInPolicyId": "b2c_1_susi"
+        "SignUpSignInPolicyId": "b2c_1_susi",
+        "SignUpPolicyId": "b2c_1_signup",
+        "SignInPolicyId": "b2c_1_signin"
     },
   "Logging": {
     "LogLevel": {

--- a/tests/webapp-b2c/appsettings.json
+++ b/tests/webapp-b2c/appsettings.json
@@ -5,6 +5,8 @@
         "Domain": "fabrikamb2c.onmicrosoft.com",
         "SignedOutCallbackPath": "/signout/B2C_1_susi",
         "SignUpSignInPolicyId": "b2c_1_susi_v3",
+        "SignUpPolicyId": "b2c_1_signup",
+        "SignInPolicyId": "b2c_1_signin",
         "ResetPasswordPolicyId": "b2c_1_reset_v3",
         "EditProfilePolicyId": "b2c_1_edit_profile", // Optional profile editing policy
         "CallbackPath": "/signin-oidc"


### PR DESCRIPTION
I am currently building a Blazor Server Web App using Azure B2C for identify management.

For my web app, it would be nice if I could have a separate 'Sign Up' and 'Sign In' user flow, as opposed having to use a single Sign Up/Sign in user flow, taking me to 'Sign In' page, in which new users then have to click through to the small 'Sign up now' link in the bottom. It would be much better if I could have separate buttons on my home page for both.

In order to add this feature, this will require:
* The addition of separate 'Sign Up' and 'Sign In' user flow options
* Moving the old 'MicrosoftIdentity/Account/SignIn' endpoint, (which is actually currently using the combined SignUpSignIn user flow), being moved to something like MicrosoftIdentity/Account/SignUpSignIn
* Creating new 'MicrosoftIdentity/Account/SignUp' and 'MicrosoftIdentity/Account/SignIn' endpoints, just for signing up and signing in.

I have tried to tackle all these in this pull request (which I am currently working on at the point of creating this draft), but please have a look and see if there is anything else I need to add.
