### PR TITLE
Display error messages when run under Development

### DIFF
--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml
@@ -17,7 +17,7 @@
 @if (Model.Error.IsEnabled)
 {
     <h3>Details</h3>
-    <p>@Model.Error.Message</p>
+    <p>@Model.Error.GetMessage(HttpContext)</p>
 }
 else
 {

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml
@@ -14,10 +14,18 @@
     </p>
 }
 
-<h3>Development Mode</h3>
-<p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
-</p>
-<p>
-    <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
-</p>
+@if (Model.Error.IsEnabled)
+{
+    <h3>Details</h3>
+    <p>@Model.Error.Message</p>
+}
+else
+{
+    <h3>Development Mode</h3>
+    <p>
+        Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
+    </p>
+    <p>
+        <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
+    </p>
+}

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml.cs
@@ -32,19 +32,19 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
 
         /// <summary>
         /// This API supports infrastructure and is not intended to be used
-        /// directly from your code.This API may change or be removed in future releases.
+        /// directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
         /// <summary>
         /// This API supports infrastructure and is not intended to be used
-        /// directly from your code.This API may change or be removed in future releases.
+        /// directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public ILoginErrorAccessor Error { get; }
 
         /// <summary>
         /// This API supports infrastructure and is not intended to be used
-        /// directly from your code.This API may change or be removed in future releases.
+        /// directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public void OnGet()
         {

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Pages/Account/Error.cshtml.cs
@@ -16,6 +16,15 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
     public class ErrorModel : PageModel
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ErrorModel"/> class.
+        /// </summary>
+        /// <param name="errorAccessor">Error accessor.</param>
+        public ErrorModel(ILoginErrorAccessor errorAccessor)
+        {
+            Error = errorAccessor;
+        }
+
+        /// <summary>
         /// This API supports infrastructure and is not intended to be used
         /// directly from your code. This API may change or be removed in future releases.
         /// </summary>
@@ -26,6 +35,12 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account
         /// directly from your code.This API may change or be removed in future releases.
         /// </summary>
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+        /// <summary>
+        /// This API supports infrastructure and is not intended to be used
+        /// directly from your code.This API may change or be removed in future releases.
+        /// </summary>
+        public ILoginErrorAccessor Error { get; }
 
         /// <summary>
         /// This API supports infrastructure and is not intended to be used

--- a/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
+++ b/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
@@ -71,6 +71,12 @@
             Model for the Error page.
             </summary>
         </member>
+        <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.#ctor(Microsoft.Identity.Web.ILoginErrorAccessor)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel"/> class.
+            </summary>
+            <param name="errorAccessor">Error accessor.</param>
+        </member>
         <member name="P:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.RequestId">
             <summary>
             This API supports infrastructure and is not intended to be used
@@ -78,6 +84,12 @@
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.ShowRequestId">
+            <summary>
+            This API supports infrastructure and is not intended to be used
+            directly from your code.This API may change or be removed in future releases.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.Error">
             <summary>
             This API supports infrastructure and is not intended to be used
             directly from your code.This API may change or be removed in future releases.

--- a/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
+++ b/src/Microsoft.Identity.Web.UI/Microsoft.Identity.Web.UI.xml
@@ -86,19 +86,19 @@
         <member name="P:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.ShowRequestId">
             <summary>
             This API supports infrastructure and is not intended to be used
-            directly from your code.This API may change or be removed in future releases.
+            directly from your code. This API may change or be removed in future releases.
             </summary>
         </member>
         <member name="P:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.Error">
             <summary>
             This API supports infrastructure and is not intended to be used
-            directly from your code.This API may change or be removed in future releases.
+            directly from your code. This API may change or be removed in future releases.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.ErrorModel.OnGet">
             <summary>
             This API supports infrastructure and is not intended to be used
-            directly from your code.This API may change or be removed in future releases.
+            directly from your code. This API may change or be removed in future releases.
             </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Pages.Account.SignedOutModel">

--- a/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
+++ b/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
@@ -12,13 +12,20 @@ namespace Microsoft.Identity.Web
 {
     internal class AzureADB2COpenIDConnectEventHandlers
     {
+        private readonly ILoginErrorAccessor _errorAccessor;
+
         private readonly IDictionary<string, string> _userFlowToIssuerAddress =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        public AzureADB2COpenIDConnectEventHandlers(string schemeName, MicrosoftIdentityOptions options)
+        public AzureADB2COpenIDConnectEventHandlers(
+            string schemeName,
+            MicrosoftIdentityOptions options,
+            ILoginErrorAccessor errorAccessor)
         {
             SchemeName = schemeName;
             Options = options;
+
+            _errorAccessor = errorAccessor;
         }
 
         public string SchemeName { get; }
@@ -84,6 +91,8 @@ namespace Microsoft.Identity.Web
             }
             else
             {
+                _errorAccessor.Message = context.Failure?.Message;
+
                 context.Response.Redirect($"{context.Request.PathBase}/MicrosoftIdentity/Account/Error");
             }
 

--- a/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
+++ b/src/Microsoft.Identity.Web/AzureADB2COpenIDConnectEventHandlers.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Web
             }
             else
             {
-                _errorAccessor.Message = context.Failure?.Message;
+                _errorAccessor.SetMessage(context.HttpContext, context.Failure?.Message);
 
                 context.Response.Redirect($"{context.Request.PathBase}/MicrosoftIdentity/Account/Error");
             }

--- a/src/Microsoft.Identity.Web/ILoginErrorAccessor.cs
+++ b/src/Microsoft.Identity.Web/ILoginErrorAccessor.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.AspNetCore.Http;
+
 namespace Microsoft.Identity.Web
 {
     /// <summary>
@@ -9,9 +11,18 @@ namespace Microsoft.Identity.Web
     public interface ILoginErrorAccessor
     {
         /// <summary>
-        /// Gets or sets the error message for the current login.
+        /// Gets the error message for the current request.
         /// </summary>
-        string? Message { get; set; }
+        /// <param name="context">Current <see cref="HttpContext"/>.</param>
+        /// <returns>The current error message if available.</returns>
+        string? GetMessage(HttpContext context);
+
+        /// <summary>
+        /// Sets the error message for the current request.
+        /// </summary>
+        /// <param name="context">Current <see cref="HttpContext"/>.</param>
+        /// <param name="message">Error message to set.</param>
+        void SetMessage(HttpContext context, string? message);
 
         /// <summary>
         /// Gets whether error messages should be displayed.

--- a/src/Microsoft.Identity.Web/ILoginErrorAccessor.cs
+++ b/src/Microsoft.Identity.Web/ILoginErrorAccessor.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Provides access to get or set the current error status. The default implementation will use TempData and be enabled when run under Development.
+    /// </summary>
+    public interface ILoginErrorAccessor
+    {
+        /// <summary>
+        /// Gets or sets the error message for the current login.
+        /// </summary>
+        string? Message { get; set; }
+
+        /// <summary>
+        /// Gets whether error messages should be displayed.
+        /// </summary>
+        bool IsEnabled { get; }
+    }
+}

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1036,6 +1036,21 @@
             <param name="httpContext">HTTP context associated with the current request.</param>
             <returns><see cref="T:System.IdentityModel.Tokens.Jwt.JwtSecurityToken"/> used to call the web API.</returns>
         </member>
+        <member name="T:Microsoft.Identity.Web.ILoginErrorAccessor">
+            <summary>
+            Provides access to get or set the current error status. The default implementation will use TempData and be enabled when run under Development.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.ILoginErrorAccessor.Message">
+            <summary>
+            Gets or sets the error message for the current login.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.ILoginErrorAccessor.IsEnabled">
+            <summary>
+            Gets whether error messages should be displayed.
+            </summary>
+        </member>
         <member name="T:Microsoft.Identity.Web.IncrementalConsentAndConditionalAccessHelper">
             <summary>
             Helper methods to handle incremental consent and conditional access in
@@ -1753,6 +1768,11 @@
              .AddSessionBasedTokenCache();
              </code>
              </example>
+        </member>
+        <member name="T:Microsoft.Identity.Web.TempDataLoginErrorAccessor">
+            <summary>
+            An implementation of <see cref="T:Microsoft.Identity.Web.ILoginErrorAccessor"/> that uses <see cref="T:Microsoft.AspNetCore.Mvc.ViewFeatures.ITempDataDictionary"/> to track error messages.
+            </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenAcquisition">
             <summary>

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1041,10 +1041,19 @@
             Provides access to get or set the current error status. The default implementation will use TempData and be enabled when run under Development.
             </summary>
         </member>
-        <member name="P:Microsoft.Identity.Web.ILoginErrorAccessor.Message">
+        <member name="M:Microsoft.Identity.Web.ILoginErrorAccessor.GetMessage(Microsoft.AspNetCore.Http.HttpContext)">
             <summary>
-            Gets or sets the error message for the current login.
+            Gets the error message for the current request.
             </summary>
+            <param name="context">Current <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/>.</param>
+            <returns>The current error message if available.</returns>
+        </member>
+        <member name="M:Microsoft.Identity.Web.ILoginErrorAccessor.SetMessage(Microsoft.AspNetCore.Http.HttpContext,System.String)">
+            <summary>
+            Sets the error message for the current request.
+            </summary>
+            <param name="context">Current <see cref="T:Microsoft.AspNetCore.Http.HttpContext"/>.</param>
+            <param name="message">Error message to set.</param>
         </member>
         <member name="P:Microsoft.Identity.Web.ILoginErrorAccessor.IsEnabled">
             <summary>

--- a/src/Microsoft.Identity.Web/TempDataLoginErrorAccessor.cs
+++ b/src/Microsoft.Identity.Web/TempDataLoginErrorAccessor.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// An implementation of <see cref="ILoginErrorAccessor"/> that uses <see cref="ITempDataDictionary"/> to track error messages.
+    /// </summary>
+    internal class TempDataLoginErrorAccessor : ILoginErrorAccessor
+    {
+        private const string Name = "MicrosoftIdentityError";
+
+        private readonly ITempDataDictionaryFactory _factory;
+        private readonly IHostEnvironment _env;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public TempDataLoginErrorAccessor(ITempDataDictionaryFactory factory, IHostEnvironment env, IHttpContextAccessor httpContextAccessor)
+        {
+            _factory = factory;
+            _env = env;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public bool IsEnabled => _env.IsDevelopment();
+
+        public string? Message
+        {
+            get
+            {
+                if (IsEnabled)
+                {
+                    var d = GetDictionary();
+
+                    if (d.TryGetValue(Name, out var result) && result is string msg)
+                    {
+                        return msg;
+                    }
+                }
+
+                return null;
+            }
+            set
+            {
+                if (IsEnabled)
+                {
+                    var d = GetDictionary();
+                    d.Add(Name, value);
+                    d.Save();
+                }
+            }
+        }
+
+        private ITempDataDictionary GetDictionary() => _factory.GetTempData(_httpContextAccessor.HttpContext);
+    }
+}

--- a/src/Microsoft.Identity.Web/TempDataLoginErrorAccessor.cs
+++ b/src/Microsoft.Identity.Web/TempDataLoginErrorAccessor.cs
@@ -15,15 +15,15 @@ namespace Microsoft.Identity.Web
 
         private readonly ITempDataDictionaryFactory _factory;
 
-        public static ILoginErrorAccessor Create(ITempDataDictionaryFactory factory, bool isDevelopment)
+        public static ILoginErrorAccessor Create(ITempDataDictionaryFactory? factory, bool isDevelopment)
         {
-            if (isDevelopment && !(factory is null))
+            if (!isDevelopment || factory is null)
             {
-                return new TempDataLoginErrorAccessor(factory);
+                return new EmptyLoginErrorAccessor();
             }
             else
             {
-                return new EmptyLoginErrorAccessor();
+                return new TempDataLoginErrorAccessor(factory);
             }
         }
 

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -6,9 +6,11 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.Resource;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -242,7 +244,14 @@ namespace Microsoft.Identity.Web
             }
 
             builder.Services.TryAddSingleton<MicrosoftIdentityIssuerValidatorFactory>();
-            builder.Services.TryAddSingleton<ILoginErrorAccessor, TempDataLoginErrorAccessor>();
+            builder.Services.TryAddSingleton<ILoginErrorAccessor>(ctx =>
+            {
+                // ITempDataDictionaryFactory is not always available, so we don't require it
+                var tempFactory = ctx.GetService<ITempDataDictionaryFactory>();
+                var env = ctx.GetRequiredService<IHostEnvironment>();
+
+                return TempDataLoginErrorAccessor.Create(tempFactory, env.IsDevelopment());
+            });
 
             if (subscribeToOpenIdConnectMiddlewareDiagnosticsEvents)
             {

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -242,6 +242,7 @@ namespace Microsoft.Identity.Web
             }
 
             builder.Services.TryAddSingleton<MicrosoftIdentityIssuerValidatorFactory>();
+            builder.Services.TryAddSingleton<ILoginErrorAccessor, TempDataLoginErrorAccessor>();
 
             if (subscribeToOpenIdConnectMiddlewareDiagnosticsEvents)
             {
@@ -260,7 +261,8 @@ namespace Microsoft.Identity.Web
                 .Configure<IServiceProvider, IOptions<MicrosoftIdentityOptions>>((options, serviceProvider, microsoftIdentityOptions) =>
                 {
                     PopulateOpenIdOptionsFromMicrosoftIdentityOptions(options, microsoftIdentityOptions.Value);
-                    var b2cOidcHandlers = new AzureADB2COpenIDConnectEventHandlers(openIdConnectScheme, microsoftIdentityOptions.Value);
+
+                    var b2cOidcHandlers = new AzureADB2COpenIDConnectEventHandlers(openIdConnectScheme, microsoftIdentityOptions.Value, serviceProvider.GetRequiredService<ILoginErrorAccessor>());
 
                     if (!string.IsNullOrEmpty(cookieScheme))
                     {

--- a/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web.Test
 
             await handler.OnRedirectToIdentityProvider(context).ConfigureAwait(false);
 
-            Assert.Empty(errorAccessor.Message);
+            errorAccessor.DidNotReceive().SetMessage(httpContext, Arg.Any<string>());
             Assert.Equal(TestConstants.Scopes, context.ProtocolMessage.Scope);
             Assert.Equal(_customIssuer, context.ProtocolMessage.IssuerAddress, true);
             Assert.False(context.Properties.Items.ContainsKey(OidcConstants.PolicyKey));
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Web.Test
 
             await handler.OnRedirectToIdentityProvider(context).ConfigureAwait(false);
 
-            Assert.Empty(errorAccessor.Message);
+            errorAccessor.DidNotReceive().SetMessage(httpContext, Arg.Any<string>());
             Assert.Null(context.ProtocolMessage.Scope);
             Assert.Null(context.ProtocolMessage.ResponseType);
             Assert.Equal(_defaultIssuer, context.ProtocolMessage.IssuerAddress);
@@ -99,7 +99,7 @@ namespace Microsoft.Identity.Web.Test
 
             await handler.OnRemoteFailure(new RemoteFailureContext(httpContext, _authScheme, new OpenIdConnectOptions(), new OpenIdConnectProtocolException(passwordResetException))).ConfigureAwait(false);
 
-            Assert.Empty(errorAccessor.Message);
+            errorAccessor.DidNotReceive().SetMessage(httpContext, Arg.Any<string>());
             httpContext.Response.Received().Redirect($"{httpContext.Request.PathBase}/MicrosoftIdentity/Account/ResetPassword/{OpenIdConnectDefaults.AuthenticationScheme}");
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Identity.Web.Test
                     new OpenIdConnectOptions(),
                     new OpenIdConnectProtocolException(cancelException))).ConfigureAwait(false);
 
-            Assert.Empty(errorAccessor.Message);
+            errorAccessor.DidNotReceive().SetMessage(httpContext, Arg.Any<string>());
 
             httpContext.Response.Received().Redirect($"{httpContext.Request.PathBase}/");
         }
@@ -142,7 +142,7 @@ namespace Microsoft.Identity.Web.Test
                     new OpenIdConnectOptions(),
                     new OpenIdConnectProtocolException(otherException))).ConfigureAwait(false);
 
-            Assert.Equal(otherException, errorAccessor.Message);
+            errorAccessor.Received(1).SetMessage(httpContext, otherException);
             httpContext.Response.Received().Redirect($"{httpContext.Request.PathBase}/MicrosoftIdentity/Account/Error");
         }
     }


### PR DESCRIPTION
Currently, if an error occurs, the message shown says to run under Development to show more details. However, this occurs even when run under Development. This change uses TempData to display the error if available, which defaults to when run under development.