### PR TITLE
Fixes #1163 (AppService authentication can declare aad or azureactivedirectory indifferently)

### DIFF
--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Identity.Web
         internal const string AppServicesAuthLogoutPathEnvironmentVariable = "WEBSITE_AUTH_LOGOUT_PATH";    // /.auth/logout
         internal const string AppServicesAuthIdentityProviderEnvironmentVariable = "WEBSITE_AUTH_DEFAULT_PROVIDER"; // AzureActiveDirectory
         internal const string AppServicesAuthAzureActiveDirectory = "AzureActiveDirectory";
+        internal const string AppServicesAuthAAD = "AAD";
         internal const string AppServicesAuthIdTokenHeader = "X-MS-TOKEN-AAD-ID-TOKEN";
         private const string AppServicesAuthIdpTokenHeader = "X-MS-CLIENT-PRINCIPAL-IDP";
 
@@ -43,10 +44,16 @@ namespace Microsoft.Identity.Web
                         Constants.True,
                         StringComparison.OrdinalIgnoreCase) &&
 
-                     string.Equals(
+                     (string.Equals(
                          Environment.GetEnvironmentVariable(AppServicesAuthIdentityProviderEnvironmentVariable),
                          AppServicesAuthAzureActiveDirectory,
-                         StringComparison.OrdinalIgnoreCase);
+                         StringComparison.OrdinalIgnoreCase)
+                     ||
+                     string.Equals(
+                         Environment.GetEnvironmentVariable(AppServicesAuthIdentityProviderEnvironmentVariable),
+                         AppServicesAuthAAD,
+                         StringComparison.OrdinalIgnoreCase)
+                     );
             }
         }
 

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -427,6 +427,8 @@ namespace Microsoft.Identity.Web.Test
         [InlineData("true", "azureactivedirectory")]
         [InlineData("tRue", AppServicesAuthenticationInformation.AppServicesAuthAzureActiveDirectory)]
         [InlineData("true", AppServicesAuthenticationInformation.AppServicesAuthAzureActiveDirectory)]
+        [InlineData("tRue", AppServicesAuthenticationInformation.AppServicesAuthAAD)]
+        [InlineData("true", AppServicesAuthenticationInformation.AppServicesAuthAAD)]
         // Regression for https://github.com/AzureAD/microsoft-identity-web/issues/1163
         public void AppServices_EnvironmentTest(string appServicesEnvEnabledValue, string idpEnvValue)
         {


### PR DESCRIPTION
Fixes #1163 based on updates from EasyAuth people