### PR TITLE
Create TokenAcquisitionAppTokenCredential.cs

### DIFF
--- a/src/Microsoft.Identity.Web/AzureSdkSupport/TokenAcquisitionAppTokenCredential.cs
+++ b/src/Microsoft.Identity.Web/AzureSdkSupport/TokenAcquisitionAppTokenCredential.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Azure SDK token credential for App tokens based on the ITokenAcquisition service.
+    /// </summary>
+    public class TokenAcquisitionAppTokenCredential : TokenCredential
+    {
+        private ITokenAcquisition _tokenAcquisition;
+
+        /// <summary>
+        /// Constructor from an ITokenAcquisition service.
+        /// </summary>
+        /// <param name="tokenAcquisition">Token acquisition.</param>
+        public TokenAcquisitionAppTokenCredential(ITokenAcquisition tokenAcquisition)
+        {
+            _tokenAcquisition = tokenAcquisition;
+        }
+
+        /// <inheritdoc/>
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            AuthenticationResult result = _tokenAcquisition.GetAuthenticationResultForAppAsync(requestContext.Scopes.First())
+                .GetAwaiter()
+                .GetResult();
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            AuthenticationResult result = await _tokenAcquisition.GetAuthenticationResultForAppAsync(requestContext.Scopes.First()).ConfigureAwait(false);
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+    }
+}


### PR DESCRIPTION
Extends Azure SDK support to include requesting tokens as the app.

This is a copy of TokenAcquisitionTokenCredential.cs with changes to class name and changes to use _tokenAcquisition.GetAuthenticationResultForAppAsync() instead of GetAuthenticationResultForUserAsync().