### PR TITLE
Add L1/L2 cache implementation

### DIFF
--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -2131,7 +2131,8 @@
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter">
             <summary>
-            An implementation of the token cache for both Confidential and Public clients backed by MemoryCache.
+            An implementation of the token cache for both Confidential and Public clients backed by a DistributedCache.
+            The DistributedCache, by default create a Memory Cache, for faster look up, two level cache.
             </summary>
             <seealso>https://aka.ms/msal-net-token-cache-serialization</seealso>
         </member>
@@ -2140,17 +2141,18 @@
             .NET Core Memory cache.
             </summary>
         </member>
-        <member name="F:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter._cacheOptions">
+        <member name="F:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter._distributedCacheOptions">
             <summary>
-            MSAL memory token cache options.
+            MSAL distributed token cache options.
             </summary>
         </member>
-        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.#ctor(Microsoft.Extensions.Caching.Distributed.IDistributedCache,Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapterOptions})">
+        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.#ctor(Microsoft.Extensions.Caching.Distributed.IDistributedCache,Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapterOptions},Microsoft.Extensions.Logging.ILogger{Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter})">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter"/> class.
             </summary>
-            <param name="memoryCache">Distributed cache instance to use.</param>
-            <param name="cacheOptions">Options for the token cache.</param>
+            <param name="distributedCache">Distributed cache instance to use.</param>
+            <param name="distributedCacheOptions">Options for the token cache.</param>
+            <param name="logger">MsalDistributedTokenCacheAdapter logger.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.RemoveKeyAsync(System.String)">
             <summary>
@@ -2182,6 +2184,19 @@
             Options for the MSAL token cache serialization adapter,
             which delegates the serialization to the IDistributedCache implementations
             available with .NET Core.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapterOptions.L1CacheSizeLimit">
+            <summary>
+            In memory (L1) cache size limit in Mb.
+            Default is 500 Mb.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapterOptions.L1ExpirationTimeRatio">
+            <summary>
+            Value more than 0, less than 1, to set the In Memory (L1) cache
+            expiration time values relative to the Distributed (L2) cache.
+            Default is 1.
             </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider">
@@ -2440,6 +2455,11 @@
              </remarks>
              <param name="services">The services collection to add to.</param>
              <returns>The service collection.</returns>
+        </member>
+        <member name="T:Microsoft.Identity.Web.TokenCacheProviders.Utility">
+            <summary>
+            Utility methods used by L1/L2 cache.
+            </summary>
         </member>
         <member name="T:Microsoft.Identity.Web.MicrosoftIdentityWebApiAuthenticationBuilder">
             <summary>

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -2131,8 +2131,8 @@
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter">
             <summary>
-            An implementation of the token cache for both Confidential and Public clients backed by a DistributedCache.
-            The DistributedCache, by default create a Memory Cache, for faster look up, two level cache.
+            An implementation of the token cache for both Confidential and Public clients backed by a Distributed Cache.
+            The Distributed Cache (L2), by default creates a Memory Cache (L1), for faster look up, resulting in a two level cache.
             </summary>
             <seealso>https://aka.ms/msal-net-token-cache-serialization</seealso>
         </member>

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -2,14 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 {
     /// <summary>
-    /// An implementation of the token cache for both Confidential and Public clients backed by MemoryCache.
+    /// An implementation of the token cache for both Confidential and Public clients backed by a DistributedCache.
+    /// The DistributedCache, by default create a Memory Cache, for faster look up, two level cache.
     /// </summary>
     /// <seealso>https://aka.ms/msal-net-token-cache-serialization</seealso>
     public class MsalDistributedTokenCacheAdapter : MsalAbstractTokenCacheProvider
@@ -18,28 +23,49 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// .NET Core Memory cache.
         /// </summary>
         private readonly IDistributedCache _distributedCache;
+        private readonly IMemoryCache _memoryCache;
+        private readonly ILogger<MsalDistributedTokenCacheAdapter> _logger;
+
+        /// <summary>
+        /// MSAL distributed token cache options.
+        /// </summary>
+        private readonly MsalDistributedTokenCacheAdapterOptions _distributedCacheOptions;
 
         /// <summary>
         /// MSAL memory token cache options.
         /// </summary>
-        private readonly MsalDistributedTokenCacheAdapterOptions _cacheOptions;
+        private readonly MsalMemoryTokenCacheOptions _memoryCacheOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MsalDistributedTokenCacheAdapter"/> class.
         /// </summary>
-        /// <param name="memoryCache">Distributed cache instance to use.</param>
-        /// <param name="cacheOptions">Options for the token cache.</param>
+        /// <param name="distributedCache">Distributed cache instance to use.</param>
+        /// <param name="distributedCacheOptions">Options for the token cache.</param>
+        /// <param name="logger">MsalDistributedTokenCacheAdapter logger.</param>
+        /// <param name="memoryCache">Memory cache instance to use.</param>
+        /// <param name="memoryCacheOptions">Memory cache options.</param>
         public MsalDistributedTokenCacheAdapter(
-                                            IDistributedCache memoryCache,
-                                            IOptions<MsalDistributedTokenCacheAdapterOptions> cacheOptions)
+                                            IDistributedCache distributedCache,
+                                            IOptions<MsalDistributedTokenCacheAdapterOptions> distributedCacheOptions,
+                                            ILogger<MsalDistributedTokenCacheAdapter> logger,
+                                            IMemoryCache? memoryCache = null,
+                                            IOptions<MsalMemoryTokenCacheOptions>? memoryCacheOptions = null)
         {
-            if (cacheOptions == null)
+            if (distributedCacheOptions == null)
             {
-                throw new ArgumentNullException(nameof(cacheOptions));
+                throw new ArgumentNullException(nameof(distributedCacheOptions));
             }
 
-            _distributedCache = memoryCache;
-            _cacheOptions = cacheOptions.Value;
+            if (memoryCacheOptions == null)
+            {
+                memoryCacheOptions = Options.Create(new MsalMemoryTokenCacheOptions());
+            }
+
+            _distributedCache = distributedCache;
+            _distributedCacheOptions = distributedCacheOptions.Value;
+            _memoryCache = memoryCache ?? new MemoryCache(new MemoryCacheOptions());
+            _memoryCacheOptions = memoryCacheOptions.Value;
+            _logger = logger;
         }
 
         /// <summary>
@@ -50,7 +76,16 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// <returns>A <see cref="Task"/> that completes when key removal has completed.</returns>
         protected override async Task RemoveKeyAsync(string cacheKey)
         {
+            // remove in both
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            _memoryCache.Remove(cacheKey);
+            stopwatch.Stop();
+            _logger.LogInformation($"[IdWebCache]: Remove cacheKey {cacheKey} MemoryCache time: {stopwatch.Elapsed.TotalMilliseconds}. ");
+            stopwatch.Start();
             await _distributedCache.RemoveAsync(cacheKey).ConfigureAwait(false);
+            stopwatch.Stop();
+            _logger.LogInformation($"[IdWebCache]: Remove cacheKey {cacheKey} DistributedCache time: {stopwatch.Elapsed.TotalMilliseconds}. ");
         }
 
         /// <summary>
@@ -62,7 +97,34 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// (account or app).</returns>
         protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey)
         {
-            return await _distributedCache.GetAsync(cacheKey).ConfigureAwait(false);
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            // check memory cache first, logic from MISE
+            byte[] result = (byte[])_memoryCache.Get(cacheKey);
+            _logger.LogInformation($"[IdWebCache]: Read memory cache {cacheKey} result: {result?.Length}. ");
+            if (result == null)
+            {
+                // not found in memory, check distributed cache
+                result = await _distributedCache.GetAsync(cacheKey).ConfigureAwait(false);
+                _logger.LogInformation($"[IdWebCache]: No result in memory, check distributed cache: {result?.Length}. ");
+
+                // back propogate to memory cache
+                if (result != null)
+                {
+                    MemoryCacheEntryOptions memoryCacheEntryOptions = new MemoryCacheEntryOptions()
+                    {
+                        AbsoluteExpirationRelativeToNow = _memoryCacheOptions.AbsoluteExpirationRelativeToNow,
+                        Size = result?.Length,
+                    };
+
+                    _logger.LogInformation($"[IdWebCache]: Back propogate from Distributed to Memory: {result?.Length}");
+                    _memoryCache.Set(cacheKey, result, memoryCacheEntryOptions);
+                }
+            }
+
+            stopwatch.Stop();
+            _logger.LogInformation($"[IdWebCache]: Read cache {cacheKey} time: {stopwatch.Elapsed.TotalMilliseconds}. ");
+            return result;
         }
 
         /// <summary>
@@ -73,7 +135,22 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// <returns>A <see cref="Task"/> that completes when a write operation has completed.</returns>
         protected override async Task WriteCacheBytesAsync(string cacheKey, byte[] bytes)
         {
-            await _distributedCache.SetAsync(cacheKey, bytes, _cacheOptions).ConfigureAwait(false);
+            MemoryCacheEntryOptions memoryCacheEntryOptions = new MemoryCacheEntryOptions()
+            {
+                AbsoluteExpirationRelativeToNow = _memoryCacheOptions.AbsoluteExpirationRelativeToNow,
+                Size = bytes?.Length,
+            };
+
+            // write in both
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            _memoryCache.Set(cacheKey, bytes, memoryCacheEntryOptions);
+            stopwatch.Stop();
+            _logger.LogInformation($"[IdWebCache]: Write cacheKey {cacheKey} size {bytes?.Length} MemoryCache time: {stopwatch.Elapsed.TotalMilliseconds}. ");
+            stopwatch.Start();
+            await _distributedCache.SetAsync(cacheKey, bytes, _distributedCacheOptions).ConfigureAwait(false);
+            stopwatch.Stop();
+            _logger.LogInformation($"[IdWebCache]: Write cacheKey {cacheKey} size {bytes?.Length} DistributedCache time: {stopwatch.Elapsed.TotalMilliseconds}. ");
         }
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// <summary>
         /// .NET Core Memory cache.
         /// </summary>
-        private readonly IDistributedCache _distributedCache;
-        private readonly MemoryCache _memoryCache;
+        internal /*for tests*/ readonly IDistributedCache _distributedCache;
+        internal /*for tests*/ readonly MemoryCache _memoryCache;
         private readonly ILogger<MsalDistributedTokenCacheAdapter> _logger;
         private readonly TimeSpan? _expirationTime;
 
@@ -110,7 +110,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             }
 
             _logger.LogDebug($"[IdWebCache] Read caches for {cacheKey} returned Bytes {result?.Length} Time in Ticks: {Utility.Watch.Elapsed.Ticks - startTicks}. ");
+#pragma warning disable CS8603 // Possible null reference return.
             return result;
+#pragma warning restore CS8603 // Possible null reference return.
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -53,6 +53,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 
             if (_distributedCacheOptions.AbsoluteExpirationRelativeToNow != null)
             {
+                if (_distributedCacheOptions.L1ExpirationTimeRatio <= 0 || _distributedCacheOptions.L1ExpirationTimeRatio > 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(_distributedCacheOptions.L1ExpirationTimeRatio), "L1ExpirationTimeRatio must be greater than 0, less than 1. ");
+                }
+
                 _expirationTime = TimeSpan.FromMilliseconds(_distributedCacheOptions.AbsoluteExpirationRelativeToNow.Value.TotalMilliseconds * _distributedCacheOptions.L1ExpirationTimeRatio);
             }
         }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -11,8 +11,8 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 {
     /// <summary>
-    /// An implementation of the token cache for both Confidential and Public clients backed by a DistributedCache.
-    /// The DistributedCache, by default create a Memory Cache, for faster look up, two level cache.
+    /// An implementation of the token cache for both Confidential and Public clients backed by a Distributed Cache.
+    /// The Distributed Cache (L2), by default creates a Memory Cache (L1), for faster look up, resulting in a two level cache.
     /// </summary>
     /// <seealso>https://aka.ms/msal-net-token-cache-serialization</seealso>
     public class MsalDistributedTokenCacheAdapter : MsalAbstractTokenCacheProvider

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapterOptions.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Distributed/MsalDistributedTokenCacheAdapterOptions.cs
@@ -12,5 +12,17 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
     /// </summary>
     public class MsalDistributedTokenCacheAdapterOptions : DistributedCacheEntryOptions
     {
+        /// <summary>
+        /// In memory (L1) cache size limit in Mb.
+        /// Default is 500 Mb.
+        /// </summary>
+        public long L1CacheSizeLimit { get; set; } = 500;
+
+        /// <summary>
+        /// Value more than 0, less than 1, to set the In Memory (L1) cache
+        /// expiration time values relative to the Distributed (L2) cache.
+        /// Default is 1.
+        /// </summary>
+        public double L1ExpirationTimeRatio { get; set; } = 1;
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MeasureDurationResult.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MeasureDurationResult.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Web.TokenCacheProviders
+{
+    internal struct MeasureDurationResult
+    {
+        public MeasureDurationResult(long ticks)
+        {
+            Ticks = ticks;
+        }
+
+        public long Ticks { get; }
+    }
+
+    internal struct MeasureDurationResult<TResult>
+    {
+        public MeasureDurationResult(TResult result, long ticks)
+        {
+            Result = result;
+            Ticks = ticks;
+        }
+
+        public TResult Result { get; }
+
+        public long Ticks { get; }
+    }
+}

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Utility.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Utility.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web.TokenCacheProviders
+{
+    /// <summary>
+    /// Utility methods used by L1/L2 cache.
+    /// </summary>
+    internal static class Utility
+    {
+        internal static readonly Stopwatch Watch = Stopwatch.StartNew();
+
+        internal static async Task<MeasureDurationResult> Measure(this Task task)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            var startTicks = Watch.Elapsed.Ticks;
+            await task.ConfigureAwait(false);
+
+            return new MeasureDurationResult(Watch.Elapsed.Ticks - startTicks);
+        }
+
+        internal static async Task<MeasureDurationResult<TResult>> Measure<TResult>(this Task<TResult> task)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            var startTicks = Watch.Elapsed.Ticks;
+            var taskResult = await task.ConfigureAwait(false);
+
+            return new MeasureDurationResult<TResult>(taskResult, Watch.Elapsed.Ticks - startTicks);
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Utility.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Utility.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheOptionsTests.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Identity.Web.Test
                     AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(3),
                 });
             BuildTheRequiredServices();
+
+            // Act & Assert Exception
             Assert.Throws<ArgumentOutOfRangeException>(() => new TestMsalDistributedTokenCacheAdapter(
                 new TestDistributedCache(),
                 msalDistributedTokenOptions,
@@ -48,11 +50,13 @@ namespace Microsoft.Identity.Web.Test
                 });
             BuildTheRequiredServices();
 
+            // Act
             var testCache = new TestMsalDistributedTokenCacheAdapter(
                 new TestDistributedCache(),
                 msalDistributedTokenOptions,
                 _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>());
 
+            // Assert
             Assert.NotNull(testCache);
             Assert.NotNull(testCache._distributedCache);
             Assert.NotNull(testCache._memoryCache);

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheOptionsTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web.TokenCacheProviders.Distributed;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    public class L1L2CacheOptionsTests
+    {
+        private ServiceProvider _provider;
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(2)]
+        public void MsalDistributedTokenCacheAdapterOptions_L1ExpirationTimeRatio_ThrowsException(double expirationRatio)
+        {
+            // Arrange
+            var msalDistributedTokenOptions = Options.Create(
+                new MsalDistributedTokenCacheAdapterOptions()
+                {
+                    L1ExpirationTimeRatio = expirationRatio,
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(3),
+                });
+            BuildTheRequiredServices();
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TestMsalDistributedTokenCacheAdapter(
+                new TestDistributedCache(),
+                msalDistributedTokenOptions,
+                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>()));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(.23)]
+        public void MsalDistributedTokenCacheAdapterOptions_L1ExpirationTimeRatio(double expirationRatio)
+        {
+            // Arrange
+            var msalDistributedTokenOptions = Options.Create(
+                new MsalDistributedTokenCacheAdapterOptions()
+                {
+                    L1ExpirationTimeRatio = expirationRatio,
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(3),
+                });
+            BuildTheRequiredServices();
+
+            var testCache = new TestMsalDistributedTokenCacheAdapter(
+                new TestDistributedCache(),
+                msalDistributedTokenOptions,
+                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>());
+
+            Assert.NotNull(testCache);
+            Assert.NotNull(testCache._distributedCache);
+            Assert.NotNull(testCache._memoryCache);
+            Assert.Equal(0, testCache._memoryCache.Count);
+        }
+
+        private void BuildTheRequiredServices()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddDistributedTokenCaches();
+            _provider = services.BuildServiceProvider();
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Concurrent;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
@@ -252,7 +250,7 @@ namespace Microsoft.Identity.Web.Test
 
         public async Task TestRemoveKeyAsync(string cacheKey)
         {
-           await RemoveKeyAsync(cacheKey).ConfigureAwait(false);
+            await RemoveKeyAsync(cacheKey).ConfigureAwait(false);
         }
 
         public async Task TestWriteCacheBytesAsync(string cacheKey, byte[] bytes)
@@ -263,58 +261,6 @@ namespace Microsoft.Identity.Web.Test
         public async Task<byte[]> TestReadCacheBytesAsync(string cacheKey)
         {
             return await ReadCacheBytesAsync(cacheKey).ConfigureAwait(false);
-        }
-    }
-
-    internal class TestDistributedCache : IDistributedCache
-    {
-        public readonly ConcurrentDictionary<string, byte[]> dict = new ConcurrentDictionary<string, byte[]>();
-
-        public byte[] Get(string key)
-        {
-            if (dict.TryGetValue(key, out var value))
-            {
-                return dict[key];
-            }
-
-            return null;
-        }
-
-        public Task<byte[]> GetAsync(string key, CancellationToken token = default)
-        {
-            return Task.FromResult(Get(key));
-        }
-
-        public void Refresh(string key)
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public Task RefreshAsync(string key, CancellationToken token = default)
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public void Remove(string key)
-        {
-            dict.TryRemove(key, out var _);
-        }
-
-        public Task RemoveAsync(string key, CancellationToken token = default)
-        {
-            Remove(key);
-            return Task.CompletedTask;
-        }
-
-        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
-        {
-            dict[key] = value;
-        }
-
-        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
-        {
-            Set(key, value, options);
-            return Task.CompletedTask;
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Microsoft.Identity.Web.Test
+{
+    public class TestDistributedCache : IDistributedCache
+    {
+        public readonly ConcurrentDictionary<string, byte[]> dict = new ConcurrentDictionary<string, byte[]>();
+
+        public byte[] Get(string key)
+        {
+            if (dict.TryGetValue(key, out var value))
+            {
+                return dict[key];
+            }
+
+            return null;
+        }
+
+        public Task<byte[]> GetAsync(string key, CancellationToken token = default)
+        {
+            return Task.FromResult(Get(key));
+        }
+
+        public void Refresh(string key)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task RefreshAsync(string key, CancellationToken token = default)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Remove(string key)
+        {
+            dict.TryRemove(key, out var _);
+        }
+
+        public Task RemoveAsync(string key, CancellationToken token = default)
+        {
+            Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+        {
+            dict[key] = value;
+        }
+
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+        {
+            Set(key, value, options);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/UtilityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/UtilityTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Identity.Web.Test
             var taskDuration = TimeSpan.FromMilliseconds(100);
             var epsilon = TimeSpan.FromMilliseconds(30).Ticks;
             var measure = await Task.Delay(taskDuration).Measure().ConfigureAwait(false);
-            Assert.True(Math.Abs(measure.Ticks - taskDuration.Ticks) < epsilon, $"{(measure.Ticks - taskDuration.Ticks) / TimeSpan.TicksPerMillisecond }ms exceeds epsilon of 30ms");
+            Assert.True(Math.Abs(measure.Ticks - taskDuration.Ticks) < epsilon, $"{(measure.Ticks - taskDuration.Ticks) / TimeSpan.TicksPerMillisecond}ms exceeds epsilon of 30ms");
 
             // measure task with a result
             var test = "test";

--- a/tests/Microsoft.Identity.Web.Test/UtilityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/UtilityTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Identity.Web.TokenCacheProviders;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    public class UtilityTests
+    {
+        [Fact(Skip = "Timing depends on resources of build VM, making the test have little value in a CI job")]
+        public async Task Measurements_Tests()
+        {
+            // measure task with no result
+            var taskDuration = TimeSpan.FromMilliseconds(100);
+            var epsilon = TimeSpan.FromMilliseconds(30).Ticks;
+            var measure = await Task.Delay(taskDuration).Measure().ConfigureAwait(false);
+            Assert.True(Math.Abs(measure.Ticks - taskDuration.Ticks) < epsilon, $"{(measure.Ticks - taskDuration.Ticks) / TimeSpan.TicksPerMillisecond }ms exceeds epsilon of 30ms");
+
+            // measure task with a result
+            var test = "test";
+            var measureResult = await DelayAndReturn(test, taskDuration).Measure().ConfigureAwait(false);
+            Assert.True(Math.Abs(measureResult.Ticks - taskDuration.Ticks) < epsilon);
+            Assert.Same(test, measureResult.Result);
+
+            // verify that an exception is thrown
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await Task.Run(() => throw new InvalidOperationException()).Measure().ConfigureAwait(false)).ConfigureAwait(false);
+        }
+
+        private async Task<string> DelayAndReturn(string test, TimeSpan taskDuration)
+        {
+            await Task.Delay(taskDuration).ConfigureAwait(false);
+            return test;
+        }
+    }
+}


### PR DESCRIPTION
#957 

Manual testing done:
- [x] L1 w/L2 redis cache in docker container w/the perf runner w/10k users

TODO:
- handle redis errors/failures - probably in a second PR