### PR TITLE
fix for handling event handlers in web APIs

### DIFF
--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Identity.Web
             {
                 var ccaOptionsMonitor = _serviceProvider.GetService<IOptionsMonitor<ConfidentialClientApplicationOptions>>();
                 ccaOptionsMonitor?.Get(authenticationScheme);
+                var bearerMonitor = _serviceProvider.GetService<IOptionsMonitor<JwtBearerOptions>>(); // supports event handlers
+                bearerMonitor?.Get(authenticationScheme);
             }
 
             DefaultCertificateLoader.UserAssignedManagedIdentityClientId = mergedOptions.UserAssignedManagedIdentityClientId;

--- a/src/Microsoft.Identity.Web/WebApiExtensions/WebApiBuilders.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/WebApiBuilders.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Web.Internal
                             {
                                 configureConfidentialClientApplicationOptions(ccaOptions);
                                 MergedOptions mergedOptions = mergedOptionsMonitor.Get(authenticationScheme);
-                                configuration.Bind(mergedOptions);
+                                configuration?.Bind(mergedOptions);
                                 MergedOptions.UpdateMergedOptionsFromConfidentialClientApplicationOptions(ccaOptions, mergedOptions);
                             });
 


### PR DESCRIPTION
Fixes https://github.com/AzureAD/microsoft-identity-web/issues/1615
Fixes an issue that when called from an event handler from the web API, the configuration for JwtBearer was not known