### PR TITLE
Enabling the unit tests to create project folders and run dotnet new

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: linux-latest
     continue-on-error: true
     strategy:
       matrix:

--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
@@ -31,7 +31,7 @@ namespace DotnetTool.CodeReaderWriter
         /// <param name="projectDescription"></param>
         /// <param name="projectDescriptions"></param>
         /// <returns></returns>
-        internal ProjectAuthenticationSettings ReadFromFiles(
+        public ProjectAuthenticationSettings ReadFromFiles(
             string folderToConfigure,
             ProjectDescription projectDescription,
             IEnumerable<ProjectDescription> projectDescriptions)

--- a/tools/app-provisioning-tool/tests/ProjectDescriptionReaderTests.cs
+++ b/tools/app-provisioning-tool/tests/ProjectDescriptionReaderTests.cs
@@ -7,6 +7,7 @@ using DotnetTool.MicrosoftIdentityPlatformApplication;
 using DotnetTool.Project;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -180,10 +181,12 @@ namespace Tests
         /// <returns>Name of the folder </returns>
         private string CreateProjectIfNeeded(string projectFolderName, string command, string testName)
         {
-            string tempFolder = Environment.GetEnvironmentVariable("Agent.TempDirectory") ?? "C:\\temp";
 
-            // Create the folder
-            string parentFolder = Path.Combine(tempFolder, "Provisionning", testName);
+            string tempFolder = Environment.GetEnvironmentVariable("Agent.TempDirectory")
+                ?? ((RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? "C:\\temp" : "");
+
+                // Create the folder
+                string parentFolder = Path.Combine(tempFolder, "Provisionning", testName);
             string createdProjectFolder = Path.Combine(parentFolder, projectFolderName);
 
             if (!Directory.Exists(createdProjectFolder))

--- a/tools/app-provisioning-tool/tests/TestUtilities.cs
+++ b/tools/app-provisioning-tool/tests/TestUtilities.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests
+{
+    internal static class TestUtilities
+    {
+        /// <summary>
+        /// Create the test project
+        /// </summary>
+        /// <param name="testOutput">Output stream to write more information about the test</param>
+        /// <param name="command">Command to run</param>
+        /// <param name="folder">Folder in which to run the command</param>
+        /// <param name="postFix">Additionnal command appended to the command</param>
+        public static void RunProcess(ITestOutputHelper testOutput, string command, string folder, string postFix = "")
+        {
+            Directory.CreateDirectory(folder);
+            ProcessStartInfo processStartInfo = new ProcessStartInfo("dotnet", command.Replace("dotnet ", string.Empty) + postFix);
+            processStartInfo.UseShellExecute = false;
+            processStartInfo.RedirectStandardOutput = true;
+            processStartInfo.RedirectStandardError = true;
+            Environment.GetEnvironmentVariables();
+            processStartInfo.WorkingDirectory = folder;
+            Process process = Process.Start(processStartInfo);
+            process.WaitForExit();
+            string output = process.StandardOutput.ReadToEnd();
+            testOutput.WriteLine(output);
+            string errors = process.StandardError.ReadToEnd();
+            testOutput.WriteLine(errors);
+            Assert.Equal(string.Empty, errors);
+        }
+    }
+}

--- a/tools/app-provisioning-tool/tests/Tests.csproj
+++ b/tools/app-provisioning-tool/tests/Tests.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\app-provisioning-lib\app-provisioning-lib.csproj" />
     <ProjectReference Include="..\App-Provisioning-Tool\ms-identity-app.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Enabling the unit tests to create project folders and run a dotnet new command so that they can be run in Azure DevOps

Not all tests pass, because there are issues (either in product code or in the tests)