### PR TITLE
Fix issue with .NET Core 3.1 project template domain value, not the same as .NET 5.0 / not recognized by msidentity-app-sync

### DIFF
--- a/ProjectTemplates/configuration.json
+++ b/ProjectTemplates/configuration.json
@@ -225,7 +225,7 @@
                     "FileRelativePath": "Client/Program.cs",
                     "Replacements": [
                         {
-                            "ReplaceFrom": "https://yourDomain.onmicrosoft.com/api.id.uri/access_as_user",
+                            "ReplaceFrom": "https://qualified.domain.name/api.id.uri/access_as_user",
                             "ReplaceBy": "https://fabrikamb2c.onmicrosoft.com/helloapi/user_impersonation"
                         }
                     ]

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/.template.config/template.json
@@ -210,8 +210,8 @@
     "AAdB2CInstance": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "https://yourDomain.b2clogin.com/",
-      "replaces": "https:////yourDomain.b2clogin.com/",
+      "defaultValue": "https://qualified.domain.name.b2clogin.com/",
+      "replaces": "https:////qualified.domain.name.b2clogin.com/",
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
@@ -258,7 +258,7 @@
     "Domain": {
       "type": "parameter",
       "datatype": "string",
-      "replaces": "yourDomain",
+      "replaces": "qualified.domain.name",
       "description": "The domain for the directory tenant (use with SingleOrg or IndividualB2C auth)."
     },
     "TenantId": {

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/appsettings.json
@@ -1,10 +1,10 @@
 {
 ////#if (IndividualB2CAuth)
 //  "AzureAdB2C": {
-//    "Instance": "https:////yourDomain.b2clogin.com/",
+//    "Instance": "https:////qualified.domain.name.b2clogin.com/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
 //    "CallbackPath": "/signin-oidc",
-//    "Domain": "yourDomain.onmicrosoft.com",
+//    "Domain": "qualified.domain.name",
 //    "SignedOutCallbackPath": "/signout/MySignUpSignInPolicyId",
 //#if (GenerateApi)
 //    "ClientSecret": "secret-from-app-registration",
@@ -21,7 +21,7 @@
 //#if (MultiOrgAuth)
 //    "TenantId": "common",
 //#elseif (SingleOrgAuth)
-//    "Domain": "yourDomain",
+//    "Domain": "qualified.domain.name",
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -363,7 +363,7 @@
     "Domain": {
       "type": "parameter",
       "datatype": "string",
-      "replaces": "yourDomain",
+      "replaces": "qualified.domain.name",
       "description": "The domain for the directory tenant (use with SingleOrg or IndividualB2C auth)."
     },
     "AppIDUri": {

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/Program.cs
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/Program.cs
@@ -55,7 +55,7 @@ namespace ComponentsWebAssembly_CSharp
             {
                 builder.Configuration.Bind("AzureAdB2C", options.ProviderOptions.Authentication);
 #if (Hosted)
-                options.ProviderOptions.DefaultAccessTokenScopes.Add("https://yourDomain.onmicrosoft.com/api.id.uri/api-scope");
+                options.ProviderOptions.DefaultAccessTokenScopes.Add("https://qualified.domain.name/api.id.uri/api-scope");
 #endif
             });
 #endif

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/appsettings.json
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Server/appsettings.json
@@ -11,7 +11,7 @@
 //  "AzureAdB2C": {
 //    "Instance": "https:////aadB2CInstance.b2clogin.com/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-//    "Domain": "yourDomain.onmicrosoft.com",
+//    "Domain": "qualified.domain.name",
 //#if (GenerateApi)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
@@ -25,7 +25,7 @@
 //#if (!SingleOrgAuth)
 //    "TenantId": "common",
 //#else
-//    "Domain": "yourDomain",
+//    "Domain": "qualified.domain.name",
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",

--- a/ProjectTemplates/templates/Functions-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/Functions-CSharp/.template.config/template.json
@@ -40,8 +40,8 @@
         "AAdB2CInstance": {
             "type": "parameter",
             "datatype": "string",
-            "defaultValue": "https://yourDomain.b2clogin.com/",
-            "replaces": "https:////yourDomain.b2clogin.com/",
+            "defaultValue": "https://qualified.domain.name.b2clogin.com/",
+            "replaces": "https:////qualified.domain.name.b2clogin.com/",
             "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
         },
         "SignUpSignInPolicyId": {
@@ -67,7 +67,7 @@
         "Domain": {
             "type": "parameter",
             "datatype": "string",
-            "replaces": "yourDomain",
+            "replaces": "qualified.domain.name",
             "description": "The domain for the directory tenant (use with SingleOrg or IndividualB2C auth)."
         },
         "DefaultScope": {

--- a/ProjectTemplates/templates/Functions-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/Functions-CSharp/appsettings.json
@@ -1,9 +1,9 @@
 ﻿{
 ////#if (IndividualB2CAuth)
 //  "AzureAdB2C": {
-//    "Instance": "https:////yourDomain.b2clogin.com/",
+//    "Instance": "https:////qualified.domain.name.b2clogin.com/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-//    "Domain": "yourDomain.onmicrosoft.com",
+//    "Domain": "qualified.domain.name",
 //#if (GenerateApi)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
@@ -17,7 +17,7 @@
 //#if (!SingleOrgAuth)
 //    "TenantId": "common",
 //#else
-//    "Domain": "yourDomain",
+//    "Domain": "qualified.domain.name",
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/.template.config/template.json
@@ -134,8 +134,8 @@
     "AAdB2CInstance": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "https://yourDomain.b2clogin.com/",
-      "replaces": "https:////yourDomain.b2clogin.com/",
+      "defaultValue": "https://qualified.domain.name.b2clogin.com/",
+      "replaces": "https:////qualified.domain.name.b2clogin.com/",
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
@@ -182,7 +182,7 @@
     "Domain": {
       "type": "parameter",
       "datatype": "string",
-      "replaces": "yourDomain",
+      "replaces": "qualified.domain.name",
       "description": "The domain for the directory tenant (use with SingleOrg or IndividualB2C auth)."
     },
     "TenantId": {

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/appsettings.json
@@ -1,10 +1,10 @@
 {
 ////#if (IndividualB2CAuth)
 //  "AzureAdB2C": {
-//    "Instance": "https:////yourDomain.b2clogin.com/",
+//    "Instance": "https:////qualified.domain.name.b2clogin.com/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
 //    "CallbackPath": "/signin-oidc",
-//    "Domain": "yourDomain.onmicrosoft.com",
+//    "Domain": "qualified.domain.name",
 //#if (GenerateApi)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
@@ -21,7 +21,7 @@
 //#if (MultiOrgAuth)
 //    "TenantId": "common",
 //#elseif (SingleOrgAuth)
-//    "Domain": "yourDomain",
+//    "Domain": "qualified.domain.name",
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",

--- a/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/.template.config/template.json
@@ -130,8 +130,8 @@
     "AAdB2CInstance": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "https://yourDomain.b2clogin.com/",
-      "replaces": "https:////yourDomain.b2clogin.com/",
+      "defaultValue": "https://qualified.domain.name.b2clogin.com/",
+      "replaces": "https:////qualified.domain.name.b2clogin.com/",
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
@@ -178,7 +178,7 @@
     "Domain": {
       "type": "parameter",
       "datatype": "string",
-      "replaces": "yourDomain",
+      "replaces": "qualified.domain.name",
       "description": "The domain for the directory tenant (use with SingleOrg or IndividualB2C auth)."
     },
     "TenantId": {

--- a/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/appsettings.json
@@ -1,9 +1,9 @@
 {
 ////#if (IndividualB2CAuth)
 //  "AzureAdB2C": {
-//    "Instance": "https:////yourDomain.b2clogin.com/",
+//    "Instance": "https:////qualified.domain.name.b2clogin.com/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-//    "Domain": "yourDomain.onmicrosoft.com",
+//    "Domain": "qualified.domain.name",
 //    "SignedOutCallbackPath": "/signout/MySignUpSignInPolicyId",
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId",
 //    "ResetPasswordPolicyId": "MyResetPasswordPolicyId",
@@ -21,7 +21,7 @@
 //#if (MultiOrgAuth)
 //    "TenantId": "common",
 //#elseif (SingleOrgAuth)
-//    "Domain": "yourDomain",
+//    "Domain": "qualified.domain.name",
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",

--- a/ProjectTemplates/templates/WebApi-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/.template.config/template.json
@@ -68,8 +68,8 @@
     "AAdB2CInstance": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "https://yourDomain.b2clogin.com/",
-      "replaces": "https:////yourDomain.b2clogin.com/",
+      "defaultValue": "https://qualified.domain.name.b2clogin.com/",
+      "replaces": "https:////qualified.domain.name.b2clogin.com/",
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
@@ -95,7 +95,7 @@
     "Domain": {
       "type": "parameter",
       "datatype": "string",
-      "replaces": "yourDomain",
+      "replaces": "qualified.domain.namen",
       "description": "The domain for the directory tenant (use with SingleOrg or IndividualB2C auth)."
     },
     "DefaultScope": {

--- a/ProjectTemplates/templates/WebApi-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/appsettings.json
@@ -3,7 +3,7 @@
 //  "AzureAdB2C": {
 //    "Instance": "https:////yourDomain.b2clogin.com/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
-//    "Domain": "yourDomain.onmicrosoft.com",
+//    "Domain": "qualified.domain.name",
 //#if (GenerateApi)
 //    "ClientSecret": "secret-from-app-registration",
 //    "ClientCertificates" : [
@@ -17,7 +17,7 @@
 //#if (!SingleOrgAuth)
 //    "TenantId": "common",
 //#else
-//    "Domain": "yourDomain",
+//    "Domain": "qualified.domain.name",
 //    "TenantId": "22222222-2222-2222-2222-222222222222",
 //#endif
 //    "ClientId": "11111111-1111-1111-11111111111111111",

--- a/ProjectTemplates/templates/WebApi-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/WebApi-CSharp/appsettings.json
@@ -1,7 +1,7 @@
 {
 ////#if (IndividualB2CAuth)
 //  "AzureAdB2C": {
-//    "Instance": "https:////yourDomain.b2clogin.com/",
+//    "Instance": "https:////qualified.domain.name.b2clogin.com/",
 //    "ClientId": "11111111-1111-1111-11111111111111111",
 //    "Domain": "qualified.domain.name",
 //#if (GenerateApi)

--- a/ProjectTemplates/templates/Worker-CSharp/.template.config/template.json
+++ b/ProjectTemplates/templates/Worker-CSharp/.template.config/template.json
@@ -58,8 +58,8 @@
     "AAdB2CInstance": {
       "type": "parameter",
       "datatype": "string",
-      "defaultValue": "https://yourDomain.b2clogin.com/",
-      "replaces": "https:////yourDomain.b2clogin.com/",
+      "defaultValue": "https://qualified.domain.name.b2clogin.com/",
+      "replaces": "https:////qualified.domain.name.b2clogin.com/",
       "description": "The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth)."
     },
     "SignUpSignInPolicyId": {
@@ -85,7 +85,7 @@
     "Domain": {
       "type": "parameter",
       "datatype": "string",
-      "replaces": "yourDomain",
+      "replaces": "qualified.domain.name",
       "description": "The domain for the directory tenant (use with SingleOrg or IndividualB2C auth)."
     },
     "DefaultScope": {

--- a/ProjectTemplates/templates/Worker-CSharp/appsettings.json
+++ b/ProjectTemplates/templates/Worker-CSharp/appsettings.json
@@ -1,54 +1,54 @@
 {
-    ////#if (IndividualB2CAuth)
-    //  "AzureAdB2C": {
-    //    "Instance": "https:////yourDomain.b2clogin.com/",
-    //    "ClientId": "11111111-1111-1111-11111111111111111",
-    //    "Domain": "yourDomain.onmicrosoft.com",
-    //#if (GenerateApi)
-    //    "ClientSecret": "secret-from-app-registration",
-    //    "ClientCertificates" : [
-    //    ],
-    //#endif
-    //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
-    //  },
-    ////#elseif (OrganizationalAuth)
-    //  "AzureAd": {
-    //    "Instance": "https:////login.microsoftonline.com/",
-    //#if (!SingleOrgAuth)
-    //    "TenantId": "common",
-    //#else
-    //    "Domain": "yourDomain",
-    //    "TenantId": "22222222-2222-2222-2222-222222222222",
-    //#endif
-    //    "ClientId": "11111111-1111-1111-11111111111111111",
+////#if (IndividualB2CAuth)
+//  "AzureAdB2C": {
+//    "Instance": "https:////qualified.domain.name.b2clogin.com/",
+//    "ClientId": "11111111-1111-1111-11111111111111111",
+//    "Domain": "qualified.domain.name",
+//#if (GenerateApi)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+//#endif
+//    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
+//  },
+////#elseif (OrganizationalAuth)
+//  "AzureAd": {
+//    "Instance": "https:////login.microsoftonline.com/",
+//#if (!SingleOrgAuth)
+//    "TenantId": "common",
+//#else
+//    "Domain": "qualified.domain.name",
+//    "TenantId": "22222222-2222-2222-2222-222222222222",
+//#endif
+//    "ClientId": "11111111-1111-1111-11111111111111111",
 
-    //#if (GenerateApiOrGraph)
-    //    "ClientSecret": "secret-from-app-registration",
-    //    "ClientCertificates" : [
-    //    ],
-    //#endif
-    //    "CallbackPath": "/signin-oidc"
-    //  },
-    ////#endif
-    ////#if (GenerateApiOrGraph)
-    //  "DownstreamApi": {
-    //    /*
-    //     'Scopes' contains space separated scopes of the Web API you want to call. This can be:
-    //      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
-    //      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
-    //        App ID URI of a legacy v1 Web application
-    //      Applications are registered in the https://portal.azure.com portal.
-    //    */
-    //    "BaseUrl": "[WebApiUrl]",
-    //    "Scopes": "user.read"
-    //  },
-    ////#endif
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
-        }
-    },
-    "AllowedHosts": "*"
+//#if (GenerateApiOrGraph)
+//    "ClientSecret": "secret-from-app-registration",
+//    "ClientCertificates" : [
+//    ],
+//#endif
+//    "CallbackPath": "/signin-oidc"
+//  },
+////#endif
+////#if (GenerateApiOrGraph)
+//  "DownstreamApi": {
+//    /*
+//     'Scopes' contains space separated scopes of the Web API you want to call. This can be:
+//      - a scope for a V2 application (for instance api://b3682cc7-8b30-4bd2-aaba-080c6bf0fd31/access_as_user)
+//      - a scope corresponding to a V1 application (for instance <App ID URI>/.default, where  <App ID URI> is the
+//        App ID URI of a legacy v1 Web application
+//      Applications are registered in the https://portal.azure.com portal.
+//    */
+//    "BaseUrl": "[WebApiUrl]",
+//    "Scopes": "user.read"
+//  },
+////#endif
+"Logging": {
+    "LogLevel": {
+        "Default": "Information",
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+    }
+},
+"AllowedHosts": "*"
 }


### PR DESCRIPTION
The ASP.NET 5.0 templates use the following value for the "Domain": "qualified.domain.name"
and this is the value recognized by msidentity-app-sync.

We need to check if the same does not need to be changed in the other web app templates (mvc, webapp, and blazorserver)