### PR TITLE
fix authorization header used for GraphClientService requests

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityAuthenticationMessageHandlerTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityAuthenticationMessageHandlerTests.cs
@@ -1,19 +1,19 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Web.Test.Common;
-
 using NSubstitute;
-
 using Xunit;
 
 namespace Microsoft.Identity.Web.Test


### PR DESCRIPTION
We want GraphService client to support Pop.
#1355 