### PR TITLE
[TokenCache] Downgrade dependency version for Microsoft.Extensions on net472

### DIFF
--- a/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.TokenCache.csproj
+++ b/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.TokenCache.csproj
@@ -82,14 +82,14 @@
     <DocumentationFile>Microsoft.Identity.Web.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.8" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />


### PR DESCRIPTION
Fixes #1662

Microsoft.Extensions.* 5.0 removed a component which breaks Kestrel when running on Net Framework.

I'm only adjusting the net472 target because net462 users typically wouldn't be using Kestrel due to some challenges with netstandard packages.