### PR TITLE
Adding more logging to the long running sample

### DIFF
--- a/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/CallbackController.cs
+++ b/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/CallbackController.cs
@@ -46,13 +46,17 @@ namespace TodoListService.Controllers
         [AllowAnonymous]
         public async Task GetAsync(string key)
         {
-            _logger.LogWarning($"Callback called {DateTime.Now}");
+            var request = HttpContext.Request;
+            string calledUrl = request.Scheme + "://" + request.Host + request.Path.Value + Request.QueryString;
+
+            _logger.LogWarning($"{DateTime.UtcNow}: {calledUrl}");
 
             using (_longRunningProcessAssertionCache.UseKey(HttpContext, key))
             {
                 var result = await _tokenAcquisition.GetAuthenticationResultForUserAsync(new string[] { "user.read" }).ConfigureAwait(false); // for testing OBO
 
-                _logger.LogWarning($"OBO token acquired from {result.AuthenticationResultMetadata.TokenSource}");
+                _logger.LogWarning($"OBO token acquired from {result.AuthenticationResultMetadata.TokenSource} expires {result.ExpiresOn.UtcDateTime}");
+
 
                 // For breakpoint
                 if (result.AuthenticationResultMetadata.TokenSource == Microsoft.Identity.Client.TokenSource.IdentityProvider)

--- a/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/TodoListController.cs
+++ b/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/TodoListController.cs
@@ -83,7 +83,7 @@ namespace TodoListService.Controllers
                 HttpClient httpClient = new HttpClient();
                 
                 var message = await httpClient.GetAsync(url);
-            }, null, 1000, 1000 * 60 * 10);
+            }, null, 1000, 1000 * 60 * 1);  // Callback every minute
         }
 
 


### PR DESCRIPTION

Logging every minute
More Logging in the callback:
- display the  URL to call the callback
- display the expiry of the OBO token