### PR TITLE
Configure redirect_uri to use HTTPS instead of detected protocol

### DIFF
--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Identity.Web
         public string? ResetPasswordPolicyId { get; set; }
 
         /// <summary>
+        /// Requires that even if the host is detected to use HTTP, the redirect_url value should use HTTPS.
+        /// </summary>
+        public bool ForceHttpsOnRedirectUri { get; set; }
+
+        /// <summary>
         /// Gets the default user flow (which is signUpsignIn).
         /// </summary>
         public string? DefaultUserFlow => SignUpSignInPolicyId;

--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -416,9 +416,17 @@ namespace Microsoft.Identity.Web
 
             var application = GetOrBuildConfidentialClientApplication();
 
+            // If the configuration indicates that HTTPS should be used regardless of the detected protocol, swap to HTTPS
+            var redirectUri = application.AppConfig.RedirectUri;
+            if (redirectUri.StartsWith("http://", StringComparison.InvariantCulture) &&
+                application.AppConfig.ForceHttpsOnRedirectUrl)
+            {
+                redirectUri = redirectUri.Replace("http://", "https://");
+            }
+            
             string consentUrl = $"{application.Authority}/oauth2/v2.0/authorize?client_id={_applicationOptions.ClientId}"
-                + $"&response_type=code&redirect_uri={application.AppConfig.RedirectUri}"
-                + $"&response_mode=query&scope=offline_access%20{string.Join("%20", scopes)}";
+                                + $"&response_type=code&redirect_uri={redirectUri}"
+                                + $"&response_mode=query&scope=offline_access%20{string.Join("%20", scopes)}";
 
             IDictionary<string, string> parameters = new Dictionary<string, string>()
                 {


### PR DESCRIPTION
I run microservices on Service Fabric using HTTP so as to avoid having to maintain short-lived certificates on the various underlying nodes. The web-facing microservices are exposed to the public internet only through Azure App Gateway in order to handle SSL offloading (and thus provide a single point where the certificates need to be maintained). Thus, any HTTPS request goes App Gateway -> (unwrap SSL) -> send HTTP request to microservice -> reply with HTTP -> (wrap SSL) -> App Gateway replies via HTTPS to caller.

This works fine until I introduce Microsoft Authentication into the picture. Upon attempted authentication, the redirect_uri that's created appears to be based on the protocol configured to be in use by the host, so the non-configurable request to AAD looks like "redirect_uri=http://example.com". AAD app registrations understandably only allow `http://` to be used with localhost and `https://` for all other domains, so this fails with "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" when I attempt to log into my microservice (even if it's otherwise accessible if the URL were to use HTTPS via App Gateway).

This pull request ([along with this PR](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2613)) introduces a boolean option to allow the developer to force the use of HTTPS in the ultimately created redirect_uri value so that my service otherwise running HTTP will instead create a value of "redirect_uri=https://example.com" in the AAD request, which _can_ be properly registered with AAD and will otherwise work. This boolean defaults to false so it only impacts users that explicitly set it, so it doesn't introduce any breaking changes.

I'd be happy to make any changes as necessary to accommodate the addition of this function.