### PR TITLE
Fix for issue 929

### DIFF
--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilder.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilder.cs
@@ -111,7 +111,6 @@ namespace Microsoft.Identity.Web
                     {
                         context.HttpContext.StoreTokenUsedToCallWebAPI(context.SecurityToken as JwtSecurityToken);
                         await onTokenValidatedHandler(context).ConfigureAwait(false);
-                        context.Success();
                     };
                 });
         }


### PR DESCRIPTION
Removed context.Success() so that token is also available in ASP.NET Core.