### PR TITLE
Return TokenValidatedContext.Fail instead of throwing UnauthorizedAccessException in case of missing Roles / Scopes

### DIFF
--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -2746,6 +2746,16 @@
             Set to true if you want to debug, or just understand the JWT bearer events.</param>
             <returns>The authentication builder to chain.</returns>
         </member>
+        <member name="M:Microsoft.Identity.Web.MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents,System.String,System.Boolean)">
+            <summary>
+            In order to ensure that the Web API only accepts tokens from tenants where it has been consented and provisioned, a token that is missing
+            both Roles and Scopes claims should be rejected. To enforce that rule, add an event handler to the beginning of the
+            <see cref="P:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents.OnTokenValidated"/> handler chain that rejects tokens that don't meet the rules.
+            </summary>
+            <param name="events">The <see cref="T:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents"/> object to modify.</param>
+            <param name="jwtBearerScheme">The JWT bearer scheme name to be used. By default it uses "Bearer".</param>
+            <param name="allowWebApiToBeAuthorizedByACL">If <see langword="true"/>, tokens are not required to have Scopes or Roles.</param>
+        </member>
         <member name="T:Microsoft.Identity.Web.MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration">
             <summary>
             Builder for web API authentication with configuration.

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -2746,7 +2746,7 @@
             Set to true if you want to debug, or just understand the JWT bearer events.</param>
             <returns>The authentication builder to chain.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents,System.String,System.Boolean)">
+        <member name="M:Microsoft.Identity.Web.MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents,System.String)">
             <summary>
             In order to ensure that the Web API only accepts tokens from tenants where it has been consented and provisioned, a token that is missing
             both Roles and Scopes claims should be rejected. To enforce that rule, add an event handler to the beginning of the
@@ -2754,7 +2754,6 @@
             </summary>
             <param name="events">The <see cref="T:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents"/> object to modify.</param>
             <param name="jwtBearerScheme">The JWT bearer scheme name to be used. By default it uses "Bearer".</param>
-            <param name="allowWebApiToBeAuthorizedByACL">If <see langword="true"/>, tokens are not required to have Scopes or Roles.</param>
         </member>
         <member name="T:Microsoft.Identity.Web.MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration">
             <summary>

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -232,7 +232,11 @@ namespace Microsoft.Identity.Web
 
                     // When an access token for our own web API is validated, we add it to MSAL.NET's cache so that it can
                     // be used from the controllers.
-                    ChainOnTokenValidatedEventForClaimsValidation(options.Events, jwtBearerScheme, mergedOptions.AllowWebApiToBeAuthorizedByACL);
+
+                    if (!mergedOptions.AllowWebApiToBeAuthorizedByACL)
+                    {
+                        ChainOnTokenValidatedEventForClaimsValidation(options.Events, jwtBearerScheme);
+                    }
 
                     if (subscribeToJwtBearerMiddlewareDiagnosticsEvents)
                     {
@@ -250,14 +254,12 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="events">The <see cref="JwtBearerEvents"/> object to modify.</param>
         /// <param name="jwtBearerScheme">The JWT bearer scheme name to be used. By default it uses "Bearer".</param>
-        /// <param name="allowWebApiToBeAuthorizedByACL">If <see langword="true"/>, tokens are not required to have Scopes or Roles.</param>
-        internal static void ChainOnTokenValidatedEventForClaimsValidation(JwtBearerEvents events, string jwtBearerScheme, bool allowWebApiToBeAuthorizedByACL)
+        internal static void ChainOnTokenValidatedEventForClaimsValidation(JwtBearerEvents events, string jwtBearerScheme)
         {
             var tokenValidatedHandler = events.OnTokenValidated;
             events.OnTokenValidated = async context =>
             {
-                if (!allowWebApiToBeAuthorizedByACL
-                    && !context!.Principal!.Claims.Any(x => x.Type == ClaimConstants.Scope
+                if (!context!.Principal!.Claims.Any(x => x.Type == ClaimConstants.Scope
                         || x.Type == ClaimConstants.Scp
                         || x.Type == ClaimConstants.Roles
                         || x.Type == ClaimConstants.Role))

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -264,8 +264,7 @@ namespace Microsoft.Identity.Web
                         || x.Type == ClaimConstants.Roles
                         || x.Type == ClaimConstants.Role))
                 {
-                    throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture,
-                        IDWebErrorMessage.NeitherScopeOrRolesClaimFoundInToken, jwtBearerScheme));
+                    context.Fail(string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.NeitherScopeOrRolesClaimFoundInToken, jwtBearerScheme));
                 }
 
                 await tokenValidatedHandler(context).ConfigureAwait(false);

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -248,8 +248,8 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// In order to ensure that the Web API only accepts tokens from tenants where it has been consented and provisioned, a token that is missing
-        /// both Roles and Scopes claims should be rejected. To enforce that rule, add an event handler to the beginning of the
+        /// In order to ensure that the Web API only accepts tokens from tenants where it has been consented and provisioned, a token that
+        /// has neither Roles nor Scopes claims should be rejected. To enforce that rule, add an event handler to the beginning of the
         /// <see cref="JwtBearerEvents.OnTokenValidated"/> handler chain that rejects tokens that don't meet the rules.
         /// </summary>
         /// <param name="events">The <see cref="JwtBearerEvents"/> object to modify.</param>

--- a/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
@@ -31,7 +31,12 @@ namespace Microsoft.Identity.Web.Test.Resource
 
         protected abstract HttpContext CreateHttpContext();
 
-        protected abstract JwtBearerEvents CreateJwtBearerEvents();
+        protected virtual JwtBearerEvents CreateJwtBearerEvents()
+        {
+            var events = new JwtBearerEvents();
+            MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(events, JwtBearerDefaults.AuthenticationScheme);
+            return events;
+        }
     }
 
     public class TokenValidated_MissingScopesAndRoles : JwtBearerEventsClaimsValidationTests
@@ -39,13 +44,6 @@ namespace Microsoft.Identity.Web.Test.Resource
         protected override HttpContext CreateHttpContext()
         {
             return HttpContextUtilities.CreateHttpContext();
-        }
-
-        protected override JwtBearerEvents CreateJwtBearerEvents()
-        {
-            var events = new JwtBearerEvents();
-            MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(events, JwtBearerDefaults.AuthenticationScheme, false);
-            return events;
         }
 
         [Fact]
@@ -63,38 +61,8 @@ namespace Microsoft.Identity.Web.Test.Resource
             return HttpContextUtilities.CreateHttpContext(new[] { "scope" }, new[] { "role" });
         }
 
-        protected override JwtBearerEvents CreateJwtBearerEvents()
-        {
-            var events = new JwtBearerEvents();
-            MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(events, JwtBearerDefaults.AuthenticationScheme, false);
-            return events;
-        }
-
         [Fact]
         public async Task TokenValidated_WithScopesAndRoles_AuthenticationSucceeds()
-        {
-            Assert.True(_tokenContext.Result.Succeeded);
-            await _jwtEvents.TokenValidated(_tokenContext).ConfigureAwait(false);
-            Assert.True(_tokenContext.Result.Succeeded);
-        }
-    }
-
-    public class TokenValidated_WithACLAuthorization : JwtBearerEventsClaimsValidationTests
-    {
-        protected override HttpContext CreateHttpContext()
-        {
-            return HttpContextUtilities.CreateHttpContext();
-        }
-
-        protected override JwtBearerEvents CreateJwtBearerEvents()
-        {
-            var events = new JwtBearerEvents();
-            MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(events, JwtBearerDefaults.AuthenticationScheme, true);
-            return events;
-        }
-
-        [Fact]
-        public async Task TokenValidated_WithACLAuthorization_AuthenticationSucceeds()
         {
             Assert.True(_tokenContext.Result.Succeeded);
             await _jwtEvents.TokenValidated(_tokenContext).ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Web.Test.Common.TestHelpers;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test.Resource
+{
+    public abstract class JwtBearerEventsClaimsValidationTests
+    {
+        protected HttpContext _httpContext;
+        protected JwtBearerOptions _jwtOptions;
+        protected JwtBearerEvents _jwtEvents;
+        protected AuthenticationScheme _authScheme;
+        protected TokenValidatedContext _tokenContext;
+
+        protected JwtBearerEventsClaimsValidationTests()
+        {
+            _httpContext = CreateHttpContext();
+            _jwtOptions = new JwtBearerOptions();
+            _jwtEvents = CreateJwtBearerEvents();
+            _authScheme = new AuthenticationScheme(JwtBearerDefaults.AuthenticationScheme, JwtBearerDefaults.AuthenticationScheme, typeof(JwtBearerHandler));
+            _tokenContext = new TokenValidatedContext(_httpContext, _authScheme, _jwtOptions)
+            {
+                Principal = _httpContext.User,
+            };
+            _tokenContext.Success();
+        }
+
+        protected abstract HttpContext CreateHttpContext();
+
+        protected abstract JwtBearerEvents CreateJwtBearerEvents();
+    }
+
+    public class TokenValidated_MissingScopesAndRoles : JwtBearerEventsClaimsValidationTests
+    {
+        protected override HttpContext CreateHttpContext()
+        {
+            return HttpContextUtilities.CreateHttpContext();
+        }
+
+        protected override JwtBearerEvents CreateJwtBearerEvents()
+        {
+            var events = new JwtBearerEvents();
+            MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(events, JwtBearerDefaults.AuthenticationScheme, false);
+            return events;
+        }
+
+        [Fact]
+        public async Task TokenValidated_MissingScopesAndRoles_AuthenticationFails()
+        {
+            Assert.True(_tokenContext.Result.Succeeded);
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => _jwtEvents.TokenValidated(_tokenContext)).ConfigureAwait(false);
+        }
+    }
+
+    public class TokenValidated_WithScopesAndRoles : JwtBearerEventsClaimsValidationTests
+    {
+        protected override HttpContext CreateHttpContext()
+        {
+            return HttpContextUtilities.CreateHttpContext(new[] { "scope" }, new[] { "role" });
+        }
+
+        protected override JwtBearerEvents CreateJwtBearerEvents()
+        {
+            var events = new JwtBearerEvents();
+            MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(events, JwtBearerDefaults.AuthenticationScheme, false);
+            return events;
+        }
+
+        [Fact]
+        public async Task TokenValidated_WithScopesAndRoles_AuthenticationSucceeds()
+        {
+            Assert.True(_tokenContext.Result.Succeeded);
+            await _jwtEvents.TokenValidated(_tokenContext).ConfigureAwait(false);
+            Assert.True(_tokenContext.Result.Succeeded);
+        }
+    }
+
+    public class TokenValidated_WithACLAuthorization : JwtBearerEventsClaimsValidationTests
+    {
+        protected override HttpContext CreateHttpContext()
+        {
+            return HttpContextUtilities.CreateHttpContext();
+        }
+
+        protected override JwtBearerEvents CreateJwtBearerEvents()
+        {
+            var events = new JwtBearerEvents();
+            MicrosoftIdentityWebApiAuthenticationBuilderExtensions.ChainOnTokenValidatedEventForClaimsValidation(events, JwtBearerDefaults.AuthenticationScheme, true);
+            return events;
+        }
+
+        [Fact]
+        public async Task TokenValidated_WithACLAuthorization_AuthenticationSucceeds()
+        {
+            Assert.True(_tokenContext.Result.Succeeded);
+            await _jwtEvents.TokenValidated(_tokenContext).ConfigureAwait(false);
+            Assert.True(_tokenContext.Result.Succeeded);
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Identity.Web.Test.Resource
         public async Task TokenValidated_MissingScopesAndRoles_AuthenticationFails()
         {
             Assert.True(_tokenContext.Result.Succeeded);
-            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => _jwtEvents.TokenValidated(_tokenContext)).ConfigureAwait(false);
+            await _jwtEvents.TokenValidated(_tokenContext).ConfigureAwait(false);
+            Assert.False(_tokenContext.Result.Succeeded);
         }
     }
 


### PR DESCRIPTION
Today, if a token is valid, but both:

1. Has neither Scopes nor Roles claims
2. Not authorized via ACL

Then the `JwtBearerHandler` will throw an `UnauthorizedAccessException` that looks like this:

```
System.UnauthorizedAccessException: IDW10201: Neither scope or roles claim was found in the bearer token.
  at Microsoft.Identity.Web.MicrosoftIdentityWebApiAuthenticationBuilderExtensions.<>c__DisplayClass3_1.<<AddMicrosoftIdentityWebApiImplementation>b__1>d.MoveNext()
  at Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerHandler.HandleAuthenticateAsync()
  at Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerHandler.HandleAuthenticateAsync()
  at Microsoft.AspNetCore.Authentication.AuthenticationHandler`1.AuthenticateAsync()
  at Microsoft.AspNetCore.Authentication.AuthenticationService.AuthenticateAsync(HttpContext context, String scheme)
  at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
```

which by default results in an unhandled exception in the auth middleware pipeline, which in turn results in a 500 error for the user.
    
While one could make the argument that a 500 is appropriate in this scenario, as the most likely cause is a misconfiguration on the AAD side, similar types of misconfiguration, such as a missing `tid` or `tenantId` claim results in a 401 Unauthorized error.

In order to make this change testable, I did the refactor in three steps, each in its own commit, to make the process easier to follow.

First, I moved the Roles / Scopes validation logic from the registration codepath into a new internal helper method, so that it could be called directly from unit tests. I used the `JwtBearerMiddlewareDiagnosticsTests` as a template.

Second, to simplify the new helper, I moved the `AllowWebApiToBeAuthorizedByACL` check out of the token validation codepath, and instead returned it to the registration codepath. This is both a minor performance win for ACL cases (because it skips the event callback when it isn't needed) and slightly reduces complexity of the helper (by making the conditional simpler), at the expense of making the ACL case difficult to test again. If there's desire to test the ACL case, we can make follow up changes.

Lastly, with the logic in a helper and tests written to validate the behavior, I replace the exception with a call to `TokenValidatedContext.Fail(message)`.

Fixes #1716