### PR TITLE
Fix thread safety issues in TokenAcquisition classes

### DIFF
--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Identity.Web
     public class AppServicesAuthenticationTokenAcquisition : ITokenAcquisition
     {
         private readonly object _applicationSyncObj = new object();
+
         /// <summary>
-        ///  Please call GetOrBuildConfidentialClientApplication instead of accessing this field directly.
+        ///  Please call GetOrCreateApplication instead of accessing this field directly.
         /// </summary>
         private IConfidentialClientApplication? _application;
         private readonly IHttpContextAccessor _httpContextAccessor;
@@ -94,7 +95,6 @@ namespace Microsoft.Identity.Web
                     }
                 }
             }
-
 
             return _application;
         }
@@ -196,6 +196,13 @@ namespace Microsoft.Identity.Web
                 scopes,
                 tokenAcquisitionOptions != null ? tokenAcquisitionOptions.CorrelationId : Guid.Empty);
             return authenticationResult;
+        }
+
+        /// <inheritdoc/>
+        public Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException, HttpResponse? httpResponse = null)
+        {
+            // Not implemented for the moment
+            throw new NotImplementedException();
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Identity.Client;
@@ -15,9 +16,15 @@ namespace Microsoft.Identity.Web
     /// <summary>
     /// Implementation of ITokenAcquisition for App Services authentication (EasyAuth).
     /// </summary>
-    public class AppServicesAuthenticationTokenAcquisition : ITokenAcquisition
+    public class AppServicesAuthenticationTokenAcquisition : ITokenAcquisition, IDisposable
     {
+        private readonly SemaphoreSlim _confidentialClientApplicationSyncObj = new SemaphoreSlim(/* max concurrent locks */ 1);
+        /// <summary>
+        /// Do no read or set this directly.
+        /// Instead, use GetOrCreateApplication which is thread-safe
+        /// </summary>
         private IConfidentialClientApplication? _confidentialClientApplication;
+        private bool _disposedValue;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IMsalHttpClientFactory _httpClientFactory;
         private readonly IMsalTokenCacheProvider _tokenCacheProvider;
@@ -50,17 +57,29 @@ namespace Microsoft.Identity.Web
         {
             if (_confidentialClientApplication == null)
             {
-                ConfidentialClientApplicationOptions options = new ConfidentialClientApplicationOptions()
+                await _confidentialClientApplicationSyncObj.WaitAsync();
+
+                try
                 {
-                    ClientId = AppServicesAuthenticationInformation.ClientId,
-                    ClientSecret = AppServicesAuthenticationInformation.ClientSecret,
-                    Instance = AppServicesAuthenticationInformation.Issuer,
-                };
-                _confidentialClientApplication = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(options)
-                    .WithHttpClientFactory(_httpClientFactory)
-                    .Build();
-                await _tokenCacheProvider.InitializeAsync(_confidentialClientApplication.AppTokenCache).ConfigureAwait(false);
-                await _tokenCacheProvider.InitializeAsync(_confidentialClientApplication.UserTokenCache).ConfigureAwait(false);
+                    if (_confidentialClientApplication == null)
+                    {
+                        ConfidentialClientApplicationOptions options = new ConfidentialClientApplicationOptions()
+                        {
+                            ClientId = AppServicesAuthenticationInformation.ClientId,
+                            ClientSecret = AppServicesAuthenticationInformation.ClientSecret,
+                            Instance = AppServicesAuthenticationInformation.Issuer,
+                        };
+                        _confidentialClientApplication = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(options)
+                            .WithHttpClientFactory(_httpClientFactory)
+                            .Build();
+                        await _tokenCacheProvider.InitializeAsync(_confidentialClientApplication.AppTokenCache).ConfigureAwait(false);
+                        await _tokenCacheProvider.InitializeAsync(_confidentialClientApplication.UserTokenCache).ConfigureAwait(false);
+                    }
+                }
+                finally
+                {
+                    _confidentialClientApplicationSyncObj.Release();
+                }
             }
 
             return _confidentialClientApplication;
@@ -87,16 +106,29 @@ namespace Microsoft.Identity.Web
         }
 
         /// <inheritdoc/>
-        public async Task<string> GetAccessTokenForUserAsync(
+        public Task<string> GetAccessTokenForUserAsync(
             IEnumerable<string> scopes,
             string? tenantId = null,
             string? userFlow = null,
             ClaimsPrincipal? user = null,
             TokenAcquisitionOptions? tokenAcquisitionOptions = null)
         {
-            string accessToken = GetAccessToken(CurrentHttpContext?.Request.Headers);
+            var httpContext = CurrentHttpContext;
+            string accessToken;
+            if (httpContext != null)
+            {
+                // Need to lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+                lock (httpContext)
+                {
+                    accessToken = GetAccessToken(httpContext.Request.Headers);
+                }
+            }
+            else
+            {
+                accessToken = string.Empty;
+            }
 
-            return await Task.FromResult(accessToken).ConfigureAwait(false);
+            return Task.FromResult(accessToken);
         }
 
         private string GetAccessToken(IHeaderDictionary? headers)
@@ -123,19 +155,39 @@ namespace Microsoft.Identity.Web
         }
 
         /// <inheritdoc/>
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async Task<AuthenticationResult> GetAuthenticationResultForUserAsync(IEnumerable<string> scopes, string? tenantId = null, string? userFlow = null, ClaimsPrincipal? user = null, TokenAcquisitionOptions? tokenAcquisitionOptions = null)
+        public Task<AuthenticationResult> GetAuthenticationResultForUserAsync(IEnumerable<string> scopes, string? tenantId = null, string? userFlow = null, ClaimsPrincipal? user = null, TokenAcquisitionOptions? tokenAcquisitionOptions = null)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc/>
-        public async Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException, HttpResponse? httpResponse = null)
+        public Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException, HttpResponse? httpResponse = null)
         {
             // Not implemented for the moment
             throw new NotImplementedException();
         }
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <inheritdoc />
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _confidentialClientApplicationSyncObj.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
 
     }
 }

--- a/src/Microsoft.Identity.Web/HttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/HttpContextExtensions.cs
@@ -16,7 +16,11 @@ namespace Microsoft.Identity.Web
         /// it can be used in the actions.</param>
         internal static void StoreTokenUsedToCallWebAPI(this HttpContext httpContext, JwtSecurityToken? token)
         {
-            httpContext.Items.Add(Constants.JwtSecurityTokenUsedToCallWebApi, token);
+            // lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+            lock(httpContext)
+            {
+                httpContext.Items.Add(Constants.JwtSecurityTokenUsedToCallWebApi, token);
+            }
         }
 
         /// <summary>
@@ -26,7 +30,11 @@ namespace Microsoft.Identity.Web
         /// <returns><see cref="JwtSecurityToken"/> used to call the web API.</returns>
         internal static JwtSecurityToken? GetTokenUsedToCallWebAPI(this HttpContext httpContext)
         {
-            return httpContext.Items[Constants.JwtSecurityTokenUsedToCallWebApi] as JwtSecurityToken;
+            // lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+            lock(httpContext)
+            {
+                return httpContext.Items[Constants.JwtSecurityTokenUsedToCallWebApi] as JwtSecurityToken;
+            }
         }
     }
 }

--- a/src/Microsoft.Identity.Web/HttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/HttpContextExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Identity.Web
         internal static void StoreTokenUsedToCallWebAPI(this HttpContext httpContext, JwtSecurityToken? token)
         {
             // lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
-            lock(httpContext)
+            lock (httpContext)
             {
                 httpContext.Items.Add(Constants.JwtSecurityTokenUsedToCallWebApi, token);
             }
@@ -31,7 +31,7 @@ namespace Microsoft.Identity.Web
         internal static JwtSecurityToken? GetTokenUsedToCallWebAPI(this HttpContext httpContext)
         {
             // lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
-            lock(httpContext)
+            lock (httpContext)
             {
                 return httpContext.Items[Constants.JwtSecurityTokenUsedToCallWebApi] as JwtSecurityToken;
             }

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -123,6 +123,11 @@
             Implementation of ITokenAcquisition for App Services authentication (EasyAuth).
             </summary>
         </member>
+        <member name="F:Microsoft.Identity.Web.AppServicesAuthenticationTokenAcquisition._application">
+            <summary>
+             Please call GetOrCreateApplication instead of accessing this field directly.
+            </summary>
+        </member>
         <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationTokenAcquisition.#ctor(Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider,Microsoft.AspNetCore.Http.IHttpContextAccessor,System.Net.Http.IHttpClientFactory)">
             <summary>
             Constructor of the AppServicesAuthenticationTokenAcquisition.
@@ -1981,6 +1986,11 @@
             Token acquisition service.
             </summary>
         </member>
+        <member name="F:Microsoft.Identity.Web.TokenAcquisition._application">
+            <summary>
+             Please call GetOrBuildConfidentialClientApplication instead of accessing this field directly.
+            </summary>
+        </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.#ctor(Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider,Microsoft.AspNetCore.Http.IHttpContextAccessor,Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Web.MicrosoftIdentityOptions},Microsoft.Extensions.Options.IOptions{Microsoft.Identity.Client.ConfidentialClientApplicationOptions},System.Net.Http.IHttpClientFactory,Microsoft.Extensions.Logging.ILogger{Microsoft.Identity.Web.TokenAcquisition},System.IServiceProvider)">
             <summary>
             Constructor of the TokenAcquisition service. This requires the Azure AD Options to
@@ -2142,11 +2152,6 @@
             <param name="context">RedirectContext passed-in to a <see cref="P:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents.OnRedirectToIdentityProviderForSignOut"/>
             OpenID Connect event.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> that represents a completed account removal operation.</returns>
-        </member>
-        <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetOrBuildConfidentialClientApplication">
-            <summary>
-            Creates an MSAL confidential client application, if needed.
-            </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.BuildConfidentialClientApplication">
             <summary>

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Identity.Web
         private readonly IMsalTokenCacheProvider _tokenCacheProvider;
 
         private readonly object _applicationSyncObj = new object();
+
         /// <summary>
         ///  Please call GetOrBuildConfidentialClientApplication instead of accessing this field directly.
         /// </summary>
@@ -383,14 +384,13 @@ namespace Microsoft.Identity.Web
         /// <param name="scopes">Scopes to consent to.</param>
         /// <param name="msalServiceException">The <see cref="MsalUiRequiredException"/> that triggered the challenge.</param>
         /// <param name="httpResponse">The <see cref="HttpResponse"/> to update.</param>
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(
+        public Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(
             IEnumerable<string> scopes,
             MsalUiRequiredException msalServiceException,
             HttpResponse? httpResponse = null)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             ReplyForbiddenWithWwwAuthenticateHeader(scopes, msalServiceException, httpResponse);
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -473,12 +473,12 @@ namespace Microsoft.Identity.Web
                 }
             }
         }
-        
+
         private string BuildCurrentUriFromRequest(HttpContext httpContext, HttpRequest request)
         {
             // need to lock to avoid threading issues with code outside of this library
             // https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
-            lock(httpContext)
+            lock (httpContext)
             {
                 return UriHelper.BuildAbsolute(
                     request.Scheme,
@@ -766,7 +766,7 @@ namespace Microsoft.Identity.Web
             if (httpContext != null)
             {
                 // Need to lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
-                lock(httpContext)
+                lock (httpContext)
                 {
                     return httpContext.User;
                 }

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Identity.Web.Test
 
             InitializeTokenAcquisitionObjects();
 
-            IConfidentialClientApplication app = _tokenAcquisition.GetOrBuildConfidentialClientApplication();
+            IConfidentialClientApplication app = _tokenAcquisition.BuildConfidentialClientApplication();
 
             string expectedAuthority = string.Format(
                 CultureInfo.InvariantCulture,
@@ -149,7 +149,7 @@ namespace Microsoft.Identity.Web.Test
 
             InitializeTokenAcquisitionObjects();
 
-            IConfidentialClientApplication app = _tokenAcquisition.GetOrBuildConfidentialClientApplication();
+            IConfidentialClientApplication app = _tokenAcquisition.BuildConfidentialClientApplication();
 
             if (!string.IsNullOrEmpty(redirectUri))
             {

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Identity.Web.Test
 
             InitializeTokenAcquisitionObjects();
 
-            IConfidentialClientApplication app = _tokenAcquisition.BuildConfidentialClientApplication();
+            IConfidentialClientApplication app = _tokenAcquisition.GetOrBuildConfidentialClientApplication();
 
             string expectedAuthority = string.Format(
                 CultureInfo.InvariantCulture,
@@ -149,7 +149,7 @@ namespace Microsoft.Identity.Web.Test
 
             InitializeTokenAcquisitionObjects();
 
-            IConfidentialClientApplication app = _tokenAcquisition.BuildConfidentialClientApplication();
+            IConfidentialClientApplication app = _tokenAcquisition.GetOrBuildConfidentialClientApplication();
 
             if (!string.IsNullOrEmpty(redirectUri))
             {


### PR DESCRIPTION
There were some cases where highly multithreaded environments could cause issues due to non thread-safe code. This PR attempts to resolve the thread safety issues with an eye on maintaining performant execution.