### PR TITLE
Update the tool's release build

### DIFF
--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -40,13 +40,13 @@ steps:
 # Pack and sign the provisioning tool
 - template: template-sign-binary.yaml
   parameters:
-    FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisioning-tool'
-    Pattern: 'bin\**\**\ms-identity-app.dll'
+    FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
+    Pattern: ''**\bin\**\**\ms-identity-app.dll'
 
 - template: template-sign-binary.yaml
   parameters:
-    FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisioning-tool'
-    Pattern: 'bin\**\**\app-provisioning-lib.dll
+    FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
+    Pattern: '**\bin\**\**\app-provisioning-lib.dll
     '
 - template: template-nuget-pack.yaml
   parameters:

--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -52,7 +52,7 @@ steps:
 - template: template-sign-binary.yaml
   parameters:
     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
-    Pattern: '**\bin\**\**\*app*.dll'
+    Pattern: '**\**\**\**\*app*.dll'
     
 # - template: template-sign-binary.yaml
 #   parameters:

--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -32,7 +32,18 @@ steps:
   inputs:
     command: build
     projects: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisionning.sln'
-    arguments: '--configuration $(BuildConfiguration) -p:RunCodeAnalysis=true -p:MsIdentityWebSemVer=$(MsIdentityWebSemVer) -p:SourceLinkCreate=true'
+    arguments: '--configuration $(BuildConfiguration) -p:RunCodeAnalysis=true -p:ClientSemVer=$(ClientSemVer) -p:SourceLinkCreate=true'
+ 
+# This task is needed so that the 1CS Rolsyn analyzers task works.
+# The previous task does the restore
+- task: VSBuild@1
+  displayName: 'Build solution Microsoft.Identity.Web.sln for governance'
+  inputs:
+    solution: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisionning.sln'
+    vsVersion: '16.0'
+    msbuildArgs: '/p:RunCodeAnalysis=false /p:ClientSemVer=$(ClientSemVer) /p:SourceLinkCreate=true'
+    platform: $(BuildPlatform)
+    configuration: $(BuildConfiguration)
  
 # Run Post-build code analysis (e.g. Roslyn)
 - template: template-postbuild-code-analysis.yaml
@@ -52,7 +63,7 @@ steps:
   parameters:
     NoBuild: 'true'
     BuildConfiguration: $(BuildConfiguration)
-    ProjectPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\ms-identity-app.csproj'
+    ProjectPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisioning-tool\ms-identity-app.csproj'
 
 # Copy all packages out to staging
 - task: CopyFiles@2

--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -30,7 +30,7 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: 'Build solution app-provisioning-tool.sln and run tests'
   inputs:
-    command: test
+    command: build
     projects: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisionning.sln'
     arguments: '--configuration $(BuildConfiguration) -p:RunCodeAnalysis=true -p:MsIdentityWebSemVer=$(MsIdentityWebSemVer) -p:SourceLinkCreate=true'
  

--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -30,7 +30,7 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: 'Build solution app-provisioning-tool.sln and run tests'
   inputs:
-    command: build
+    command: test
     projects: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisionning.sln'
     arguments: '--configuration $(BuildConfiguration) -p:RunCodeAnalysis=true -p:ClientSemVer=$(ClientSemVer) -p:SourceLinkCreate=true'
  
@@ -53,11 +53,6 @@ steps:
   parameters:
     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
     Pattern: '**\**\**\**\*app*.dll'
-    
-# - template: template-sign-binary.yaml
-#   parameters:
-#     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
-#     Pattern: '**\bin\**\**\ms-identity-app.dll'
 
 - template: template-nuget-pack.yaml
   parameters:

--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -47,17 +47,17 @@ steps:
  
 # Run Post-build code analysis (e.g. Roslyn)
 - template: template-postbuild-code-analysis.yaml
- 
+
 # Pack and sign the provisioning tool
 - template: template-sign-binary.yaml
   parameters:
     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
-    Pattern: '**\bin\**\**\ms-identity-app.dll'
-
-- template: template-sign-binary.yaml
-  parameters:
-    FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
-    Pattern: '**\bin\**\**\app-provisioning-lib.dll'
+    Pattern: '**\bin\**\**\*app*.dll'
+    
+# - template: template-sign-binary.yaml
+#   parameters:
+#     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
+#     Pattern: '**\bin\**\**\ms-identity-app.dll'
 
 - template: template-nuget-pack.yaml
   parameters:

--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -41,12 +41,12 @@ steps:
 - template: template-sign-binary.yaml
   parameters:
     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisioning-tool'
-    Pattern: 'bin\**\**\**\ms-identity-app.dll'
+    Pattern: 'bin\**\**\ms-identity-app.dll'
 
 - template: template-sign-binary.yaml
   parameters:
     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisioning-tool'
-    Pattern: 'bin\**\**\**\app-provisioning-lib.dll
+    Pattern: 'bin\**\**\app-provisioning-lib.dll
     '
 - template: template-nuget-pack.yaml
   parameters:

--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -38,11 +38,21 @@ steps:
 - template: template-postbuild-code-analysis.yaml
  
 # Pack and sign the provisioning tool
-- template: template-pack-and-sign-nuget.yaml
+- template: template-sign-binary.yaml
   parameters:
+    FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisioning-tool'
+    Pattern: 'bin\**\**\**\ms-identity-app.dll'
+
+- template: template-sign-binary.yaml
+  parameters:
+    FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\app-provisioning-tool'
+    Pattern: 'bin\**\**\**\app-provisioning-lib.dll
+    '
+- template: template-nuget-pack.yaml
+  parameters:
+    NoBuild: 'true'
     BuildConfiguration: $(BuildConfiguration)
-    ProjectRootPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
-    AssemblyName: '**\*app*'
+    ProjectPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool\ms-identity-app.csproj'
 
 # Copy all packages out to staging
 - task: CopyFiles@2

--- a/build/release-provisioning-tool.yml
+++ b/build/release-provisioning-tool.yml
@@ -41,13 +41,13 @@ steps:
 - template: template-sign-binary.yaml
   parameters:
     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
-    Pattern: ''**\bin\**\**\ms-identity-app.dll'
+    Pattern: '**\bin\**\**\ms-identity-app.dll'
 
 - template: template-sign-binary.yaml
   parameters:
     FolderPath: '$(Build.SourcesDirectory)\tools\app-provisioning-tool'
-    Pattern: '**\bin\**\**\app-provisioning-lib.dll
-    '
+    Pattern: '**\bin\**\**\app-provisioning-lib.dll'
+
 - template: template-nuget-pack.yaml
   parameters:
     NoBuild: 'true'


### PR DESCRIPTION
Updates the release build for the app provisioning tool to:
- ensure that all DLLs are signed.
- ensure that the Roslyn analyzers are run

Verified that the generated package contains a dotnet global too with signed DLLs 
https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=735796&view=results