### PR TITLE
fix l2 cache expiry

### DIFF
--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.Logger.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.Logger.cs
@@ -58,12 +58,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                     LoggingEventId.MemoryCacheRead,
                     "[MsIdWeb] {CacheType}: {Operation} cacheKey {CacheKey} cache size {Size} ");
 
-            private static readonly Action<ILogger, string, string, Exception?> s_l1CacheNegativeExpiry =
-                LoggerMessage.Define<string, string>(
-                    LogLevel.Debug,
-                    LoggingEventId.MemoryCacheNegativeExpiry,
-                    "[MsIdWeb] {CacheType}: {Operation} The TokenCacheNotificationArgs.SuggestedCacheExpiry from MSAL was negative. ");
-
             private static readonly Action<ILogger, string, string, int, Exception?> s_l1CacheCount =
                 LoggerMessage.Define<string, string, int>(
                     LogLevel.Debug,
@@ -97,23 +91,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                     operation,
                     cacheKey,
                     cacheSize,
-                    ex);
-
-            /// <summary>
-            /// Memory cache negative expiry.
-            /// </summary>
-            /// <param name="logger">ILogger.</param>
-            /// <param name="cacheType">Distributed or Memory.</param>
-            /// <param name="operation">Cache operation (Read, Write, etc...).</param>
-            /// <param name="ex">Exception.</param>
-            public static void MemoryCacheNegativeExpiry(
-                ILogger logger,
-                string cacheType,
-                string operation,
-                Exception? ex) => s_l1CacheNegativeExpiry(
-                    logger,
-                    cacheType,
-                    operation,
                     ex);
 
             /// <summary>

--- a/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.xml
@@ -130,15 +130,6 @@
             <param name="cacheSize">Cache size in bytes, or 0 if empty.</param>
             <param name="ex">Exception.</param>
         </member>
-        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.Logger.MemoryCacheNegativeExpiry(Microsoft.Extensions.Logging.ILogger,System.String,System.String,System.Exception)">
-            <summary>
-            Memory cache negative expiry.
-            </summary>
-            <param name="logger">ILogger.</param>
-            <param name="cacheType">Distributed or Memory.</param>
-            <param name="operation">Cache operation (Read, Write, etc...).</param>
-            <param name="ex">Exception.</param>
-        </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.Distributed.MsalDistributedTokenCacheAdapter.Logger.MemoryCacheRemove(Microsoft.Extensions.Logging.ILogger,System.String,System.String,System.String,System.Exception)">
             <summary>
             Memory cache remove.

--- a/src/Microsoft.Identity.Web.TokenCache/TokenCacheLoggingEventId.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/TokenCacheLoggingEventId.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Identity.Web
         public static readonly EventId MemoryCacheRead = new EventId(106, "MemoryCacheRead");
         public static readonly EventId MemoryCacheCount = new EventId(107, "MemoryCacheCount");
         public static readonly EventId BackPropagateL2toL1 = new EventId(108, "BackPropagateL2toL1");
-        public static readonly EventId MemoryCacheNegativeExpiry = new EventId(109, "MemoryCacheNegativeExpiry");
 #pragma warning restore IDE1006 // Naming Styles
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
@@ -10,13 +10,23 @@ namespace Microsoft.Identity.Web.Test
 {
     public class TestDistributedCache : IDistributedCache
     {
-        public readonly ConcurrentDictionary<string, byte[]> dict = new ConcurrentDictionary<string, byte[]>();
+        internal readonly ConcurrentDictionary<string, Entry> _dict = new ConcurrentDictionary<string, Entry>();
 
         public byte[] Get(string key)
         {
-            if (dict.TryGetValue(key, out var value))
+            if (_dict.TryGetValue(key, out var value))
             {
-                return dict[key];
+                return _dict[key].Value;
+            }
+
+            return null;
+        }
+
+        public DistributedCacheEntryOptions GetDistributedCacheEntryOptions(string key)
+        {
+            if (_dict.TryGetValue(key, out var value))
+            {
+                return _dict[key].DistributedCacheEntryOptions;
             }
 
             return null;
@@ -40,7 +50,7 @@ namespace Microsoft.Identity.Web.Test
 
         public void Remove(string key)
         {
-            dict.TryRemove(key, out var _);
+            _dict.TryRemove(key, out var _);
         }
 
         public Task RemoveAsync(string key, CancellationToken token = default)
@@ -51,13 +61,25 @@ namespace Microsoft.Identity.Web.Test
 
         public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
         {
-            dict[key] = value;
+            _dict[key] = new Entry(value, options);
         }
 
         public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
         {
             Set(key, value, options);
             return Task.CompletedTask;
+        }
+
+        internal class Entry
+        {
+            public byte[] Value { get; set; }
+            public DistributedCacheEntryOptions DistributedCacheEntryOptions { get; set; }
+
+            public Entry(byte[] value, DistributedCacheEntryOptions options)
+            {
+                Value = value;
+                DistributedCacheEntryOptions = options;
+            }
         }
     }
 }


### PR DESCRIPTION
ignore branch name, was from another investigation.

have tested w/redis cache manually as well.

#1566 