### PR TITLE
make cca creation not async

### DIFF
--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
@@ -183,6 +183,13 @@ namespace Microsoft.Identity.Web
         }
 
         /// <inheritdoc/>
+        public void ReplyForbiddenWithWwwAuthenticateHeader(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException, HttpResponse? httpResponse = null)
+        {
+            // Not implemented for the moment
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
         public Task<AuthenticationResult> GetAuthenticationResultForAppAsync(string scope, string? tenant = null, TokenAcquisitionOptions? tokenAcquisitionOptions = null)
         {
             throw new NotImplementedException();

--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Web
             _tokenCacheProvider = tokenCacheProvider;
         }
 
-        private async Task<IConfidentialClientApplication> GetOrCreateApplication()
+        private IConfidentialClientApplication GetOrCreateApplication()
         {
             if (_confidentialClientApplication == null)
             {
@@ -81,8 +81,8 @@ namespace Microsoft.Identity.Web
                 _confidentialClientApplication = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(options)
                     .WithHttpClientFactory(_httpClientFactory)
                     .Build();
-                await _tokenCacheProvider.InitializeAsync(_confidentialClientApplication.AppTokenCache).ConfigureAwait(false);
-                await _tokenCacheProvider.InitializeAsync(_confidentialClientApplication.UserTokenCache).ConfigureAwait(false);
+                _tokenCacheProvider.Initialize(_confidentialClientApplication.AppTokenCache);
+                _tokenCacheProvider.Initialize(_confidentialClientApplication.UserTokenCache);
             }
 
             return _confidentialClientApplication;
@@ -100,7 +100,7 @@ namespace Microsoft.Identity.Web
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            var app = await GetOrCreateApplication().ConfigureAwait(false);
+            var app = GetOrCreateApplication();
             AuthenticationResult result = await app.AcquireTokenForClient(new string[] { scope })
                 .ExecuteAsync()
                 .ConfigureAwait(false);
@@ -176,7 +176,7 @@ namespace Microsoft.Identity.Web
         }
 
         /// <inheritdoc/>
-        public async Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException, HttpResponse? httpResponse = null)
+        public Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException, HttpResponse? httpResponse = null)
         {
             // Not implemented for the moment
             throw new NotImplementedException();
@@ -188,6 +188,5 @@ namespace Microsoft.Identity.Web
             throw new NotImplementedException();
         }
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
-
     }
 }

--- a/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web/Constants/IDWebErrorMessage.cs
@@ -67,6 +67,8 @@ namespace Microsoft.Identity.Web
             "StoreName must be empty or one of '{0}'. ";
 
         // Obsolete messages IDW10800 = "IDW10800:"
-        public const string AadIssuerValidatorGetIssuerValidatorIsObsolete = "IDW10800: Use MicrosoftIdentityIssuerValidatorFactory.GetAadIssuerValidator. See https://aka.ms/ms-id-web/1.2.0";
+        public const string AadIssuerValidatorGetIssuerValidatorIsObsolete = "IDW10800: Use MicrosoftIdentityIssuerValidatorFactory.GetAadIssuerValidator. See https://aka.ms/ms-id-web/1.2.0. ";
+        public const string InitializeAsyncIsObsolete = "IDW10801: Use Initialize instead. See https://aka.ms/ms-id-web/1.9.0. ";
+        public const string ReplyForbiddenWithWwwAuthenticateHeaderAsyncIsObsolete = "IDW10801: Use ReplyForbiddenWithWwwAuthenticateHeader instead. See https://aka.ms/ms-id-web/1.9.0. ";
     }
 }

--- a/src/Microsoft.Identity.Web/ITokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/ITokenAcquisition.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -100,7 +101,21 @@ namespace Microsoft.Identity.Web
         /// <param name="scopes">Scopes to consent to.</param>
         /// <param name="msalServiceException"><see cref="MsalUiRequiredException"/> triggering the challenge.</param>
         /// <param name="httpResponse">The <see cref="HttpResponse"/> to update.</param>
+        void ReplyForbiddenWithWwwAuthenticateHeader(
+        IEnumerable<string> scopes,
+        MsalUiRequiredException msalServiceException,
+        HttpResponse? httpResponse = null);
+
+        /// <summary>
+        /// Used in web APIs (which therefore cannot have an interaction with the user).
+        /// Replies to the client through the HttpResponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
+        /// the client can trigger an interaction with the user so the user can consent to more scopes.
+        /// </summary>
+        /// <param name="scopes">Scopes to consent to.</param>
+        /// <param name="msalServiceException"><see cref="MsalUiRequiredException"/> triggering the challenge.</param>
+        /// <param name="httpResponse">The <see cref="HttpResponse"/> to update.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Obsolete(IDWebErrorMessage.InitializeAsyncIsObsolete, true)]
         Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(
         IEnumerable<string> scopes,
         MsalUiRequiredException msalServiceException,

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -94,24 +94,24 @@
         </member>
         <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationInformation.GetIdToken(System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues})">
             <summary>
-            Get the ID token from the headers send by App services authentication.
+            Get the ID token from the headers sent by App services authentication.
             </summary>
             <param name="headers">Headers.</param>
-            <returns>the ID Token.</returns>
+            <returns>The ID Token.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationInformation.GetIdp(System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues})">
             <summary>
-            Get the IDP token from the headers send by App services authentication.
+            Get the IDP from the headers sent by App services authentication.
             </summary>
             <param name="headers">Headers.</param>
-            <returns>the IDP.</returns>
+            <returns>The IDP.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationInformation.GetUser(System.Collections.Generic.IDictionary{System.String,Microsoft.Extensions.Primitives.StringValues})">
             <summary>
-            Get the user claims from the headers and environment variables
+            Get the user claims from the headers and environment variables.
             </summary>
-            <param name="headers">Headers</param>
-            <returns>User claims</returns>
+            <param name="headers">Headers.</param>
+            <returns>User claims.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.AppServicesAuthenticationOptions">
             <summary>
@@ -141,6 +141,9 @@
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationTokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeaderAsync(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException,Microsoft.AspNetCore.Http.HttpResponse)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationTokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeader(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException,Microsoft.AspNetCore.Http.HttpResponse)">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationTokenAcquisition.GetAuthenticationResultForAppAsync(System.String,System.String,Microsoft.Identity.Web.TokenAcquisitionOptions)">
@@ -1295,6 +1298,16 @@
             <param name="tokenAcquisitionOptions">Options passed-in to create the token acquisition object which calls into MSAL .NET.</param>
             <returns>An authentication result for the app itself, based on its scopes.</returns>
         </member>
+        <member name="M:Microsoft.Identity.Web.ITokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeader(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException,Microsoft.AspNetCore.Http.HttpResponse)">
+            <summary>
+            Used in web APIs (which therefore cannot have an interaction with the user).
+            Replies to the client through the HttpResponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
+            the client can trigger an interaction with the user so the user can consent to more scopes.
+            </summary>
+            <param name="scopes">Scopes to consent to.</param>
+            <param name="msalServiceException"><see cref="T:Microsoft.Identity.Client.MsalUiRequiredException"/> triggering the challenge.</param>
+            <param name="httpResponse">The <see cref="T:Microsoft.AspNetCore.Http.HttpResponse"/> to update.</param>
+        </member>
         <member name="M:Microsoft.Identity.Web.ITokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeaderAsync(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException,Microsoft.AspNetCore.Http.HttpResponse)">
             <summary>
             Used in web APIs (which therefore cannot have an interaction with the user).
@@ -2111,7 +2124,16 @@
             <param name="scopes">Scopes to consent to.</param>
             <param name="msalServiceException">The <see cref="T:Microsoft.Identity.Client.MsalUiRequiredException"/> that triggered the challenge.</param>
             <param name="httpResponse">The <see cref="T:Microsoft.AspNetCore.Http.HttpResponse"/> to update.</param>
-            <returns>A <see cref="T:System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisition.ReplyForbiddenWithWwwAuthenticateHeader(System.Collections.Generic.IEnumerable{System.String},Microsoft.Identity.Client.MsalUiRequiredException,Microsoft.AspNetCore.Http.HttpResponse)">
+            <summary>
+            Used in web APIs (no user interaction).
+            Replies to the client through the HTTP response by sending a 403 (forbidden) and populating the 'WWW-Authenticate' header so that
+            the client, in turn, can trigger a user interaction so that the user consents to more scopes.
+            </summary>
+            <param name="scopes">Scopes to consent to.</param>
+            <param name="msalServiceException">The <see cref="T:Microsoft.Identity.Client.MsalUiRequiredException"/> that triggered the challenge.</param>
+            <param name="httpResponse">The <see cref="T:Microsoft.AspNetCore.Http.HttpResponse"/> to update.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenAcquisition.RemoveAccountAsync(Microsoft.AspNetCore.Authentication.OpenIdConnect.RedirectContext)">
             <summary>
@@ -2121,12 +2143,12 @@
             OpenID Connect event.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> that represents a completed account removal operation.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetOrBuildConfidentialClientApplicationAsync">
+        <member name="M:Microsoft.Identity.Web.TokenAcquisition.GetOrBuildConfidentialClientApplication">
             <summary>
             Creates an MSAL confidential client application, if needed.
             </summary>
         </member>
-        <member name="M:Microsoft.Identity.Web.TokenAcquisition.BuildConfidentialClientApplicationAsync">
+        <member name="M:Microsoft.Identity.Web.TokenAcquisition.BuildConfidentialClientApplication">
             <summary>
             Creates an MSAL confidential client application.
             </summary>
@@ -2304,6 +2326,12 @@
             <param name="tokenCache">Token cache for which to initialize the serialization.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> that represents a completed initialization operation.</returns>
         </member>
+        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider.Initialize(Microsoft.Identity.Client.ITokenCache)">
+            <summary>
+            Initializes a token cache (which can be a user token cache or an app token cache).
+            </summary>
+            <param name="tokenCache">Token cache for which to initialize the serialization.</param>
+        </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider.ClearAsync(System.String)">
             <summary>
             Clear the user token cache.
@@ -2391,6 +2419,12 @@
             Token cache provider with default implementation.
             </summary>
             <seealso cref="T:Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider" />
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.Initialize(Microsoft.Identity.Client.ITokenCache)">
+            <summary>
+            Initializes the token cache serialization.
+            </summary>
+            <param name="tokenCache">Token cache to serialize/deserialize.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.InitializeAsync(Microsoft.Identity.Client.ITokenCache)">
             <summary>

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Web
 
             try
             {
-                _application = await GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
+                _application = GetOrBuildConfidentialClientApplication();
 
                 // Do not share the access token with ASP.NET Core otherwise ASP.NET will cache it and will not send the OAuth 2.0 request in
                 // case a further call to AcquireTokenByAuthorizationCodeAsync in the future is required for incremental consent (getting a code requesting more scopes)
@@ -210,7 +210,7 @@ namespace Microsoft.Identity.Web
 
             user = await GetAuthenticatedUserAsync(user).ConfigureAwait(false);
 
-            _application = await GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
+            _application = GetOrBuildConfidentialClientApplication();
 
             string authority = CreateAuthorityBasedOnTenantIfProvided(_application, tenantId);
 
@@ -263,7 +263,7 @@ namespace Microsoft.Identity.Web
         /// for multi tenant apps or daemons.</param>
         /// <param name="tokenAcquisitionOptions">Options passed-in to create the token acquisition object which calls into MSAL .NET.</param>
         /// <returns>An authentication result for the app itself, based on its scopes.</returns>
-        public async Task<AuthenticationResult> GetAuthenticationResultForAppAsync(
+        public Task<AuthenticationResult> GetAuthenticationResultForAppAsync(
             string scope,
             string? tenant = null,
             TokenAcquisitionOptions? tokenAcquisitionOptions = null)
@@ -289,10 +289,9 @@ namespace Microsoft.Identity.Web
             }
 
             // Use MSAL to get the right token to call the API
-            _application = await GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
+            _application = GetOrBuildConfidentialClientApplication();
             string authority = CreateAuthorityBasedOnTenantIfProvided(_application, tenant);
 
-            AuthenticationResult result;
             var builder = _application
                    .AcquireTokenForClient(new string[] { scope }.Except(_scopesRequestedByMsal))
                    .WithSendX5C(_microsoftIdentityOptions.SendX5C)
@@ -310,9 +309,7 @@ namespace Microsoft.Identity.Web
                 }
             }
 
-            result = await builder.ExecuteAsync()
-                                  .ConfigureAwait(false);
-            return result;
+            return builder.ExecuteAsync();
         }
 
         /// <summary>
@@ -384,7 +381,6 @@ namespace Microsoft.Identity.Web
         /// <param name="scopes">Scopes to consent to.</param>
         /// <param name="msalServiceException">The <see cref="MsalUiRequiredException"/> that triggered the challenge.</param>
         /// <param name="httpResponse">The <see cref="HttpResponse"/> to update.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException, HttpResponse? httpResponse = null)
         {
             // A user interaction is required, but we are in a web API, and therefore, we need to report back to the client through a 'WWW-Authenticate' header https://tools.ietf.org/html/rfc6750#section-3.1
@@ -394,7 +390,7 @@ namespace Microsoft.Identity.Web
                 throw msalServiceException;
             }
 
-            _application = await GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
+            _application = GetOrBuildConfidentialClientApplication();
 
             string consentUrl = $"{_application.Authority}/oauth2/v2.0/authorize?client_id={_applicationOptions.ClientId}"
                 + $"&response_type=code&redirect_uri={_application.AppConfig.RedirectUri}"
@@ -421,6 +417,8 @@ namespace Microsoft.Identity.Web
             httpResponse.StatusCode = (int)HttpStatusCode.Forbidden;
 
             headers[HeaderNames.WWWAuthenticate] = new StringValues($"{Constants.Bearer} {parameterString}");
+
+            await Task.CompletedTask.ConfigureAwait(false); // we don't want to take a breaking change right now. will be for 2.0
         }
 
         /// <summary>
@@ -435,7 +433,7 @@ namespace Microsoft.Identity.Web
             string? userId = user.GetMsalAccountId();
             if (!string.IsNullOrEmpty(userId))
             {
-                IConfidentialClientApplication app = await GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
+                IConfidentialClientApplication app = GetOrBuildConfidentialClientApplication();
 
                 if (_microsoftIdentityOptions.IsB2C)
                 {
@@ -458,11 +456,11 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Creates an MSAL confidential client application, if needed.
         /// </summary>
-        internal /* for testing */ async Task<IConfidentialClientApplication> GetOrBuildConfidentialClientApplicationAsync()
+        internal /* for testing */ IConfidentialClientApplication GetOrBuildConfidentialClientApplication()
         {
             if (_application == null)
             {
-                return await BuildConfidentialClientApplicationAsync().ConfigureAwait(false);
+                return BuildConfidentialClientApplication();
             }
 
             return _application;
@@ -471,7 +469,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Creates an MSAL confidential client application.
         /// </summary>
-        private async Task<IConfidentialClientApplication> BuildConfidentialClientApplicationAsync()
+        private IConfidentialClientApplication BuildConfidentialClientApplication()
         {
             var request = CurrentHttpContext?.Request;
             string? currentUri = null;
@@ -535,8 +533,8 @@ namespace Microsoft.Identity.Web
                 IConfidentialClientApplication app = builder.Build();
                 _application = app;
                 // Initialize token cache providers
-                await _tokenCacheProvider.InitializeAsync(app.AppTokenCache).ConfigureAwait(false);
-                await _tokenCacheProvider.InitializeAsync(app.UserTokenCache).ConfigureAwait(false);
+                _tokenCacheProvider.Initialize(app.AppTokenCache);
+                _tokenCacheProvider.Initialize(app.UserTokenCache);
                 return app;
             }
             catch (Exception ex)

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -381,7 +381,28 @@ namespace Microsoft.Identity.Web
         /// <param name="scopes">Scopes to consent to.</param>
         /// <param name="msalServiceException">The <see cref="MsalUiRequiredException"/> that triggered the challenge.</param>
         /// <param name="httpResponse">The <see cref="HttpResponse"/> to update.</param>
-        public async Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(IEnumerable<string> scopes, MsalUiRequiredException msalServiceException, HttpResponse? httpResponse = null)
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async Task ReplyForbiddenWithWwwAuthenticateHeaderAsync(
+            IEnumerable<string> scopes,
+            MsalUiRequiredException msalServiceException,
+            HttpResponse? httpResponse = null)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        {
+            ReplyForbiddenWithWwwAuthenticateHeader(scopes, msalServiceException, httpResponse);
+        }
+
+        /// <summary>
+        /// Used in web APIs (no user interaction).
+        /// Replies to the client through the HTTP response by sending a 403 (forbidden) and populating the 'WWW-Authenticate' header so that
+        /// the client, in turn, can trigger a user interaction so that the user consents to more scopes.
+        /// </summary>
+        /// <param name="scopes">Scopes to consent to.</param>
+        /// <param name="msalServiceException">The <see cref="MsalUiRequiredException"/> that triggered the challenge.</param>
+        /// <param name="httpResponse">The <see cref="HttpResponse"/> to update.</param>
+        public void ReplyForbiddenWithWwwAuthenticateHeader(
+            IEnumerable<string> scopes,
+            MsalUiRequiredException msalServiceException,
+            HttpResponse? httpResponse = null)
         {
             // A user interaction is required, but we are in a web API, and therefore, we need to report back to the client through a 'WWW-Authenticate' header https://tools.ietf.org/html/rfc6750#section-3.1
             string proposedAction = Constants.Consent;
@@ -417,8 +438,6 @@ namespace Microsoft.Identity.Web
             httpResponse.StatusCode = (int)HttpStatusCode.Forbidden;
 
             headers[HeaderNames.WWWAuthenticate] = new StringValues($"{Constants.Bearer} {parameterString}");
-
-            await Task.CompletedTask.ConfigureAwait(false); // we don't want to take a breaking change right now. will be for 2.0
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// Initializes a token cache (which can be a user token cache or an app token cache).
         /// </summary>
         /// <param name="tokenCache">Token cache for which to initialize the serialization.</param>
-        /// <returns>A <see cref="Task"/> that represents a completed initialization operation.</returns>
-        Task InitializeAsync(ITokenCache tokenCache);
+        void Initialize(ITokenCache tokenCache);
 
         /// <summary>
         /// Clear the user token cache.

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 
@@ -11,6 +12,14 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
     /// </summary>
     public interface IMsalTokenCacheProvider
     {
+        /// <summary>
+        /// Initializes a token cache (which can be a user token cache or an app token cache).
+        /// </summary>
+        /// <param name="tokenCache">Token cache for which to initialize the serialization.</param>
+        /// <returns>A <see cref="Task"/> that represents a completed initialization operation.</returns>
+        [Obsolete(IDWebErrorMessage.InitializeAsyncIsObsolete, true)]
+        Task InitializeAsync(ITokenCache tokenCache);
+
         /// <summary>
         /// Initializes a token cache (which can be a user token cache or an app token cache).
         /// </summary>

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
@@ -30,6 +30,17 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         }
 
         /// <summary>
+        /// Initializes the token cache serialization.
+        /// </summary>
+        /// <param name="tokenCache">Token cache to serialize/deserialize.</param>
+        /// <returns>A <see cref="Task"/> that represents a completed initialization operation.</returns>
+        public Task InitializeAsync(ITokenCache tokenCache)
+        {
+            Initialize(tokenCache);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Raised AFTER MSAL added the new token in its in-memory copy of the cache.
         /// This notification is called every time MSAL accesses the cache, not just when a write takes place:
         /// If MSAL's current operation resulted in a cache change, the property TokenCacheNotificationArgs.HasStateChanged will be set to true.

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// Initializes the token cache serialization.
         /// </summary>
         /// <param name="tokenCache">Token cache to serialize/deserialize.</param>
-        /// <returns>A <see cref="Task"/> that represents a completed initialization operation.</returns>
-        public Task InitializeAsync(ITokenCache tokenCache)
+        public void Initialize(ITokenCache tokenCache)
         {
             if (tokenCache == null)
             {
@@ -28,8 +27,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
             tokenCache.SetBeforeAccessAsync(OnBeforeAccessAsync);
             tokenCache.SetAfterAccessAsync(OnAfterAccessAsync);
             tokenCache.SetBeforeWriteAsync(OnBeforeWriteAsync);
-
-            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Web.Test
         [InlineData(TestConstants.B2CLoginMicrosoft)]
         [InlineData(TestConstants.B2CInstance, true)]
         [InlineData(TestConstants.B2CLoginMicrosoft, true)]
-        public async Task VerifyCorrectAuthorityUsedInTokenAcquisition_B2CAuthorityTestsAsync(
+        public void VerifyCorrectAuthorityUsedInTokenAcquisition_B2CAuthorityTests(
             string authorityInstance,
             bool withTfp = false)
         {
@@ -119,7 +119,7 @@ namespace Microsoft.Identity.Web.Test
 
             InitializeTokenAcquisitionObjects();
 
-            IConfidentialClientApplication app = await _tokenAcquisition.GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
+            IConfidentialClientApplication app = _tokenAcquisition.GetOrBuildConfidentialClientApplication();
 
             string expectedAuthority = string.Format(
                 CultureInfo.InvariantCulture,
@@ -134,7 +134,7 @@ namespace Microsoft.Identity.Web.Test
         [Theory]
         [InlineData("https://localhost:1234")]
         [InlineData("")]
-        public async Task VerifyCorrectRedirectUriAsync(
+        public void VerifyCorrectRedirectUriAsync(
             string redirectUri)
         {
             _microsoftIdentityOptions = new MicrosoftIdentityOptions
@@ -149,7 +149,7 @@ namespace Microsoft.Identity.Web.Test
 
             InitializeTokenAcquisitionObjects();
 
-            IConfidentialClientApplication app = await _tokenAcquisition.GetOrBuildConfidentialClientApplicationAsync().ConfigureAwait(false);
+            IConfidentialClientApplication app = _tokenAcquisition.GetOrBuildConfidentialClientApplication();
 
             if (!string.IsNullOrEmpty(redirectUri))
             {


### PR DESCRIPTION
@DavidParks8 thanks for the suggestion of making cca not async. i think this was done back it was a sample and needed for something else...as things moved to MSAL, we were able to remove that functionality out of id web. @jmprieur 