### PR TITLE
Fixes a KeyNotFoundException when calling WithAppOnly(), WithScopes()

### DIFF
--- a/src/Microsoft.Identity.Web.MicrosoftGraph/BaseRequestExtensions.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/BaseRequestExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Web
 
         private static T SetParameter<T>(T baseRequest, Action<TokenAcquisitionAuthenticationProviderOption> action) where T : IBaseRequest
         {
-            string authHandlerOptionKey = typeof(AuthenticationHandlerOption).ToString();
+            string authHandlerOptionKey = typeof(AuthenticationHandlerOption).Name;
             AuthenticationHandlerOption authHandlerOptions = baseRequest.MiddlewareOptions[authHandlerOptionKey] as AuthenticationHandlerOption ?? new AuthenticationHandlerOption();
             TokenAcquisitionAuthenticationProviderOption msalAuthProviderOption = authHandlerOptions?.AuthenticationProviderOption as TokenAcquisitionAuthenticationProviderOption ?? new TokenAcquisitionAuthenticationProviderOption();
 


### PR DESCRIPTION
Using Microsoft Graph Client, calling WithAppOnly() or WithScopes() results in a KeyNotFoundException. In SetParameter(), the key is typeof(AuthenticationHandlerOption).ToString() which results in the name being set as "Microsoft.Graph.AuthenticationHandlerOption" while the value is actually present as "AuthenticationHandlerOption". This change retrieves the Name property of the Type which will always return only the class name which will be consistent with the name that is present in the dictionary.