### PR TITLE
update cert

### DIFF
--- a/src/Microsoft.Identity.Web/CertificateManagement/CertificateDescription.cs
+++ b/src/Microsoft.Identity.Web/CertificateManagement/CertificateDescription.cs
@@ -30,7 +30,9 @@ namespace Microsoft.Identity.Web
         /// <param name="keyVaultUrl">The Key Vault URL.</param>
         /// <param name="keyVaultCertificateName">The name of the certificate in Key Vault.</param>
         /// <returns>A certificate description.</returns>
-        public static CertificateDescription FromKeyVault(string keyVaultUrl, string keyVaultCertificateName)
+        public static CertificateDescription FromKeyVault(
+            string keyVaultUrl,
+            string keyVaultCertificateName)
         {
             return new CertificateDescription
             {
@@ -215,6 +217,11 @@ namespace Microsoft.Identity.Web
         /// Base64 encoded certificate value.
         /// </summary>
         public string? Base64EncodedValue { get; set; }
+
+        /// <summary>
+        ///  Defines where and how to import the private key of an X.509 certificate.
+        /// </summary>
+        public X509KeyStorageFlags X509KeyStorageFlags { get; set; } = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet;
 
         /// <summary>
         /// Reference to the certificate or value.

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -297,6 +297,11 @@
             Base64 encoded certificate value.
             </summary>
         </member>
+        <member name="P:Microsoft.Identity.Web.CertificateDescription.X509KeyStorageFlags">
+            <summary>
+             Defines where and how to import the private key of an X.509 certificate.
+            </summary>
+        </member>
         <member name="P:Microsoft.Identity.Web.CertificateDescription.ReferenceOrValue">
             <summary>
             Reference to the certificate or value.
@@ -378,12 +383,13 @@
             </summary>
             <param name="certificateDescription">Description of the certificate.</param>
         </member>
-        <member name="M:Microsoft.Identity.Web.DefaultCertificateLoader.LoadFromKeyVault(System.String,System.String)">
+        <member name="M:Microsoft.Identity.Web.DefaultCertificateLoader.LoadFromKeyVault(System.String,System.String,System.Security.Cryptography.X509Certificates.X509KeyStorageFlags)">
             <summary>
             Load a certificate from Key Vault, including the private key.
             </summary>
             <param name="keyVaultUrl">URL of Key Vault.</param>
             <param name="certificateName">Name of the certificate.</param>
+            <param name="x509KeyStorageFlags">Defines where and how to import the private key of an X.509 certificate.</param>
             <returns>An <see cref="T:System.Security.Cryptography.X509Certificates.X509Certificate2"/> certificate.</returns>
             <remarks>This code is inspired by Heath Stewart's code in:
             https://github.com/heaths/azsdk-sample-getcert/blob/master/Program.cs#L46-L82.
@@ -1422,6 +1428,14 @@
             <summary>
             Gets the default user flow (which is signUpsignIn).
             </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.LegacyCacheCompatibilityEnabled">
+            <summary>
+            Enables legacy ADAL cache serialization and deserialization.
+            Performance improvements when working with MSAL only apps.
+            Set to true if you have a shared cache with ADAL apps.
+            </summary>
+            The default is <c>false.</c>
         </member>
         <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.IsB2C">
             <summary>

--- a/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Identity.Web.Test.Certificates
             Assert.Equal(certificateName, certificateDescription.ReferenceOrValue);
             Assert.Equal(certificateName, certificateDescription.KeyVaultCertificateName);
             Assert.Equal(keyVaultUrl, certificateDescription.KeyVaultUrl);
+            Assert.Equal(X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet, certificateDescription.X509KeyStorageFlags);
+            certificateDescription.X509KeyStorageFlags = X509KeyStorageFlags.UserKeySet;
+            Assert.Equal(X509KeyStorageFlags.UserKeySet, certificateDescription.X509KeyStorageFlags);
         }
 
         [Theory]


### PR DESCRIPTION
It's now possible to specify the `X509KeyStorageFlags` in the certificate description (both in the config file, or programmatically). This way if customers want to use other storage flags than the default, this is possible;.