### PR TITLE
fix error message

### DIFF
--- a/tools/app-provisioning-tool/app-provisioning-lib/AuthenticationParameters/ApplicationParameters.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/AuthenticationParameters/ApplicationParameters.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.App.AuthenticationParameters
         /// <summary>
         /// Application display name.
         /// </summary>
-        public string? DisplayName { get; set; }
+        public string? ApplicationDisplayName { get; set; }
 
         /// <summary>
         /// Tenant in which the application is created.

--- a/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
@@ -102,7 +102,11 @@ namespace Microsoft.Identity.App.DeveloperCredentials
                     "Error returned: {1}",
                     account?.Username ?? "Account not specified, sign-in to Visual Studio",
                     ex.Message);
-                Environment.Exit(1);
+                result = await app.AcquireTokenInteractive(requestContext.Scopes)
+                    .WithAccount(account)
+                    .WithClaims(ex.Claims)
+                    .WithAuthority(Instance, TenantId)
+                    .ExecuteAsync(cancellationToken);
             }
             return new AccessToken(result.AccessToken, result.ExpiresOn);
         }

--- a/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.App.DeveloperCredentials
             }
             return App;
         }
-        
+
         public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
             var app = await GetOrCreateApp();
@@ -107,6 +107,12 @@ namespace Microsoft.Identity.App.DeveloperCredentials
                     .WithClaims(ex.Claims)
                     .WithAuthority(Instance, TenantId)
                     .ExecuteAsync(cancellationToken);
+            }
+            catch (MsalServiceException ex)
+            {
+                Console.WriteLine("Error encountered with sign-in. See error message for details:\n{0}",
+                    ex.Message);
+                Environment.Exit(1);
             }
             return new AccessToken(result.AccessToken, result.ExpiresOn);
         }

--- a/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Identity.App.DeveloperCredentials
             {
                 Console.WriteLine("Error encountered with sign-in. See error message for details:\n{0}",
                     ex.Message);
-                Environment.Exit(1);
+                Environment.Exit(1); // we want to exit here. Re-sign in will not resolve the issue.
             }
             return new AccessToken(result.AccessToken, result.ExpiresOn);
         }

--- a/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.App.DeveloperCredentials
         public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
             var app = await GetOrCreateApp();
-            AuthenticationResult result;
+            AuthenticationResult? result = null;
             var accounts = await app.GetAccountsAsync()!;
             IAccount? account;
 
@@ -98,12 +98,11 @@ namespace Microsoft.Identity.App.DeveloperCredentials
             }
             catch (MsalUiRequiredException ex)
             {
-                Console.WriteLine("Please re-sign-in in Visual Studio. ");
-                result = await app.AcquireTokenInteractive(requestContext.Scopes)
-                    .WithAccount(account)
-                    .WithClaims(ex.Claims)
-                    .WithAuthority(Instance, TenantId)
-                    .ExecuteAsync(cancellationToken);
+                Console.WriteLine("No valid tokens found in the cache.\nPlease sign-in to Visual Studio with this account:\n\n{0}.\n\nAfter signing-in, re-run the tool.\n" +
+                    "Error returned: {1}",
+                    account?.Username ?? "Account not specified, sign-in to Visual Studio",
+                    ex.Message);
+                Environment.Exit(1);
             }
             return new AccessToken(result.AccessToken, result.ExpiresOn);
         }

--- a/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Core;
+using Microsoft.Graph;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
 using System;
@@ -39,7 +40,7 @@ namespace Microsoft.Identity.App.DeveloperCredentials
         {
             if (App == null)
             {
-                // On Windows, USERPROFILE is guarantied to be set
+                // On Windows, USERPROFILE is guaranteed to be set
                 string userProfile = Environment.GetEnvironmentVariable("USERPROFILE")!;
                 string cacheDir = Path.Combine(userProfile, @"AppData\Local\.IdentityService");
 

--- a/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/MicrosoftIdentityPlatformApplicationManager.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/MicrosoftIdentityPlatformApplicationManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
             // Create the app.
             Application application = new Application()
             {
-                DisplayName = applicationParameters.DisplayName,
+                DisplayName = applicationParameters.ApplicationDisplayName,
                 SignInAudience = AppParameterAudienceToMicrosoftIdentityPlatformAppAudience(applicationParameters.SignInAudience!),
                 Description = applicationParameters.Description
             };
@@ -224,7 +224,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
         {
             var passwordCredential = new PasswordCredential
             {
-                DisplayName = "Password created by the provisionning tool"
+                DisplayName = "Password created by the provisioning tool"
             };
 
             PasswordCredential returnedPasswordCredential = await graphServiceClient.Applications[$"{createdApplication.Id}"]
@@ -557,7 +557,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
             bool isB2C = (tenant.TenantType == "AAD B2C");
             var effectiveApplicationParameters = new ApplicationParameters
             {
-                DisplayName = application.DisplayName,
+                ApplicationDisplayName = application.DisplayName,
                 ClientId = application.AppId,
                 IsAAD = !isB2C,
                 IsB2C = isB2C,

--- a/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/TokenCredentialAuthenticationProvider.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/TokenCredentialAuthenticationProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
             IEnumerable<string>? initialScopes = null)
         {
             _tokenCredentials = tokenCredentials;
-            _initialScopes = initialScopes ?? new string[] { "Application.ReadWrite.All" };
+            _initialScopes = initialScopes ?? new string[] { "https://graph.microsoft.com/.default" };
         }
 
         readonly TokenCredential _tokenCredentials;

--- a/tools/app-provisioning-tool/app-provisioning-lib/Tool/AppProvisioningTool.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/Tool/AppProvisioningTool.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Identity.App
         {
             CodeReader reader = new CodeReader();
             ProjectAuthenticationSettings projectSettings = reader.ReadFromFiles(provisioningToolOptions.CodeFolder, projectDescription, projectDescriptions);
-            projectSettings.ApplicationParameters.DisplayName ??= Path.GetFileName(provisioningToolOptions.CodeFolder);
+            projectSettings.ApplicationParameters.ApplicationDisplayName ??= Path.GetFileName(provisioningToolOptions.CodeFolder);
             projectSettings.ApplicationParameters.ClientId ??= provisioningToolOptions.ClientId;
             projectSettings.ApplicationParameters.TenantId ??= provisioningToolOptions.TenantId;
             return projectSettings;

--- a/tools/app-provisioning-tool/app-provisioning-tool/Program.cs
+++ b/tools/app-provisioning-tool/app-provisioning-tool/Program.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Identity.App
         /// used when you don't want to register a new app, but want to configure the code 
         /// from an existing application (which can also be updated by the tool if needed).
         /// You might want to also pass-in the <paramref name="clientSecret"/> if you know it.</param>
-        /// <param name="unregister">Unregister the application, instead of registering it.</param>
         /// <param name="folder">When specified, will analyze the application code in the specified folder. 
         /// Otherwise analyzes the code in the current directory.</param>
         /// <param name="clientSecret">Client secret to use as a client credential.</param>
+        /// <param name="unregister">Unregister the application, instead of registering it.</param>
         /// <returns></returns>
         static public async Task Main(
             string? tenantId,
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.App
                 ClientId = clientId,
                 ClientSecret = clientSecret,
                 TenantId = tenantId,
-                Unregister = unregister.HasValue ? unregister.Value : false
+                Unregister = unregister ?? false
             };
 
             if (folder != null)


### PR DESCRIPTION
**Update**
Working now for everything but MSA, w/the `.../.default` scope

----
@jmprieur i have to have an account w/MFA enabled it seems. but anyway, here is the experience based on the updated error message. I thought it would be helpful for us to be able to get the actual error returned from MSAL, instead of relying on a stack trace, which might be harder to get later.
![image](https://user-images.githubusercontent.com/19942418/108605291-0dc8f980-7368-11eb-9aaf-f0ad61477e1b.png)

After setting up MFA, i get this error...but, it's because the template was already configured for a Microsoft tenant, when I removed the pre configuration, it worked.

![image](https://user-images.githubusercontent.com/19942418/108605566-9dbb7300-7369-11eb-93d2-7c9d3a24bf10.png)


When creating an MSA account via VS UI, getting an Msal Service Exception that consumers is not available.
![image](https://user-images.githubusercontent.com/19942418/108606215-a7df7080-736d-11eb-920e-7654e6e947c1.png)

