### PR TITLE
Uses a distributed cache for long running processes

### DIFF
--- a/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/CallbackController.cs
+++ b/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/CallbackController.cs
@@ -1,21 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web;
-using Microsoft.Identity.Web.Resource;
-using System;
-using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
-using System.Net.Http;
-using System.Security.Claims;
-using System.Threading;
-using System.Threading.Tasks;
-using TodoListService.Models;
 
 namespace TodoListService.Controllers
 {
@@ -51,9 +43,11 @@ namespace TodoListService.Controllers
 
             _logger.LogWarning($"{DateTime.UtcNow}: {calledUrl}");
 
-            using (_longRunningProcessAssertionCache.UseKey(HttpContext, key))
+            using (await _longRunningProcessAssertionCache.UseKey(HttpContext, key))
             {
-                var result = await _tokenAcquisition.GetAuthenticationResultForUserAsync(new string[] { "user.read" }).ConfigureAwait(false); // for testing OBO
+                var result = await _tokenAcquisition.GetAuthenticationResultForUserAsync(
+                    new string[] { "user.read" })
+                    .ConfigureAwait(false); // for testing OBO
 
                 _logger.LogWarning($"OBO token acquired from {result.AuthenticationResultMetadata.TokenSource} expires {result.ExpiresOn.UtcDateTime}");
 

--- a/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/ILongRunningProcessContextFactory.cs
+++ b/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/ILongRunningProcessContextFactory.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.IdentityModel.Tokens.Jwt;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace TodoListService
 {
     public interface ILongRunningProcessContextFactory
     {
-        string CreateKey(HttpContext http);
-        LongRunningProcessContext UseKey(HttpContext httpContext, string key);
+        Task<string> CreateKey(HttpContext http, string keyHint = null);
+        Task<LongRunningProcessContext> UseKey(HttpContext httpContext, string key);
     }
 }

--- a/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/LongRunningProcessContextFactory.cs
+++ b/tests/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/LongRunningProcessContextFactory.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
 
 namespace TodoListService
 {
@@ -24,14 +24,24 @@ namespace TodoListService
         /// Get a key associated with the current incoming token
         /// </summary>
         /// <param name="httpContext">Http context in which the controller action is running</param>
+        /// <param name="keyHint">Hint for the key you want to use.</param>
         /// <returns>A unique string repesenting the incoming token to the web API. This
         /// key will be used in the future to retrieve the incoming token even if it has expired therefore
         /// enabling getting an OBO token.</returns>
-        public string CreateKey(HttpContext httpContext)
+        public async Task<string> CreateKey(HttpContext httpContext, string keyHint = null)
         {
             JwtSecurityToken token = httpContext.Items["JwtSecurityTokenUsedToCallWebAPI"] as JwtSecurityToken;
-            string key = Guid.NewGuid().ToString();
-            privateAssertionOfKey.TryAdd(key, token);
+            string key = keyHint ?? Guid.NewGuid().ToString();
+
+            IDistributedCache distributedCache = httpContext.RequestServices.GetService(typeof(IDistributedCache)) as IDistributedCache;
+            if (distributedCache != null)
+            {
+                await distributedCache.SetStringAsync(key, token.RawData);
+            }
+            else
+            {
+                privateAssertionOfKey.TryAdd(key, token);
+            }
             return key;
         }
 
@@ -40,12 +50,24 @@ namespace TodoListService
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        public LongRunningProcessContext UseKey(HttpContext httpContext, string key)
+        public async Task<LongRunningProcessContext> UseKey(HttpContext httpContext, string key)
         {
-            JwtSecurityToken token = privateAssertionOfKey[key];
+
+            IDistributedCache distributedCache = httpContext.RequestServices.GetService(typeof(IDistributedCache)) as IDistributedCache;
+            JwtSecurityToken token;
+            if (distributedCache != null)
+            {
+                string rawToken = await distributedCache.GetStringAsync(key);
+                token = new JwtSecurityToken(rawToken);
+            }
+            else
+            {
+                token = privateAssertionOfKey[key];
+            }
             return new LongRunningProcessContext(httpContext, token);
         }
-
+        
+        // Fallback: in memory
         private IDictionary<string, JwtSecurityToken> privateAssertionOfKey = new Dictionary<string, JwtSecurityToken>();
     }
 }

--- a/tests/WebAppCallsWebApiCallsGraph/TodoListService/Properties/launchSettings.json
+++ b/tests/WebAppCallsWebApiCallsGraph/TodoListService/Properties/launchSettings.json
@@ -23,7 +23,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:1040/"
+      "applicationUrl": "https://localhost:44351/"
     }
   }
 }

--- a/tests/WebAppCallsWebApiCallsGraph/TodoListService/appsettings.json
+++ b/tests/WebAppCallsWebApiCallsGraph/TodoListService/appsettings.json
@@ -24,13 +24,13 @@
             }
         ]
     },
-    "Kestrel": {
-        "Endpoints": {
-            "Http": {
-                "Url": "http://localhost:44351"
-            }
-        }
-    },
+    //"Kestrel": {
+    //    "Endpoints": {
+    //        "Http": {
+    //            "Url": "http://localhost:44351"
+    //        }
+    //    }
+    //},
     "CalledApi": {
         /*
      'CalledApiScopes' contains space separated scopes of the Web API you want to call. This can be:


### PR DESCRIPTION
This PR uses, when available, a IDistributedCache to store the mapping between the keys
of the long running processes and the tokens to use to
call OBO

Also fixes the fact that we could not start the Kestrel
apps (only IIS) for the web API