### PR TITLE
Avoid exception: An item with the same key has already been added. Key: MicrosoftIdentityError

### DIFF
--- a/src/Microsoft.Identity.Web/TempDataLoginErrorAccessor.cs
+++ b/src/Microsoft.Identity.Web/TempDataLoginErrorAccessor.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Web
             {
                 _tempData = _factory.GetTempData(context);
 
-                _tempData.Add(Name, message);
+                _tempData[Name] = message;
                 _tempData.Save();
             }
         }


### PR DESCRIPTION
This exception occurs sometimes when there are errors during login. It's not always the case but perhaps something to do with Temp Data not being cleared during debugging/testing and restarting. In any case, it's easily solved by just setting the temp data value instead of adding it.

Update: I've replaced the `ILoginErrorAccessor` with my own just see how this is caused and it's not due to Temp Data not being cleared. It ends up being called twice if you accidentally redirect to the same oicd handler address that is handling it - then the same key is added twice. Obviously not common and shouldn't actually occur (oops!) but still can be avoided by not using "Set"

Stack trace

```
ArgumentException: An item with the same key has already been added. Key: MicrosoftIdentityError
System.Collections.Generic.Dictionary<TKey, TValue>.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
System.Collections.Generic.Dictionary<TKey, TValue>.Add(TKey key, TValue value)
Microsoft.AspNetCore.Mvc.ViewFeatures.TempDataDictionary.Add(string key, object value)
Microsoft.Identity.Web.TempDataLoginErrorAccessor.SetMessage(HttpContext context, string message)
Microsoft.Identity.Web.AzureADB2COpenIDConnectEventHandlers.OnRemoteFailure(RemoteFailureContext context)
Microsoft.Identity.Web.MicrosoftIdentityWebAppAuthenticationBuilderExtensions+<>c__DisplayClass5_2+<<AddMicrosoftIdentityWebAppInternal>b__5>d.MoveNext()
```