### PR TITLE
add cancellationToken param to DownstreamWebApi methods

### DIFF
--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
@@ -59,6 +59,13 @@ namespace Microsoft.Identity.Web
                 throw new ArgumentException(IDWebErrorMessage.ScopesNotConfiguredInConfigurationOrViaDelegate);
             }
 
+            if (effectiveOptions.TokenAcquisitionOptions == null)
+            {
+                effectiveOptions.TokenAcquisitionOptions = new TokenAcquisitionOptions();
+            }
+
+            effectiveOptions.TokenAcquisitionOptions.CancellationToken = cancellationToken;
+
             MicrosoftIdentityOptions microsoftIdentityOptions = _microsoftIdentityOptionsMonitor
                 .Get(_tokenAcquisition.GetEffectiveAuthenticationScheme(authenticationScheme));
 
@@ -74,16 +81,6 @@ namespace Microsoft.Identity.Web
             else
             {
                 userflow = effectiveOptions.UserFlow;
-            }
-
-            if (cancellationToken != default)
-            {
-                if (effectiveOptions.TokenAcquisitionOptions == null)
-                {
-                    effectiveOptions.TokenAcquisitionOptions = new TokenAcquisitionOptions();
-                }
-
-                effectiveOptions.TokenAcquisitionOptions.CancellationToken = cancellationToken;
             }
 
             AuthenticationResult authResult = await _tokenAcquisition.GetAuthenticationResultForUserAsync(
@@ -173,19 +170,17 @@ namespace Microsoft.Identity.Web
                 throw new ArgumentException(IDWebErrorMessage.ScopesNotConfiguredInConfigurationOrViaDelegate);
             }
 
+            if (effectiveOptions.TokenAcquisitionOptions == null)
+            {
+                effectiveOptions.TokenAcquisitionOptions = new TokenAcquisitionOptions();
+            }
+
+            effectiveOptions.TokenAcquisitionOptions.CancellationToken = cancellationToken;
+
             string apiUrl = effectiveOptions.GetApiUrl();
 
             CreateProofOfPossessionConfiguration(effectiveOptions, apiUrl);
 
-            if (cancellationToken != default)
-            {
-                if (effectiveOptions.TokenAcquisitionOptions == null)
-                {
-                    effectiveOptions.TokenAcquisitionOptions = new TokenAcquisitionOptions();
-                }
-
-                effectiveOptions.TokenAcquisitionOptions.CancellationToken = cancellationToken;
-            }
 
             AuthenticationResult authResult = await _tokenAcquisition.GetAuthenticationResultForAppAsync(
                 effectiveOptions.Scopes,
@@ -243,11 +238,6 @@ namespace Microsoft.Identity.Web
         {
             if (effectiveOptions.IsProofOfPossessionRequest && effectiveOptions.TokenAcquisitionOptions?.PoPConfiguration != null)
             {
-                if (effectiveOptions.TokenAcquisitionOptions == null)
-                {
-                    effectiveOptions.TokenAcquisitionOptions = new TokenAcquisitionOptions();
-                }
-
                 effectiveOptions.TokenAcquisitionOptions.PoPConfiguration = new PoPAuthenticationConfiguration(new Uri(apiUrl))
                 {
                     HttpMethod = effectiveOptions.HttpMethod,

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Identity.Web
             }
             catch
             {
-#if NET5_0_OR_GREATER
+#if DOTNET_50_AND_ABOVE
                 string error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
                 string error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Web
                 throw new HttpRequestException($"{(int)response.StatusCode} {response.StatusCode} {error}");
             }
 
-#if NET5_0_OR_GREATER
+#if DOTNET_50_AND_ABOVE
             string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
             string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiGenericExtensions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiGenericExtensions.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web
@@ -32,6 +33,7 @@ namespace Microsoft.Identity.Web
         /// will find the user from the HttpContext.</param>
         /// <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
         /// if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A strongly typed response from the web API.</returns>
         public static async Task<TOutput?> GetForUserAsync<TOutput>(
             this IDownstreamWebApi downstreamWebApi,
@@ -39,7 +41,8 @@ namespace Microsoft.Identity.Web
             string relativePath,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
             ClaimsPrincipal? user = null,
-            string? authenticationScheme = null)
+            string? authenticationScheme = null,
+            CancellationToken cancellationToken = default)
             where TOutput : class
         {
             if (downstreamWebApi is null)
@@ -52,9 +55,10 @@ namespace Microsoft.Identity.Web
                 authenticationScheme,
                 PrepareOptions(relativePath, downstreamWebApiOptionsOverride, HttpMethod.Get),
                 user,
-                null).ConfigureAwait(false);
+                null,
+                cancellationToken).ConfigureAwait(false);
 
-            return await ConvertToOutput<TOutput>(response).ConfigureAwait(false);
+            return await ConvertToOutput<TOutput>(response, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -77,6 +81,7 @@ namespace Microsoft.Identity.Web
         /// will find the user from the HttpContext.</param>
         /// <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
         /// if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A strongly typed response from the web API.</returns>
         public static async Task<TOutput?> PostForUserAsync<TOutput, TInput>(
             this IDownstreamWebApi downstreamWebApi,
@@ -85,7 +90,8 @@ namespace Microsoft.Identity.Web
             TInput inputData,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
             ClaimsPrincipal? user = null,
-            string? authenticationScheme = null)
+            string? authenticationScheme = null,
+            CancellationToken cancellationToken = default)
             where TOutput : class
         {
             if (downstreamWebApi is null)
@@ -100,9 +106,10 @@ namespace Microsoft.Identity.Web
                authenticationScheme,
                PrepareOptions(relativePath, downstreamWebApiOptionsOverride, HttpMethod.Post),
                user,
-               input).ConfigureAwait(false);
+               input,
+               cancellationToken).ConfigureAwait(false);
 
-            return await ConvertToOutput<TOutput>(response).ConfigureAwait(false);
+            return await ConvertToOutput<TOutput>(response, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -123,6 +130,7 @@ namespace Microsoft.Identity.Web
         /// will find the user from the HttpContext.</param>
         /// <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
         /// if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The value returned by the downstream web API.</returns>
         public static async Task PutForUserAsync<TInput>(
             this IDownstreamWebApi downstreamWebApi,
@@ -131,7 +139,8 @@ namespace Microsoft.Identity.Web
             TInput inputData,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
             ClaimsPrincipal? user = null,
-            string? authenticationScheme = null)
+            string? authenticationScheme = null,
+            CancellationToken cancellationToken = default)
         {
             if (downstreamWebApi is null)
             {
@@ -145,7 +154,8 @@ namespace Microsoft.Identity.Web
               authenticationScheme,
               PrepareOptions(relativePath, downstreamWebApiOptionsOverride, HttpMethod.Put),
               user,
-              input).ConfigureAwait(false);
+              input,
+              cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -168,6 +178,7 @@ namespace Microsoft.Identity.Web
         /// will find the user from the HttpContext.</param>
         /// <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
         /// if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A strongly typed response from the web API.</returns>
         public static async Task<TOutput?> PutForUserAsync<TOutput, TInput>(
             this IDownstreamWebApi downstreamWebApi,
@@ -176,7 +187,8 @@ namespace Microsoft.Identity.Web
             TInput inputData,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
             ClaimsPrincipal? user = null,
-            string? authenticationScheme = null)
+            string? authenticationScheme = null,
+            CancellationToken cancellationToken = default)
             where TOutput : class
         {
             if (downstreamWebApi is null)
@@ -191,9 +203,10 @@ namespace Microsoft.Identity.Web
                authenticationScheme,
                PrepareOptions(relativePath, downstreamWebApiOptionsOverride, HttpMethod.Put),
                user,
-               input).ConfigureAwait(false);
+               input,
+               cancellationToken).ConfigureAwait(false);
 
-            return await ConvertToOutput<TOutput>(response).ConfigureAwait(false);
+            return await ConvertToOutput<TOutput>(response, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -213,13 +226,15 @@ namespace Microsoft.Identity.Web
         /// will find the user from the HttpContext.</param>
         /// <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
         /// if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The value returned by the downstream web API.</returns>
         public static async Task<TOutput?> CallWebApiForUserAsync<TOutput>(
             this IDownstreamWebApi downstreamWebApi,
             string serviceName,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
             ClaimsPrincipal? user = null,
-            string? authenticationScheme = null)
+            string? authenticationScheme = null,
+            CancellationToken cancellationToken = default)
             where TOutput : class
         {
             if (downstreamWebApi is null)
@@ -232,9 +247,10 @@ namespace Microsoft.Identity.Web
               authenticationScheme,
               downstreamWebApiOptionsOverride,
               user,
-              null).ConfigureAwait(false);
+              null,
+              cancellationToken).ConfigureAwait(false);
 
-            return await ConvertToOutput<TOutput>(response).ConfigureAwait(false);
+            return await ConvertToOutput<TOutput>(response, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -254,6 +270,7 @@ namespace Microsoft.Identity.Web
         /// will find the user from the HttpContext.</param>
         /// <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
         /// if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The value returned by the downstream web API.</returns>
         public static async Task GetForUserAsync<TInput>(
             this IDownstreamWebApi downstreamWebApi,
@@ -261,7 +278,8 @@ namespace Microsoft.Identity.Web
             TInput inputData,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
             ClaimsPrincipal? user = null,
-            string? authenticationScheme = null)
+            string? authenticationScheme = null,
+            CancellationToken cancellationToken = default)
         {
             if (downstreamWebApi is null)
             {
@@ -275,7 +293,8 @@ namespace Microsoft.Identity.Web
              authenticationScheme,
              downstreamWebApiOptionsOverride,
              user,
-             input).ConfigureAwait(false);
+             input,
+             cancellationToken).ConfigureAwait(false);
         }
 
         private static StringContent ConvertFromInput<TInput>(TInput input)
@@ -283,7 +302,7 @@ namespace Microsoft.Identity.Web
             return new StringContent(JsonSerializer.Serialize(input), Encoding.UTF8, "application/json");
         }
 
-        private static async Task<TOutput?> ConvertToOutput<TOutput>(HttpResponseMessage response)
+        private static async Task<TOutput?> ConvertToOutput<TOutput>(HttpResponseMessage response, CancellationToken cancellationToken = default)
             where TOutput : class
         {
             try
@@ -292,12 +311,20 @@ namespace Microsoft.Identity.Web
             }
             catch
             {
+#if DOTNET_50_AND_ABOVE
+                string error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
                 string error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
 
                 throw new HttpRequestException($"{(int)response.StatusCode} {response.StatusCode} {error}");
             }
 
+#if DOTNET_50_AND_ABOVE
+            string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
             string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
 
             if (string.IsNullOrWhiteSpace(content))
             {

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/IDownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/IDownstreamWebApi.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net.Http;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web
@@ -28,19 +29,22 @@ namespace Microsoft.Identity.Web
         /// will find the user from the HttpContext.</param>
         /// <param name="content">HTTP context in the case where <see cref="DownstreamWebApiOptions.HttpMethod"/> is
         /// <see cref="HttpMethod.Patch"/>, <see cref="HttpMethod.Post"/>, <see cref="HttpMethod.Put"/>.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An <see cref="HttpResponseMessage"/> that the application will process.</returns>
         public Task<HttpResponseMessage> CallWebApiForUserAsync(
             string serviceName,
             Action<DownstreamWebApiOptions>? calledDownstreamWebApiOptionsOverride = null,
             ClaimsPrincipal? user = null,
-            StringContent? content = null)
+            StringContent? content = null,
+            CancellationToken cancellationToken = default)
         {
             return CallWebApiForUserAsync(
                 serviceName,
                 null,
                 calledDownstreamWebApiOptionsOverride,
                 user,
-                content);
+                content,
+                cancellationToken);
         }
 
         /// <summary>
@@ -60,13 +64,15 @@ namespace Microsoft.Identity.Web
         /// will find the user from the HttpContext.</param>
         /// <param name="content">HTTP context in the case where <see cref="DownstreamWebApiOptions.HttpMethod"/> is
         /// <see cref="HttpMethod.Patch"/>, <see cref="HttpMethod.Post"/>, <see cref="HttpMethod.Put"/>.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An <see cref="HttpResponseMessage"/> that the application will process.</returns>
         Task<HttpResponseMessage> CallWebApiForUserAsync(
             string serviceName,
             string? authenticationScheme,
             Action<DownstreamWebApiOptions>? calledDownstreamWebApiOptionsOverride = null,
             ClaimsPrincipal? user = null,
-            StringContent? content = null);
+            StringContent? content = null,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Calls a downstream web API consuming JSON with some data and returns data.
@@ -83,6 +89,7 @@ namespace Microsoft.Identity.Web
         /// <param name="user">[Optional] Claims representing a user. This is useful in platforms like Blazor
         /// or Azure Signal R, where the HttpContext is not available. In other platforms, the library
         /// will find the user from the HttpContext.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The value returned by the downstream web API.</returns>
         /// <example>
         /// A list method that returns an IEnumerable&lt;MyItem&gt;&gt;.
@@ -118,7 +125,8 @@ namespace Microsoft.Identity.Web
             string serviceName,
             TInput input,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
-            ClaimsPrincipal? user = null)
+            ClaimsPrincipal? user = null,
+            CancellationToken cancellationToken = default)
             where TOutput : class
         {
             return CallWebApiForUserAsync<TInput, TOutput>(
@@ -126,7 +134,8 @@ namespace Microsoft.Identity.Web
                 input,
                 null,
                 downstreamWebApiOptionsOverride,
-                user);
+                user,
+                cancellationToken);
         }
 
         /// <summary>
@@ -146,6 +155,7 @@ namespace Microsoft.Identity.Web
         /// <param name="user">[Optional] Claims representing a user. This is useful in platforms like Blazor
         /// or Azure Signal R, where the HttpContext is not available. In other platforms, the library
         /// will find the user from the HttpContext.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The value returned by the downstream web API.</returns>
         /// <example>
         /// A list method that returns an IEnumerable&lt;MyItem&gt;&gt;.
@@ -182,7 +192,8 @@ namespace Microsoft.Identity.Web
             TInput input,
             string? authenticationScheme,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
-            ClaimsPrincipal? user = null)
+            ClaimsPrincipal? user = null,
+            CancellationToken cancellationToken = default)
             where TOutput : class;
 
         /// <summary>
@@ -196,17 +207,20 @@ namespace Microsoft.Identity.Web
         /// by <paramref name="serviceName"/>.</param>
         /// <param name="content">HTTP content in the case where <see cref="DownstreamWebApiOptions.HttpMethod"/> is
         /// <see cref="HttpMethod.Patch"/>, <see cref="HttpMethod.Post"/>, <see cref="HttpMethod.Put"/>.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An <see cref="HttpResponseMessage"/> that the application will process.</returns>
         public Task<HttpResponseMessage> CallWebApiForAppAsync(
             string serviceName,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
-            StringContent? content = null)
+            StringContent? content = null,
+            CancellationToken cancellationToken = default)
         {
             return CallWebApiForAppAsync(
                 serviceName,
                 null,
                 downstreamWebApiOptionsOverride,
-                content);
+                content,
+                cancellationToken);
         }
 
         /// <summary>
@@ -222,11 +236,13 @@ namespace Microsoft.Identity.Web
         /// by <paramref name="serviceName"/>.</param>
         /// <param name="content">HTTP content in the case where <see cref="DownstreamWebApiOptions.HttpMethod"/> is
         /// <see cref="HttpMethod.Patch"/>, <see cref="HttpMethod.Post"/>, <see cref="HttpMethod.Put"/>.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An <see cref="HttpResponseMessage"/> that the application will process.</returns>
         Task<HttpResponseMessage> CallWebApiForAppAsync(
             string serviceName,
             string? authenticationScheme,
             Action<DownstreamWebApiOptions>? downstreamWebApiOptionsOverride = null,
-            StringContent? content = null);
+            StringContent? content = null,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -567,7 +567,7 @@
             Extensions for the downstream web API.
             </summary>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.GetForUserAsync``1(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.GetForUserAsync``1(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String,System.Threading.CancellationToken)">
             <summary>
             Get a strongly typed response from the web API.
             </summary>
@@ -585,9 +585,10 @@
             will find the user from the HttpContext.</param>
             <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
             if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>A strongly typed response from the web API.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.PostForUserAsync``2(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.String,``1,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.PostForUserAsync``2(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.String,``1,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String,System.Threading.CancellationToken)">
             <summary>
             Calls the web API with an HttpPost, providing strongly typed input and getting
             strongly typed output.
@@ -608,9 +609,10 @@
             will find the user from the HttpContext.</param>
             <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
             if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>A strongly typed response from the web API.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.PutForUserAsync``1(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.String,``0,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.PutForUserAsync``1(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.String,``0,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String,System.Threading.CancellationToken)">
             <summary>
             Calls the web API endpoint with an HttpPut, providing strongly typed input data.
             </summary>
@@ -629,9 +631,10 @@
             will find the user from the HttpContext.</param>
             <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
             if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>The value returned by the downstream web API.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.PutForUserAsync``2(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.String,``1,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.PutForUserAsync``2(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.String,``1,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String,System.Threading.CancellationToken)">
             <summary>
             Calls the web API endpoint with an HttpPut, provinding strongly typed input data
             and getting back strongly typed data.
@@ -652,9 +655,10 @@
             will find the user from the HttpContext.</param>
             <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
             if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>A strongly typed response from the web API.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.CallWebApiForUserAsync``1(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.CallWebApiForUserAsync``1(Microsoft.Identity.Web.IDownstreamWebApi,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String,System.Threading.CancellationToken)">
             <summary>
             Call a web API endpoint with an HttpGet,
             and return strongly typed data.
@@ -672,9 +676,10 @@
             will find the user from the HttpContext.</param>
             <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
             if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>The value returned by the downstream web API.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.GetForUserAsync``1(Microsoft.Identity.Web.IDownstreamWebApi,System.String,``0,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions.GetForUserAsync``1(Microsoft.Identity.Web.IDownstreamWebApi,System.String,``0,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.String,System.Threading.CancellationToken)">
             <summary>
             Call a web API with a strongly typed input, with an HttpGet.
             </summary>
@@ -692,6 +697,7 @@
             will find the user from the HttpContext.</param>
             <param name="authenticationScheme">Authentication scheme. If null, will use OpenIdConnectDefault.AuthenticationScheme
             if called from a web app, and JwtBearerDefault.AuthenticationScheme if called from a web API.</param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>The value returned by the downstream web API.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.DownstreamWebApiOptions">
@@ -761,7 +767,7 @@
             will find the user from the HttpContext.</param>
             <param name="content">HTTP context in the case where <see cref="P:Microsoft.Identity.Web.DownstreamWebApiOptions.HttpMethod"/> is
             <see cref="P:System.Net.Http.HttpMethod.Patch"/>, <see cref="P:System.Net.Http.HttpMethod.Post"/>, <see cref="P:System.Net.Http.HttpMethod.Put"/>.</param>
-            <param name="cancellationToken"></param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>An <see cref="T:System.Net.Http.HttpResponseMessage"/> that the application will process.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Net.Http.StringContent,System.Threading.CancellationToken)">
@@ -782,7 +788,7 @@
             will find the user from the HttpContext.</param>
             <param name="content">HTTP context in the case where <see cref="P:Microsoft.Identity.Web.DownstreamWebApiOptions.HttpMethod"/> is
             <see cref="P:System.Net.Http.HttpMethod.Patch"/>, <see cref="P:System.Net.Http.HttpMethod.Post"/>, <see cref="P:System.Net.Http.HttpMethod.Put"/>.</param>
-            <param name="cancellationToken"></param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>An <see cref="T:System.Net.Http.HttpResponseMessage"/> that the application will process.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync``2(System.String,``0,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Threading.CancellationToken)">
@@ -801,7 +807,7 @@
              <param name="user">[Optional] Claims representing a user. This is useful in platforms like Blazor
              or Azure Signal R, where the HttpContext is not available. In other platforms, the library
              will find the user from the HttpContext.</param>
-             <param name="cancellationToken"></param>
+             <param name="cancellationToken">The cancellation token to cancel the operation.</param>
              <returns>The value returned by the downstream web API.</returns>
              <example>
              A list method that returns an IEnumerable&lt;MyItem&gt;&gt;.
@@ -852,7 +858,7 @@
              <param name="user">[Optional] Claims representing a user. This is useful in platforms like Blazor
              or Azure Signal R, where the HttpContext is not available. In other platforms, the library
              will find the user from the HttpContext.</param>
-             <param name="cancellationToken"></param>
+             <param name="cancellationToken">The cancellation token to cancel the operation.</param>
              <returns>The value returned by the downstream web API.</returns>
              <example>
              A list method that returns an IEnumerable&lt;MyItem&gt;&gt;.
@@ -897,7 +903,7 @@
             by <paramref name="serviceName"/>.</param>
             <param name="content">HTTP content in the case where <see cref="P:Microsoft.Identity.Web.DownstreamWebApiOptions.HttpMethod"/> is
             <see cref="P:System.Net.Http.HttpMethod.Patch"/>, <see cref="P:System.Net.Http.HttpMethod.Post"/>, <see cref="P:System.Net.Http.HttpMethod.Put"/>.</param>
-            <param name="cancellationToken"></param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>An <see cref="T:System.Net.Http.HttpResponseMessage"/> that the application will process.</returns>
         </member>
         <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForAppAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.StringContent,System.Threading.CancellationToken)">
@@ -914,7 +920,7 @@
             by <paramref name="serviceName"/>.</param>
             <param name="content">HTTP content in the case where <see cref="P:Microsoft.Identity.Web.DownstreamWebApiOptions.HttpMethod"/> is
             <see cref="P:System.Net.Http.HttpMethod.Patch"/>, <see cref="P:System.Net.Http.HttpMethod.Post"/>, <see cref="P:System.Net.Http.HttpMethod.Put"/>.</param>
-            <param name="cancellationToken"></param>
+            <param name="cancellationToken">The cancellation token to cancel the operation.</param>
             <returns>An <see cref="T:System.Net.Http.HttpResponseMessage"/> that the application will process.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.IMicrosoftIdentityAuthenticationDelegatingHandlerFactory">

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -216,6 +216,23 @@
             <param name="httpContext">The current HTTP Context, such as req.HttpContext.</param>
             <returns>A task indicating success or failure. In case of failure <see cref="T:Microsoft.AspNetCore.Mvc.UnauthorizedObjectResult"/>.</returns>
         </member>
+        <member name="T:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential">
+            <summary>
+            Azure SDK token credential for App tokens based on the ITokenAcquisition service.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.#ctor(Microsoft.Identity.Web.ITokenAcquisition)">
+            <summary>
+            Constructor from an ITokenAcquisition service.
+            </summary>
+            <param name="tokenAcquisition">Token acquisition.</param>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.GetToken(Azure.Core.TokenRequestContext,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.GetTokenAsync(Azure.Core.TokenRequestContext,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="T:Microsoft.Identity.Web.TokenAcquisitionTokenCredential">
             <summary>
             Azure SDK token credential based on the ITokenAcquisition service.
@@ -504,13 +521,13 @@
             <param name="httpClient">HTTP client.</param>
             <param name="microsoftIdentityOptionsMonitor">Configuration options.</param>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApi.CallWebApiForUserAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Net.Http.StringContent)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApi.CallWebApiForUserAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Net.Http.StringContent,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApi.CallWebApiForUserAsync``2(System.String,``0,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApi.CallWebApiForUserAsync``2(System.String,``0,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApi.CallWebApiForAppAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.StringContent)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApi.CallWebApiForAppAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.StringContent,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
         <member name="M:Microsoft.Identity.Web.DownstreamWebApi.MergeOptions(System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions})">
@@ -728,7 +745,7 @@
             Interface used to call a downstream web API, for instance from controllers.
             </summary>
         </member>
-        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync(System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Net.Http.StringContent)">
+        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync(System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Net.Http.StringContent,System.Threading.CancellationToken)">
             <summary>
             Calls the downstream web API for the user, based on a description of the
             downstream web API in the configuration.
@@ -744,9 +761,10 @@
             will find the user from the HttpContext.</param>
             <param name="content">HTTP context in the case where <see cref="P:Microsoft.Identity.Web.DownstreamWebApiOptions.HttpMethod"/> is
             <see cref="P:System.Net.Http.HttpMethod.Patch"/>, <see cref="P:System.Net.Http.HttpMethod.Post"/>, <see cref="P:System.Net.Http.HttpMethod.Put"/>.</param>
+            <param name="cancellationToken"></param>
             <returns>An <see cref="T:System.Net.Http.HttpResponseMessage"/> that the application will process.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Net.Http.StringContent)">
+        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Net.Http.StringContent,System.Threading.CancellationToken)">
             <summary>
             Calls the downstream web API for the user, based on a description of the
             downstream web API in the configuration.
@@ -764,9 +782,10 @@
             will find the user from the HttpContext.</param>
             <param name="content">HTTP context in the case where <see cref="P:Microsoft.Identity.Web.DownstreamWebApiOptions.HttpMethod"/> is
             <see cref="P:System.Net.Http.HttpMethod.Patch"/>, <see cref="P:System.Net.Http.HttpMethod.Post"/>, <see cref="P:System.Net.Http.HttpMethod.Put"/>.</param>
+            <param name="cancellationToken"></param>
             <returns>An <see cref="T:System.Net.Http.HttpResponseMessage"/> that the application will process.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync``2(System.String,``0,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal)">
+        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync``2(System.String,``0,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Threading.CancellationToken)">
              <summary>
              Calls a downstream web API consuming JSON with some data and returns data.
              </summary>
@@ -782,6 +801,7 @@
              <param name="user">[Optional] Claims representing a user. This is useful in platforms like Blazor
              or Azure Signal R, where the HttpContext is not available. In other platforms, the library
              will find the user from the HttpContext.</param>
+             <param name="cancellationToken"></param>
              <returns>The value returned by the downstream web API.</returns>
              <example>
              A list method that returns an IEnumerable&lt;MyItem&gt;&gt;.
@@ -814,7 +834,7 @@
              </code>
              </example>
         </member>
-        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync``2(System.String,``0,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal)">
+        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForUserAsync``2(System.String,``0,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Threading.CancellationToken)">
              <summary>
              Calls a downstream web API consuming JSON with some data and returns data.
              </summary>
@@ -832,6 +852,7 @@
              <param name="user">[Optional] Claims representing a user. This is useful in platforms like Blazor
              or Azure Signal R, where the HttpContext is not available. In other platforms, the library
              will find the user from the HttpContext.</param>
+             <param name="cancellationToken"></param>
              <returns>The value returned by the downstream web API.</returns>
              <example>
              A list method that returns an IEnumerable&lt;MyItem&gt;&gt;.
@@ -864,7 +885,7 @@
              </code>
              </example>
         </member>
-        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForAppAsync(System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.StringContent)">
+        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForAppAsync(System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.StringContent,System.Threading.CancellationToken)">
             <summary>
             Calls the downstream web API for the app, with the required scopes.
             </summary>
@@ -876,9 +897,10 @@
             by <paramref name="serviceName"/>.</param>
             <param name="content">HTTP content in the case where <see cref="P:Microsoft.Identity.Web.DownstreamWebApiOptions.HttpMethod"/> is
             <see cref="P:System.Net.Http.HttpMethod.Patch"/>, <see cref="P:System.Net.Http.HttpMethod.Post"/>, <see cref="P:System.Net.Http.HttpMethod.Put"/>.</param>
+            <param name="cancellationToken"></param>
             <returns>An <see cref="T:System.Net.Http.HttpResponseMessage"/> that the application will process.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForAppAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.StringContent)">
+        <member name="M:Microsoft.Identity.Web.IDownstreamWebApi.CallWebApiForAppAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.StringContent,System.Threading.CancellationToken)">
             <summary>
             Calls the downstream web API for the app, with the required scopes.
             </summary>
@@ -892,6 +914,7 @@
             by <paramref name="serviceName"/>.</param>
             <param name="content">HTTP content in the case where <see cref="P:Microsoft.Identity.Web.DownstreamWebApiOptions.HttpMethod"/> is
             <see cref="P:System.Net.Http.HttpMethod.Patch"/>, <see cref="P:System.Net.Http.HttpMethod.Post"/>, <see cref="P:System.Net.Http.HttpMethod.Put"/>.</param>
+            <param name="cancellationToken"></param>
             <returns>An <see cref="T:System.Net.Http.HttpResponseMessage"/> that the application will process.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.IMicrosoftIdentityAuthenticationDelegatingHandlerFactory">


### PR DESCRIPTION
Addresses #1739 

Add optional cancellationToken param to DownstreamWebApi methods and extension methods allowing consumers the possibility to cancel the operations.

For now I passed the cancellationToken down to methods supporting it. I'm not sure if it would be better to call `ThrowIfCancellationRequested` ourselves between `await` calls.