### PR TITLE
Add abstract method to MicrosoftIdentityAuthenticationBaseMessageHandler so subclasses can more easily override

### DIFF
--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/MicrosoftIdentityAppAuthenticationMessageHandler.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/MicrosoftIdentityAppAuthenticationMessageHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web
 {
@@ -30,6 +31,22 @@ namespace Microsoft.Identity.Web
         }
 
         /// <inheritdoc/>
+        protected override async Task<AuthenticationResult> GetTokenAsync(MicrosoftIdentityAuthenticationMessageHandlerOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            return await TokenAcquisition.GetAuthenticationResultForAppAsync(
+                options.Scopes!,
+                options.AuthenticationScheme,
+                options.Tenant,
+                options.TokenAcquisitionOptions)
+                .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             // validate arguments
@@ -41,12 +58,7 @@ namespace Microsoft.Identity.Web
             // authenticate
             var options = GetOptionsForRequest(request);
 
-            var authResult = await TokenAcquisition.GetAuthenticationResultForAppAsync(
-                options.Scopes!,
-                options.AuthenticationScheme,
-                options.Tenant,
-                options.TokenAcquisitionOptions)
-                .ConfigureAwait(false);
+            var authResult = await GetTokenAsync(options).ConfigureAwait(false);
 
             // add or replace authorization header
             if (request.Headers.Contains(Constants.Authorization))

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/MicrosoftIdentityAuthenticationBaseMessageHandler.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/MicrosoftIdentityAuthenticationBaseMessageHandler.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Net.Http;
-
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
 
 namespace Microsoft.Identity.Web
@@ -65,6 +66,13 @@ namespace Microsoft.Identity.Web
 
             return options;
         }
+
+        /// <summary>
+        /// Method to abstract getting the auth token itself. Useful for subclasses to customize token acquisition behavior.
+        /// </summary>
+        /// <param name="options">Token acquisition options</param>
+        /// <returns>The <see cref="AuthenticationResult"/> token.</returns>
+        protected abstract Task<AuthenticationResult> GetTokenAsync(MicrosoftIdentityAuthenticationMessageHandlerOptions options);
 
         private static void CreateProofOfPossessionConfiguration(MicrosoftIdentityAuthenticationMessageHandlerOptions options, Uri apiUri, HttpMethod method)
         {

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/MicrosoftIdentityUserAuthenticationMessageHandler.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/MicrosoftIdentityUserAuthenticationMessageHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web
 {
@@ -35,6 +36,23 @@ namespace Microsoft.Identity.Web
         }
 
         /// <inheritdoc/>
+        protected override async Task<AuthenticationResult> GetTokenAsync(MicrosoftIdentityAuthenticationMessageHandlerOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            return await TokenAcquisition.GetAuthenticationResultForUserAsync(
+                options.GetScopes(),
+                authenticationScheme: options.AuthenticationScheme,
+                tenantId: options.Tenant,
+                userFlow: options.UserFlow,
+                tokenAcquisitionOptions: options.TokenAcquisitionOptions)
+                .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             // validate arguments
@@ -48,17 +66,12 @@ namespace Microsoft.Identity.Web
             var microsoftIdentityOptions = _microsoftIdentityOptions
                 .Get(TokenAcquisition.GetEffectiveAuthenticationScheme(options.AuthenticationScheme));
 
-            var userflow = microsoftIdentityOptions.IsB2C && string.IsNullOrEmpty(options.UserFlow)
-                ? microsoftIdentityOptions.DefaultUserFlow
-                : options.UserFlow;
+            if (microsoftIdentityOptions.IsB2C && string.IsNullOrEmpty(options.UserFlow))
+            {
+                options.UserFlow = microsoftIdentityOptions.DefaultUserFlow;
+            }
 
-            var authResult = await TokenAcquisition.GetAuthenticationResultForUserAsync(
-                options.GetScopes(),
-                authenticationScheme: options.AuthenticationScheme,
-                tenantId: options.Tenant,
-                userFlow: userflow,
-                tokenAcquisitionOptions: options.TokenAcquisitionOptions)
-                .ConfigureAwait(false);
+            var authResult = await GetTokenAsync(options).ConfigureAwait(false);
 
             // add or replace authorization header
             if (request.Headers.Contains(Constants.Authorization))


### PR DESCRIPTION
Add an abstract method `GetToken()` on
`MicrosoftIdentityAuthenticationBaseMessageHandler` in order
to more easily let inheriting implementations to override token
options or acquisition behavior.