### PR TITLE
add fire and forget to L2 when L1 is in use

### DIFF
--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// <returns>A <see cref="Task"/> that completes when key removal has completed.</returns>
         protected override async Task RemoveKeyAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
         {
-            string remove = "Remove";
+            const string remove = "Remove";
 
             if (_memoryCache != null)
             {
@@ -151,7 +151,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// (account or app).</returns>
         protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
         {
-            string read = "Read";
+            const string read = "Read";
             byte[]? result = null;
 
             if (_memoryCache != null)
@@ -231,7 +231,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             byte[] bytes,
             CacheSerializerHints cacheSerializerHints)
         {
-            string write = "Write";
+            const string write = "Write";
 
             DateTimeOffset? cacheExpiry = cacheSerializerHints?.SuggestedCacheExpiry;
 
@@ -263,7 +263,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                 SlidingExpiration = _distributedCacheOptions.SlidingExpiration,
             };
 
-            if (_distributedCacheOptions.DisableL1Cache)
+            if (_distributedCacheOptions.DisableL1Cache || !_distributedCacheOptions.EnableAsyncL2Write)
             {
                 await L2OperationWithRetryOnFailureAsync(
                     write,
@@ -276,15 +276,15 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             }
             else
             {
-               _ = Task.Run(async () => await
-                L2OperationWithRetryOnFailureAsync(
-                write,
-                (cacheKey) => _distributedCache.SetAsync(
-                    cacheKey,
-                    bytes,
-                    distributedCacheEntryOptions,
-                    cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
-                cacheKey).Measure().ConfigureAwait(false));
+                _ = Task.Run(async () => await
+                 L2OperationWithRetryOnFailureAsync(
+                 write,
+                 (cacheKey) => _distributedCache.SetAsync(
+                     cacheKey,
+                     bytes,
+                     distributedCacheEntryOptions,
+                     cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
+                 cacheKey).Measure().ConfigureAwait(false));
             }
         }
 

--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapterOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapterOptions.cs
@@ -53,5 +53,13 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// </summary>
         /// The default is <c>false.</c>
         public bool DisableL1Cache { get; set; }
+
+        /// <summary>
+        /// Enable writing to the L2 cache to be async (fire and forget).
+        /// This improves performance as the MSAL.NET will not have to wait
+        /// for the write to complete.
+        /// </summary>
+        /// The default is <c>false.</c>
+        public bool EnableAsyncL2Write { get; set; }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -35,10 +35,13 @@ namespace Microsoft.Identity.Web.Test
                 _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>());
         }
 
-        [Fact]
-        public async Task WriteCache_WritesInL1L2_TestAsync()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WriteCache_WritesInL1L2_TestAsync(bool enableAsyncL2Write)
         {
             // Arrange
+            _provider.GetService<IOptions<MsalDistributedTokenCacheAdapterOptions>>().Value.EnableAsyncL2Write = enableAsyncL2Write;
             byte[] cache = new byte[3];
             AssertCacheValues(_testCacheAdapter);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Identity.Web.Test
 
             // Assert
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
+            await Task.Delay(1).ConfigureAwait(false); // needed for L2 fire&forget
             Assert.Single(L2Cache._dict);
         }
 
@@ -60,6 +61,7 @@ namespace Microsoft.Identity.Web.Test
 
             // Assert
             Assert.Null(_testCacheAdapter._memoryCache.Get(DefaultCacheKey));
+
             await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
         }
@@ -149,6 +151,7 @@ namespace Microsoft.Identity.Web.Test
 
             // Assert
             Assert.Equal(memoryCacheExpectedCount, _testCacheAdapter._memoryCache.Count);
+            await Task.Delay(1).ConfigureAwait(false); // needed for L2 fire&forget
             Assert.Single(L2Cache._dict);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -45,11 +45,12 @@ namespace Microsoft.Identity.Web.Test
             Assert.Empty(L2Cache._dict);
 
             // Act
+            TestDistributedCache.resetEvent.Reset();
             await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache).ConfigureAwait(false);
 
             // Assert
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
-            await Task.Delay(1).ConfigureAwait(false); // needed for L2 fire&forget
+            TestDistributedCache.resetEvent.Wait();
             Assert.Single(L2Cache._dict);
         }
 
@@ -147,11 +148,12 @@ namespace Microsoft.Identity.Web.Test
             cacheSerializerHints.SuggestedCacheExpiry = dateTimeOffset;
 
             // Act
+            TestDistributedCache.resetEvent.Reset();
             await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache, cacheSerializerHints).ConfigureAwait(false);
 
             // Assert
             Assert.Equal(memoryCacheExpectedCount, _testCacheAdapter._memoryCache.Count);
-            await Task.Delay(10).ConfigureAwait(false); // needed for L2 fire&forget
+            TestDistributedCache.resetEvent.Wait();
             Assert.Single(L2Cache._dict);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Identity.Web.Test
             Assert.Empty(L2Cache._dict);
 
             // Act
-            TestDistributedCache.resetEvent.Reset();
+            TestDistributedCache.ResetEvent.Reset();
             await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache).ConfigureAwait(false);
 
             // Assert
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
-            TestDistributedCache.resetEvent.Wait();
+            TestDistributedCache.ResetEvent.Wait();
             Assert.Single(L2Cache._dict);
         }
 
@@ -151,12 +151,12 @@ namespace Microsoft.Identity.Web.Test
             cacheSerializerHints.SuggestedCacheExpiry = dateTimeOffset;
 
             // Act
-            TestDistributedCache.resetEvent.Reset();
+            TestDistributedCache.ResetEvent.Reset();
             await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache, cacheSerializerHints).ConfigureAwait(false);
 
             // Assert
             Assert.Equal(memoryCacheExpectedCount, _testCacheAdapter._memoryCache.Count);
-            TestDistributedCache.resetEvent.Wait();
+            TestDistributedCache.ResetEvent.Wait();
             Assert.Single(L2Cache._dict);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Identity.Web.Test
 
             // Assert
             Assert.Equal(memoryCacheExpectedCount, _testCacheAdapter._memoryCache.Count);
-            await Task.Delay(1).ConfigureAwait(false); // needed for L2 fire&forget
+            await Task.Delay(10).ConfigureAwait(false); // needed for L2 fire&forget
             Assert.Single(L2Cache._dict);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Web.Test
     public class TestDistributedCache : IDistributedCache
     {
         internal readonly ConcurrentDictionary<string, Entry> _dict = new ConcurrentDictionary<string, Entry>();
-        internal static ManualResetEventSlim resetEvent { get; set; } = new ManualResetEventSlim(initialState: false);
+        internal static ManualResetEventSlim ResetEvent { get; set; } = new ManualResetEventSlim(initialState: false);
 
         public byte[] Get(string key)
         {
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Web.Test
         public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
         {
             _dict[key] = new Entry(value, options);
-            resetEvent.Set();
+            ResetEvent.Set();
         }
 
         public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)

--- a/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Identity.Web.Test
     public class TestDistributedCache : IDistributedCache
     {
         internal readonly ConcurrentDictionary<string, Entry> _dict = new ConcurrentDictionary<string, Entry>();
+        internal static ManualResetEventSlim resetEvent { get; set; } = new ManualResetEventSlim(initialState: false);
 
         public byte[] Get(string key)
         {
@@ -62,6 +63,7 @@ namespace Microsoft.Identity.Web.Test
         public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
         {
             _dict[key] = new Entry(value, options);
+            resetEvent.Set();
         }
 
         public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)


### PR DESCRIPTION
#1047 

in one sample, difference in write in one case was 10 ms vs 106 ms before fix.