### PR TITLE
Allow configuration of HttpClients used by DownstreamWebApi

### DIFF
--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Web
     public class DownstreamWebApi : IDownstreamWebApi
     {
         private readonly ITokenAcquisition _tokenAcquisition;
-        private readonly HttpClient _httpClient;
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly IOptionsMonitor<DownstreamWebApiOptions> _namedDownstreamWebApiOptions;
         private readonly IOptionsMonitor<MicrosoftIdentityOptions> _microsoftIdentityOptionsMonitor;
 
@@ -28,17 +28,17 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="tokenAcquisition">Token acquisition service.</param>
         /// <param name="namedDownstreamWebApiOptions">Named options provider.</param>
-        /// <param name="httpClient">HTTP client.</param>
+        /// <param name="httpClientFactory">HTTP client factory.</param>
         /// <param name="microsoftIdentityOptionsMonitor">Configuration options.</param>
         public DownstreamWebApi(
             ITokenAcquisition tokenAcquisition,
             IOptionsMonitor<DownstreamWebApiOptions> namedDownstreamWebApiOptions,
-            HttpClient httpClient,
+            IHttpClientFactory httpClientFactory,
             IOptionsMonitor<MicrosoftIdentityOptions> microsoftIdentityOptionsMonitor)
         {
             _tokenAcquisition = tokenAcquisition;
             _namedDownstreamWebApiOptions = namedDownstreamWebApiOptions;
-            _httpClient = httpClient;
+            _httpClientFactory = httpClientFactory;
             _microsoftIdentityOptionsMonitor = microsoftIdentityOptionsMonitor;
         }
 
@@ -96,7 +96,11 @@ namespace Microsoft.Identity.Web
                     Constants.Authorization,
                     authResult.CreateAuthorizationHeader());
                 effectiveOptions.CustomizeHttpRequestMessage?.Invoke(httpRequestMessage);
-                return await _httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
+
+                using (HttpClient httpClient = _httpClientFactory.CreateClient(serviceName))
+                {
+                    return await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
+                }
             }
         }
 
@@ -176,7 +180,11 @@ namespace Microsoft.Identity.Web
                     Constants.Authorization,
                     authResult.CreateAuthorizationHeader());
                 effectiveOptions.CustomizeHttpRequestMessage?.Invoke(httpRequestMessage);
-                response = await _httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
+
+                using (HttpClient httpClient = _httpClientFactory.CreateClient(serviceName))
+                {
+                    response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
+                }
             }
 
             return response;

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
@@ -19,11 +19,13 @@ namespace Microsoft.Identity.Web
         /// <param name="serviceName">Name of the configuration for the service.
         /// This is the name used when calling the service from controller/pages.</param>
         /// <param name="configuration">Configuration.</param>
+        /// <param name="configureHttpClient">Configure the HttpClient for the Downstream Web Api.</param>
         /// <returns>The builder for chaining.</returns>
         public static MicrosoftIdentityAppCallsWebApiAuthenticationBuilder AddDownstreamWebApi(
             this MicrosoftIdentityAppCallsWebApiAuthenticationBuilder builder,
             string serviceName,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            Action<IHttpClientBuilder>? configureHttpClient = null)
         {
             if (builder is null)
             {
@@ -31,7 +33,10 @@ namespace Microsoft.Identity.Web
             }
 
             builder.Services.Configure<DownstreamWebApiOptions>(serviceName, configuration);
-            builder.Services.AddHttpClient<IDownstreamWebApi, DownstreamWebApi>();
+
+            IHttpClientBuilder httpClientBuilder = builder.Services.AddHttpClient<IDownstreamWebApi, DownstreamWebApi>(serviceName);
+            configureHttpClient?.Invoke(httpClientBuilder);
+
             return builder;
         }
 
@@ -42,11 +47,13 @@ namespace Microsoft.Identity.Web
         /// <param name="serviceName">Name of the configuration for the service.
         /// This is the name which will be used when calling the service from controller/pages.</param>
         /// <param name="configureOptions">Action to configure the options.</param>
+        /// <param name="configureHttpClient">Configure the HttpClient for the Downstream Web Api.</param>
         /// <returns>The builder for chaining.</returns>
         public static MicrosoftIdentityAppCallsWebApiAuthenticationBuilder AddDownstreamWebApi(
             this MicrosoftIdentityAppCallsWebApiAuthenticationBuilder builder,
             string serviceName,
-            Action<DownstreamWebApiOptions> configureOptions)
+            Action<DownstreamWebApiOptions> configureOptions,
+            Action<IHttpClientBuilder>? configureHttpClient = null)
         {
             if (builder is null)
             {
@@ -56,7 +63,9 @@ namespace Microsoft.Identity.Web
             builder.Services.Configure<DownstreamWebApiOptions>(serviceName, configureOptions);
 
             // https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
-            builder.Services.AddHttpClient<IDownstreamWebApi, DownstreamWebApi>();
+            IHttpClientBuilder httpClientBuilder = builder.Services.AddHttpClient<IDownstreamWebApi, DownstreamWebApi>(serviceName);
+            configureHttpClient?.Invoke(httpClientBuilder);
+
             builder.Services.Configure(serviceName, configureOptions);
             return builder;
         }

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Identity.Web
 {
@@ -34,7 +35,7 @@ namespace Microsoft.Identity.Web
 
             builder.Services.Configure<DownstreamWebApiOptions>(serviceName, configuration);
 
-            builder.Services.AddTransient<IDownstreamWebApi, DownstreamWebApi>();
+            builder.Services.TryAddTransient<IDownstreamWebApi, DownstreamWebApi>();
 
             IHttpClientBuilder httpClientBuilder = builder.Services.AddHttpClient(serviceName);
             configureHttpClient?.Invoke(httpClientBuilder);
@@ -64,7 +65,7 @@ namespace Microsoft.Identity.Web
 
             builder.Services.Configure<DownstreamWebApiOptions>(serviceName, configureOptions);
 
-            builder.Services.AddTransient<IDownstreamWebApi, DownstreamWebApi>();
+            builder.Services.TryAddTransient<IDownstreamWebApi, DownstreamWebApi>();
 
             // https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
             IHttpClientBuilder httpClientBuilder = builder.Services.AddHttpClient(serviceName);

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Identity.Web
 
             builder.Services.Configure<DownstreamWebApiOptions>(serviceName, configuration);
 
-            IHttpClientBuilder httpClientBuilder = builder.Services.AddHttpClient<IDownstreamWebApi, DownstreamWebApi>(serviceName);
+            builder.Services.AddTransient<IDownstreamWebApi, DownstreamWebApi>();
+
+            IHttpClientBuilder httpClientBuilder = builder.Services.AddHttpClient(serviceName);
             configureHttpClient?.Invoke(httpClientBuilder);
 
             return builder;
@@ -62,8 +64,10 @@ namespace Microsoft.Identity.Web
 
             builder.Services.Configure<DownstreamWebApiOptions>(serviceName, configureOptions);
 
+            builder.Services.AddTransient<IDownstreamWebApi, DownstreamWebApi>();
+
             // https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
-            IHttpClientBuilder httpClientBuilder = builder.Services.AddHttpClient<IDownstreamWebApi, DownstreamWebApi>(serviceName);
+            IHttpClientBuilder httpClientBuilder = builder.Services.AddHttpClient(serviceName);
             configureHttpClient?.Invoke(httpClientBuilder);
 
             builder.Services.Configure(serviceName, configureOptions);

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -216,6 +216,23 @@
             <param name="httpContext">The current HTTP Context, such as req.HttpContext.</param>
             <returns>A task indicating success or failure. In case of failure <see cref="T:Microsoft.AspNetCore.Mvc.UnauthorizedObjectResult"/>.</returns>
         </member>
+        <member name="T:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential">
+            <summary>
+            Azure SDK token credential for App tokens based on the ITokenAcquisition service.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.#ctor(Microsoft.Identity.Web.ITokenAcquisition)">
+            <summary>
+            Constructor from an ITokenAcquisition service.
+            </summary>
+            <param name="tokenAcquisition">Token acquisition.</param>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.GetToken(Azure.Core.TokenRequestContext,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.GetTokenAsync(Azure.Core.TokenRequestContext,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="T:Microsoft.Identity.Web.TokenAcquisitionTokenCredential">
             <summary>
             Azure SDK token credential based on the ITokenAcquisition service.
@@ -495,13 +512,13 @@
             Implementation for the downstream web API.
             </summary>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApi.#ctor(Microsoft.Identity.Web.ITokenAcquisition,Microsoft.Extensions.Options.IOptionsMonitor{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.HttpClient,Microsoft.Extensions.Options.IOptionsMonitor{Microsoft.Identity.Web.MicrosoftIdentityOptions})">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApi.#ctor(Microsoft.Identity.Web.ITokenAcquisition,Microsoft.Extensions.Options.IOptionsMonitor{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Net.Http.IHttpClientFactory,Microsoft.Extensions.Options.IOptionsMonitor{Microsoft.Identity.Web.MicrosoftIdentityOptions})">
             <summary>
             Constructor.
             </summary>
             <param name="tokenAcquisition">Token acquisition service.</param>
             <param name="namedDownstreamWebApiOptions">Named options provider.</param>
-            <param name="httpClient">HTTP client.</param>
+            <param name="httpClientFactory">HTTP client factory.</param>
             <param name="microsoftIdentityOptionsMonitor">Configuration options.</param>
         </member>
         <member name="M:Microsoft.Identity.Web.DownstreamWebApi.CallWebApiForUserAsync(System.String,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Security.Claims.ClaimsPrincipal,System.Net.Http.StringContent)">
@@ -525,7 +542,7 @@
             Extension methods to support downstream web API services.
             </summary>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApiExtensions.AddDownstreamWebApi(Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder,System.String,Microsoft.Extensions.Configuration.IConfiguration)">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApiExtensions.AddDownstreamWebApi(Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder,System.String,Microsoft.Extensions.Configuration.IConfiguration,System.Action{Microsoft.Extensions.DependencyInjection.IHttpClientBuilder})">
             <summary>
             Adds a named downstream web API service related to a specific configuration section.
             </summary>
@@ -533,9 +550,10 @@
             <param name="serviceName">Name of the configuration for the service.
             This is the name used when calling the service from controller/pages.</param>
             <param name="configuration">Configuration.</param>
+            <param name="configureHttpClient">Configure the HttpClient for the Downstream Web Api.</param>
             <returns>The builder for chaining.</returns>
         </member>
-        <member name="M:Microsoft.Identity.Web.DownstreamWebApiExtensions.AddDownstreamWebApi(Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions})">
+        <member name="M:Microsoft.Identity.Web.DownstreamWebApiExtensions.AddDownstreamWebApi(Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder,System.String,System.Action{Microsoft.Identity.Web.DownstreamWebApiOptions},System.Action{Microsoft.Extensions.DependencyInjection.IHttpClientBuilder})">
             <summary>
             Adds a named downstream web API service initialized with delegates.
             </summary>
@@ -543,6 +561,7 @@
             <param name="serviceName">Name of the configuration for the service.
             This is the name which will be used when calling the service from controller/pages.</param>
             <param name="configureOptions">Action to configure the options.</param>
+            <param name="configureHttpClient">Configure the HttpClient for the Downstream Web Api.</param>
             <returns>The builder for chaining.</returns>
         </member>
         <member name="T:Microsoft.Identity.Web.DownstreamWebApiGenericExtensions">


### PR DESCRIPTION
Addresses #1740 

The MS docs recommends [implementing resilient http requests](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests) using libraries like Polly. At the same time, the recommended way to make authenticated api calls is through the [IDownstreamWebApi interface](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-web-api-call-api-call-api?tabs=aspnetcore). This PR closes the gaps in the docs and allows the consumer access to the IHttpClientBuilder, allowing them to add Polly policies for their downstream apis etc.

Changed to add named HttpClients, which DownstreamWebApi then gets from IHttpClientFactory, allowing the consumer to optionally configure HttpClient per downstream service.

Example usage with this:
```csharp
builder.Services.AddMicrosoftIdentityWebApi(builder.Configuration)
  .EnableTokenAcquisitionToCallDownstreamApi()
    .AddDownstreamWebApi(
      "DownstreamApi",
      builder.Configuration.GetSection("DownstreamApi"),
      httpClientBuilder => httpClientBuilder
        .AddTransientHttpErrorPolicy(builder => builder.WaitAndRetryAsync(new[]
        {
          TimeSpan.FromSeconds(1),
          TimeSpan.FromSeconds(5),
          TimeSpan.FromSeconds(10)
        })))
    .AddDownstreamWebApi(
      "AnotherApi",
      builder.Configuration.GetSection("AnotherApi"),
      httpClientBuilder => httpClientBuilder
        .AddTransientHttpErrorPolicy(builder => builder.WaitAndRetryAsync(new[]
        {
          TimeSpan.FromSeconds(1),
          TimeSpan.FromSeconds(2)
        })))
  .AddDistributedTokenCaches();
```