### PR TITLE
fix user assigned managed identity

### DIFF
--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Identity.Web
                 ccaOptionsMonitor?.Get(authenticationScheme);
             }
 
+            DefaultCertificateLoader.UserAssignedManagedIdentityClientId = mergedOptions.UserAssignedManagedIdentityClientId;
             return mergedOptions;
         }
 

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -218,6 +218,7 @@ namespace Microsoft.Identity.Web
                     // If you provide a token decryption certificate, it will be used to decrypt the token
                     if (mergedOptions.TokenDecryptionCertificates != null)
                     {
+                        DefaultCertificateLoader.UserAssignedManagedIdentityClientId = mergedOptions.UserAssignedManagedIdentityClientId;
                         IEnumerable<X509Certificate2?> certificates = DefaultCertificateLoader.LoadAllCertificates(mergedOptions.TokenDecryptionCertificates);
                         IEnumerable<X509SecurityKey> keys = certificates.Select(c => new X509SecurityKey(c));
                         options.TokenValidationParameters.TokenDecryptionKeys = keys;


### PR DESCRIPTION
Fix for #1598 
The regression happened when implementing the multiple-authentication schemes.