### PR TITLE
When deserialization fails, throw a more descriptive error.

### DIFF
--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                                             IOptions<MsalDistributedTokenCacheAdapterOptions> distributedCacheOptions,
                                             ILogger<MsalDistributedTokenCacheAdapter> logger,
                                             IServiceProvider? serviceProvider = null)
-            : base(GetDataProtector(distributedCacheOptions, serviceProvider))
+            : base(GetDataProtector(distributedCacheOptions, serviceProvider), logger)
         {
             if (distributedCacheOptions == null)
             {

--- a/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.xml
@@ -380,6 +380,9 @@
             Token cache provider with default implementation.
             </summary>
             <seealso cref="T:Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider" />
+            <summary>
+            LoggingMessage class for MsalAbstractTokenCacheProvider.
+            </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.#ctor(Microsoft.AspNetCore.DataProtection.IDataProtector)">
             <summary>
@@ -387,6 +390,14 @@
             </summary>
             <param name="dataProtector">Service provider. Can be null, in which case the token cache
             will not be encrypted. See https://aka.ms/ms-id-web/token-cache-encryption.</param>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.#ctor(Microsoft.AspNetCore.DataProtection.IDataProtector,Microsoft.Extensions.Logging.ILogger{Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider})">
+            <summary>
+            Constructor.
+            </summary>
+            <param name="dataProtector">Service provider. Can be null, in which case the token cache
+            will not be encrypted. See https://aka.ms/ms-id-web/token-cache-encryption.</param>
+            <param name="logger">MsalDistributedTokenCacheAdapter logger.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.Initialize(Microsoft.Identity.Client.ITokenCache)">
             <summary>
@@ -470,6 +481,20 @@
             <param name="cacheKey">Cache key.</param>
             <param name="cacheSerializerHints">Hints for the cache serialization implementation optimization.</param>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> that represents a completed remove key operation.</returns>
+        </member>
+        <member name="T:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.Logger">
+            <summary>
+            LoggingMessage class for MsalAbstractTokenCacheProvider.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenCacheProviders.MsalAbstractTokenCacheProvider.Logger.CacheDeserializationError(Microsoft.Extensions.Logging.ILogger,System.String,System.String,System.Exception)">
+            <summary>
+            Cache deserialization error.
+            </summary>
+            <param name="logger">ILogger.</param>
+            <param name="cacheKey">MSAL.NET cache key.</param>
+            <param name="errorMessage">Error message.</param>
+            <param name="ex">Exception.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.TokenCacheProviders.Utility">
             <summary>

--- a/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.Logger.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.Logger.cs
@@ -16,26 +16,29 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// </summary>
         private static class Logger
         {
-            private static readonly Action<ILogger, string, string, Exception> s_cacheDeserializationError =
-                LoggerMessage.Define<string, string>(
+            private static readonly Action<ILogger, string, bool, string, Exception> s_cacheDeserializationError =
+                LoggerMessage.Define<string, bool, string>(
                     LogLevel.Warning,
                     LoggingEventId.DistributedCacheConnectionError,
-                    "[MsIdWeb] Unable to deserialize cache entry. Cache key : {CacheKey} Error message: {ErrorMessage} ");
+                    "[MsIdWeb] Unable to deserialize cache entry. Cache key : {CacheKey}. Encryption enabled: {EncryptionEnabled}. Error message: {ErrorMessage} ");
 
             /// <summary>
             /// Cache deserialization error.
             /// </summary>
             /// <param name="logger">ILogger.</param>
             /// <param name="cacheKey">MSAL.NET cache key.</param>
+            /// <param name="encryptionEnabled">Whether cache is encrypted or not.</param>
             /// <param name="errorMessage">Error message.</param>
             /// <param name="ex">Exception.</param>
             public static void CacheDeserializationError(
                 ILogger logger,
                 string cacheKey,
+                bool encryptionEnabled,
                 string errorMessage,
                 Exception ex) => s_cacheDeserializationError(
                     logger,
                     cacheKey,
+                    encryptionEnabled,
                     errorMessage,
                     ex);
         }

--- a/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.Logger.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.Logger.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Identity.Web.TokenCacheProviders
+{
+    /// <summary>
+    /// LoggingMessage class for MsalAbstractTokenCacheProvider.
+    /// </summary>
+    public abstract partial class MsalAbstractTokenCacheProvider
+    {
+        /// <summary>
+        /// LoggingMessage class for MsalAbstractTokenCacheProvider.
+        /// </summary>
+        private static class Logger
+        {
+            private static readonly Action<ILogger, string, string, Exception> s_cacheDeserializationError =
+                LoggerMessage.Define<string, string>(
+                    LogLevel.Warning,
+                    LoggingEventId.DistributedCacheConnectionError,
+                    "[MsIdWeb] Unable to deserialize cache entry. Cache key : {CacheKey} Error message: {ErrorMessage} ");
+
+            /// <summary>
+            /// Cache deserialization error.
+            /// </summary>
+            /// <param name="logger">ILogger.</param>
+            /// <param name="cacheKey">MSAL.NET cache key.</param>
+            /// <param name="errorMessage">Error message.</param>
+            /// <param name="ex">Exception.</param>
+            public static void CacheDeserializationError(
+                ILogger logger,
+                string cacheKey,
+                string errorMessage,
+                Exception ex) => s_cacheDeserializationError(
+                    logger,
+                    cacheKey,
+                    errorMessage,
+                    ex);
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web.TokenCache/TokenCacheErrorMessage.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/TokenCacheErrorMessage.cs
@@ -6,5 +6,6 @@ namespace Microsoft.Identity.Web
     internal static class TokenCacheErrorMessage
     {
         public const string InitializeAsyncIsObsolete = "IDW10801: Use Initialize instead. See https://aka.ms/ms-id-web/1.9.0. ";
+        public const string ExceptionDeserializingCache = "IDW10802: Exception occurred while deserializing token cache. See https://aka.ms/msal-net-token-cache-serialization general guidance and https://aka.ms/ms-id-web/token-cache-troubleshooting for token cache troubleshooting information.";
     }
 }

--- a/src/Microsoft.Identity.Web.TokenCache/TokenCacheLoggingEventId.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/TokenCacheLoggingEventId.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Identity.Web
         public static readonly EventId MemoryCacheRead = new EventId(106, "MemoryCacheRead");
         public static readonly EventId MemoryCacheCount = new EventId(107, "MemoryCacheCount");
         public static readonly EventId BackPropagateL2toL1 = new EventId(108, "BackPropagateL2toL1");
+        public static readonly EventId CacheDeserializationError = new EventId(109, "CacheDeserializationError");
 #pragma warning restore IDE1006 // Naming Styles
     }
 }

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -42,7 +41,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         public MsalSessionTokenCacheProvider(
             ISession session,
             ILogger<MsalSessionTokenCacheProvider> logger)
-            : base(null)
+            : base(null, logger)
         {
             _session = session;
             _logger = logger;


### PR DESCRIPTION
Fixes #1643.

**Changes**
- Clear the cache instead of throwing an exception when deserialization fails.
- Added logging related code for `MsalAbstractTokenCacheProvider`.

**Testing**
Tested with [WebAppCallsMicrosoftGraph](https://github.com/AzureAD/microsoft-identity-web/tree/master/tests/WebAppCallsMicrosoftGraph). All unit tests pass.