### PR TITLE
Remove Outdated Comment on TokenDecryptionCertificates

### DIFF
--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1541,7 +1541,6 @@
         <member name="P:Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCertificates">
             <summary>
             Description of the certificates used to decrypt an encrypted token in a web API.
-            For the moment only the first certificate is considered.
             </summary>
             <example> An example in the appsetting.json:
             <code>

--- a/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web/MicrosoftIdentityOptions.cs
@@ -93,7 +93,6 @@ namespace Microsoft.Identity.Web
 
         /// <summary>
         /// Description of the certificates used to decrypt an encrypted token in a web API.
-        /// For the moment only the first certificate is considered.
         /// </summary>
         /// <example> An example in the appsetting.json:
         /// <code>


### PR DESCRIPTION
There is a comment on the public class MicrosoftIdentityOptions.cs which indicates only the first certificate in the set is considered.  Reading through the code as well as looking over historical PRs, it appears this limitation was resolved.

https://github.com/AzureAD/microsoft-identity-web/issues/905

Correcting comment to save others from the same investigation.