### PR TITLE
Jmprieur/fixing linux issues

### DIFF
--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
@@ -57,8 +57,7 @@ namespace DotnetTool.CodeReaderWriter
             var properties = projectDescription.GetMergedConfigurationProperties(projectDescriptions).ToArray();
             foreach (ConfigurationProperties configurationProperties in properties)
             {
-                string fileRelativePath = configurationProperties.FileRelativePath!.Replace("\\", Path.DirectorySeparatorChar.ToString());
-                string? filePath = Directory.EnumerateFiles(projectPath, fileRelativePath!).FirstOrDefault();
+                string? filePath = Directory.EnumerateFiles(projectPath, configurationProperties.FileRelativePath!).FirstOrDefault();
                 ProcessFile(projectAuthenticationSettings, filePath, configurationProperties);
             }
 

--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
@@ -57,7 +57,8 @@ namespace DotnetTool.CodeReaderWriter
             var properties = projectDescription.GetMergedConfigurationProperties(projectDescriptions).ToArray();
             foreach (ConfigurationProperties configurationProperties in properties)
             {
-                string? filePath = Directory.EnumerateFiles(projectPath, configurationProperties.FileRelativePath!).FirstOrDefault();
+                string fileRelativePath = configurationProperties.FileRelativePath!.Replace("\\", Path.DirectorySeparatorChar.ToString());
+                string? filePath = Directory.EnumerateFiles(projectPath, fileRelativePath!).FirstOrDefault();
                 ProcessFile(projectAuthenticationSettings, filePath, configurationProperties);
             }
 

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/ConfigurationProperties.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/ConfigurationProperties.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.IO;
 using System.Linq;
 
 namespace DotnetTool.Project
@@ -9,7 +10,12 @@ namespace DotnetTool.Project
     {
         private static PropertyMapping[] s_emptyPropertyMappings = new PropertyMapping[0];
 
-        public string? FileRelativePath { get; set; }
+        public string? FileRelativePath 
+        {
+            get { return fileRelativePath?.Replace("\\", Path.DirectorySeparatorChar.ToString()); }
+            set { fileRelativePath = value; } 
+        }
+        private string? fileRelativePath;
 
         public PropertyMapping[] Properties { get; set; } = S_emptyPropertyMappings;
         public static PropertyMapping[] S_emptyPropertyMappings { get => s_emptyPropertyMappings; set => s_emptyPropertyMappings = value; }

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/MatchesForProjectType.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/MatchesForProjectType.cs
@@ -1,13 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.IO;
 using System.Linq;
 
 namespace DotnetTool.Project
 {
     public class MatchesForProjectType
     {
-        public string? FileRelativePath { get; set; }
+        public string? FileRelativePath
+        {
+            get { return fileRelativePath?.Replace("\\", Path.DirectorySeparatorChar.ToString()); }
+            set { fileRelativePath = value; }
+        }
+        private string? fileRelativePath;
 
         public string[]? MatchAny { get; set; }
         public string? Sets { get; set; }

--- a/tools/app-provisioning-tool/tests/Tests.csproj
+++ b/tools/app-provisioning-tool/tests/Tests.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\app-provisioning-lib\app-provisioning-lib.csproj" />
-    <ProjectReference Include="..\App-Provisioning-Tool\ms-identity-app.csproj" />
+    <ProjectReference Include="..\app-provisioning-tool\ms-identity-app.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Jmprieur/fixing Linux issues:
- \\ is a Windows separator
- the name of the project should be case sensitively the same.