### PR TITLE
Fix Visual Studio authenication timeout errors

### DIFF
--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -129,7 +129,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Azure.Identity 1.3.0 [fixed some issues causing auth timeouts](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/CHANGELOG.md#130-2020-11-12) when working locally in Visual Studio. Microsoft.Identity.Web 1.9.2 still uses 1.2.3. The reason for the errors is not immediately obvious because of a misleading reference to Azure CLI.

The fix is to upgrade to Azure.Identity 1.3.0.