### PR TITLE
[DRAFT] Write Wilson Logs to ILogger

### DIFF
--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -103,7 +103,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Extensions.AspNetCore" Version="6.16.1-preview-30427231238" />
+    <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="$(IdentityModelVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Extensions.AspNetCore" Version="$(IdentityModelVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="$(IdentityModelVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Validators" Version="$(IdentityModelVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityModelVersion)" />

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -24,7 +24,7 @@
     <PackageReleaseNotes>The release notes are available at https://github.com/AzureAD/microsoft-identity-web/releases and the roadmap at https://github.com/AzureAD/microsoft-identity-web/wiki#roadmap </PackageReleaseNotes>
     <PackageTags>Microsoft Identity Web;Microsoft identity platform;Microsoft.Identity.Web;.NET;ASP.NET Core;Web App;Web API;B2C;Azure Active Directory;AAD;Identity;Authentication;Authorization</PackageTags>
     <ProjectGuid>{FD55C071-48D1-4FE8-8B1D-773E067FEC91}</ProjectGuid>
-    <IdentityModelVersion>6.17.0</IdentityModelVersion>
+    <IdentityModelVersion>6.16.1-preview-30427231238</IdentityModelVersion>
   </PropertyGroup>
   <PropertyGroup Label="Source Link">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -103,6 +103,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Extensions.AspNetCore" Version="6.16.1-preview-30427231238" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="$(IdentityModelVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Validators" Version="$(IdentityModelVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityModelVersion)" />

--- a/tests/WebAppCallsMicrosoftGraph/appsettings.json
+++ b/tests/WebAppCallsMicrosoftGraph/appsettings.json
@@ -1,34 +1,19 @@
 {
-    //"AzureAd": {
-    //    "Instance": "https://login.microsoftonline.com/",
-    //    "Domain": "msidentitytesting.onmicrosofonline.com",
-    //    "TenantId": "7f58f645-c190-4ce5-9de4-e2b7acd2a6ab",
-    //    "ClientId": "56c9a633-236e-45ee-9af1-a53d9811fbd6",
-    //    // To call an API
-    //    //"ClientSecret": "",
-    //    //"EnablePiiLogging": true,
-    //    "CallbackPath": "/signin-oidc",
-    //    "EnableCacheSynchronization": "false",
-    //    "ClientCredentialsUsingManagedIdentity": {
-    //        "IsEnabled": true, // default true
-    //        "ManagedIdentityObjectId": "02c0b640-8e3d-405e-999d-4781f2f0438a"
-    //    }
-    //},
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
         "Domain": "msidentitytesting.onmicrosofonline.com",
         "TenantId": "7f58f645-c190-4ce5-9de4-e2b7acd2a6ab",
         "ClientId": "56c9a633-236e-45ee-9af1-a53d9811fbd6",
         // To call an API
-        "ClientSecret": "1LsUtZPpE=t2a9iYJk5s=tyFuZnKM.e-",
+        //"ClientSecret": "",
         //"EnablePiiLogging": true,
         "CallbackPath": "/signin-oidc",
-        "EnableCacheSynchronization": "false"
-        // "ClientCredentialsUsingManagedIdentity": {
-        //    "IsEnabled": true, // default true
-        //    "ManagedIdentityObjectId": "02c0b640-8e3d-405e-999d-4781f2f0438a"
+        "EnableCacheSynchronization": "false",
+        "ClientCredentialsUsingManagedIdentity": {
+            "IsEnabled": true, // default true
+            "ManagedIdentityObjectId": "02c0b640-8e3d-405e-999d-4781f2f0438a"
+        }
     },
-
     "GraphBeta": {
         "BaseUrl": "https://graph.microsoft.com/beta",
         "Scopes": "user.read"

--- a/tests/WebAppCallsMicrosoftGraph/appsettings.json
+++ b/tests/WebAppCallsMicrosoftGraph/appsettings.json
@@ -1,18 +1,32 @@
 {
+    //"AzureAd": {
+    //    "Instance": "https://login.microsoftonline.com/",
+    //    "Domain": "msidentitytesting.onmicrosofonline.com",
+    //    "TenantId": "7f58f645-c190-4ce5-9de4-e2b7acd2a6ab",
+    //    "ClientId": "56c9a633-236e-45ee-9af1-a53d9811fbd6",
+    //    // To call an API
+    //    //"ClientSecret": "",
+    //    //"EnablePiiLogging": true,
+    //    "CallbackPath": "/signin-oidc",
+    //    "EnableCacheSynchronization": "false",
+    //    "ClientCredentialsUsingManagedIdentity": {
+    //        "IsEnabled": true, // default true
+    //        "ManagedIdentityObjectId": "02c0b640-8e3d-405e-999d-4781f2f0438a"
+    //    }
+    //},
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
         "Domain": "msidentitytesting.onmicrosofonline.com",
         "TenantId": "7f58f645-c190-4ce5-9de4-e2b7acd2a6ab",
         "ClientId": "56c9a633-236e-45ee-9af1-a53d9811fbd6",
         // To call an API
-        //"ClientSecret": "",
+        "ClientSecret": "1LsUtZPpE=t2a9iYJk5s=tyFuZnKM.e-",
         //"EnablePiiLogging": true,
         "CallbackPath": "/signin-oidc",
-        "EnableCacheSynchronization": "false",
-        "ClientCredentialsUsingManagedIdentity": {
-            "IsEnabled": true, // default true
-            "ManagedIdentityObjectId": "02c0b640-8e3d-405e-999d-4781f2f0438a"
-        }
+        "EnableCacheSynchronization": "false"
+        // "ClientCredentialsUsingManagedIdentity": {
+        //    "IsEnabled": true, // default true
+        //    "ManagedIdentityObjectId": "02c0b640-8e3d-405e-999d-4781f2f0438a"
     },
 
     "GraphBeta": {
@@ -25,7 +39,8 @@
             "Default": "Information",
             "Microsoft": "Warning",
             "Microsoft.Hosting.Lifetime": "Information",
-            "Microsoft.Identity.Web": "Information"
+            "Microsoft.Identity": "Debug"
+
         }
     },
     "AllowedHosts": "*"


### PR DESCRIPTION
MicrosoftIdentityWebAppAuthenticationBuilderExtensions was modified to invoke SetIdentityModelLogger which 
- Checks if an ILogger instance was already created and creates one if user configured logging
- Passes the ILogger instance to IdentityModelLoggerAdapter
- Sets the resulting identityLogger on a static property in Wilson

Wilson will then write log messages to identityLogger.

These changes were made so that Wilson, Id.Web and MSAL logs show up in one place when SAL is not in use. 

This is only a Proof-Of-Concept. 