### PR TITLE
update to msal4.37

### DIFF
--- a/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.TokenCache.csproj
+++ b/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.TokenCache.csproj
@@ -109,7 +109,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.36.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
 
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -2320,7 +2320,7 @@
             <param name="application"><see cref="T:Microsoft.Identity.Client.IConfidentialClientApplication"/>.</param>
             <param name="claimsPrincipal">Claims principal for the user on behalf of whom to get a token.</param>
             <param name="scopes">Scopes for the downstream API to call.</param>
-            <param name="authority">(optional) Authority based on a specific tenant for which to acquire a token to access the scopes
+            <param name="tenantId">(optional) TenantID based on a specific tenant for which to acquire a token to access the scopes
             on behalf of the user described in the claimsPrincipal.</param>
             <param name="mergedOptions">Merged options.</param>
             <param name="userFlow">Azure AD B2C user flow to target.</param>
@@ -2334,7 +2334,7 @@
             <param name="account">User IAccount for which to acquire a token.
             See <see cref="P:Microsoft.Identity.Client.AccountId.Identifier"/>.</param>
             <param name="scopes">Scopes for the downstream API to call.</param>
-            <param name="authority">Authority based on a specific tenant for which to acquire a token to access the scopes
+            <param name="tenantId">TenantID based on a specific tenant for which to acquire a token to access the scopes
             on behalf of the user.</param>
             <param name="mergedOptions">Merged options.</param>
             <param name="userFlow">Azure AD B2C user flow.</param>

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -54,48 +54,6 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Theory]
-        [InlineData(TestConstants.GuestTenantId)]
-        [InlineData(TestConstants.HomeTenantId)]
-        [InlineData(null)]
-        [InlineData("")]
-        public void VerifyCorrectAuthorityUsedInTokenAcquisitionTests(string tenant)
-        {
-            _microsoftIdentityOptionsMonitor = new TestOptionsMonitor<MicrosoftIdentityOptions>(new MicrosoftIdentityOptions
-            {
-                Authority = TestConstants.AuthorityCommonTenant,
-                ClientId = TestConstants.ConfidentialClientId,
-                CallbackPath = string.Empty,
-            });
-
-            _applicationOptionsMonitor = new TestOptionsMonitor<ConfidentialClientApplicationOptions>(new ConfidentialClientApplicationOptions
-            {
-                Instance = TestConstants.AadInstance,
-                ClientId = TestConstants.ConfidentialClientId,
-                ClientSecret = TestConstants.ClientSecret,
-            });
-
-            BuildTheRequiredServices();
-            InitializeTokenAcquisitionObjects();
-            IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
-                 .CreateWithApplicationOptions(_applicationOptionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme))
-                 .WithAuthority(TestConstants.AuthorityCommonTenant).Build();
-
-            if (!string.IsNullOrEmpty(tenant))
-            {
-                Assert.Equal(
-                    string.Format(
-                        CultureInfo.InvariantCulture, "{0}/{1}/", TestConstants.AadInstance, tenant),
-                    _tokenAcquisition.CreateAuthorityBasedOnTenantIfProvided(
-                        app,
-                        tenant));
-            }
-            else
-            {
-                Assert.Equal(app.Authority, _tokenAcquisition.CreateAuthorityBasedOnTenantIfProvided(app, tenant));
-            }
-        }
-
-        [Theory]
         [InlineData(JwtBearerDefaults.AuthenticationScheme)]
         [InlineData(OpenIdConnectDefaults.AuthenticationScheme)]
         [InlineData(null)]

--- a/tools/GenerateMergeOptionsMethods/GenerateMergeOptionsMethods.csproj
+++ b/tools/GenerateMergeOptionsMethods/GenerateMergeOptionsMethods.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.36.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- use static cache options (same as the -preview version)
- use .WithTenantId on AT calls