### PR TITLE
use cache expiry

### DIFF
--- a/src/Microsoft.Identity.Web/TokenCacheProviders/CacheSerializerHints.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/CacheSerializerHints.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders
@@ -14,5 +15,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// CancellationToken enabling cooperative cancellation between threads, thread pool, or Task objects.
         /// </summary>
         public CancellationToken CancellationToken { get; set; }
+
+        /// <summary>
+        /// Suggested cache expiry based on the in-coming token. Use to optimize cache eviction
+        /// with the app token cache.
+        /// </summary>
+        public DateTimeOffset? SuggestedCacheExpiry { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheProvider.cs
@@ -73,9 +73,30 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         /// <returns>A <see cref="Task"/> that completes when a write operation has completed.</returns>
         protected override Task WriteCacheBytesAsync(string cacheKey, byte[] bytes)
         {
+            return WriteCacheBytesAsync(cacheKey, bytes, new CacheSerializerHints());
+        }
+
+        /// <summary>
+        /// Writes a token cache blob to the serialization cache (identified by its key).
+        /// </summary>
+        /// <param name="cacheKey">Token cache key.</param>
+        /// <param name="bytes">Bytes to write.</param>
+        /// <param name="cacheSerializerHints">Hints for the cache serialization implementation optimization.</param>
+        /// <returns>A <see cref="Task"/> that completes when a write operation has completed.</returns>
+        protected override Task WriteCacheBytesAsync(
+            string cacheKey,
+            byte[] bytes,
+            CacheSerializerHints cacheSerializerHints)
+        {
+            TimeSpan? cacheExpiry = null;
+            if (cacheSerializerHints != null && cacheSerializerHints?.SuggestedCacheExpiry != null)
+            {
+                cacheExpiry = cacheSerializerHints.SuggestedCacheExpiry.Value.UtcDateTime - DateTime.UtcNow;
+            }
+
             MemoryCacheEntryOptions memoryCacheEntryOptions = new MemoryCacheEntryOptions()
             {
-                AbsoluteExpirationRelativeToNow = _cacheOptions.AbsoluteExpirationRelativeToNow,
+                AbsoluteExpirationRelativeToNow = cacheExpiry ?? _cacheOptions.AbsoluteExpirationRelativeToNow,
                 Size = bytes?.Length,
             };
 

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/MsalAbstractTokenCacheProvider.cs
@@ -66,10 +66,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
             }
         }
 
-        private static CacheSerializerHints CreateHintsFromArgs(TokenCacheNotificationArgs args)
-        {
-            return new CacheSerializerHints { CancellationToken = args.CancellationToken };
-        }
+        private static CacheSerializerHints CreateHintsFromArgs(TokenCacheNotificationArgs args) => new CacheSerializerHints { CancellationToken = args.CancellationToken, SuggestedCacheExpiry = args.SuggestedCacheExpiry };
 
         private async Task OnBeforeAccessAsync(TokenCacheNotificationArgs args)
         {


### PR DESCRIPTION
#1304 
tested w/web app calls web API w/redis, so the cache key is null always.