### PR TITLE
Adding support for .net 6 simplified templates apps

### DIFF
--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescriptions/dotnet-web.json
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescriptions/dotnet-web.json
@@ -87,7 +87,30 @@
         ]
     },
     {
-      "FileRelativePath": "Startup.cs",
+        "FileRelativePath": "Startup.cs",
+        "Properties": [
+            {
+                "MatchAny": [ ".AddMicrosoftGraph", ".AddMicrosoftGraphBeta" ],
+                "Sets": "CallsMicrosoftGraph"
+            },
+            {
+                "MatchAny": [ ".EnableTokenAcquisitionToCallDownstreamApi", ".AddDownstreamWebApi" ],
+                "Sets": "CallsDownstreamApi"
+            },
+            {
+                "Property": "\"AzureAdB2C\"",
+                "Represents": "Application.ConfigurationSection",
+                "Sets": "IsB2C"
+            },
+            {
+                "Property": "\"AzureAd\"",
+                "Represents": "Application.ConfigurationSection",
+                "Sets": "IsAAD"
+            }
+        ]
+    },
+    {
+      "FileRelativePath": "Program.cs",
         "Properties": [
             {
                 "MatchAny": [ ".AddMicrosoftGraph", ".AddMicrosoftGraphBeta" ],

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescriptions/dotnet-webapi.json
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescriptions/dotnet-webapi.json
@@ -15,7 +15,16 @@
   ],
   "ConfigurationProperties": [
     {
-      "FileRelativePath": "Startup.cs",
+        "FileRelativePath": "Startup.cs",
+        "Properties": [
+            {
+                "MatchAny": [ ".AddAzureAdBearer", ".AddMicrosoftIdentityWebApi", ".AddMicrosoftIdentityWebApiAuthentication" ],
+                "Sets": "HasAuthentication"
+            }
+        ]
+    },
+    {
+      "FileRelativePath": "Program.cs",
       "Properties": [
         {
           "MatchAny": [ ".AddAzureAdBearer", ".AddMicrosoftIdentityWebApi", ".AddMicrosoftIdentityWebApiAuthentication" ],

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescriptions/dotnet-webapp.json
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescriptions/dotnet-webapp.json
@@ -18,7 +18,16 @@
   ],
   "ConfigurationProperties": [
     {
-      "FileRelativePath": "Startup.cs",
+        "FileRelativePath": "Startup.cs",
+        "Properties": [
+            {
+                "MatchAny": [ ".AddAzureAD", ".AddMicrosoftIdentityWebApp", ".AddMicrosoftIdentityWebAppAuthentication" ],
+                "Sets": "HasAuthentication"
+            }
+        ]
+    },
+   {
+      "FileRelativePath": "Program.cs",
       "Properties": [
         {
           "MatchAny": [ ".AddAzureAD", ".AddMicrosoftIdentityWebApp", ".AddMicrosoftIdentityWebAppAuthentication" ],

--- a/tools/app-provisioning-tool/app-provisioning-tool/Readme.txt
+++ b/tools/app-provisioning-tool/app-provisioning-tool/Readme.txt
@@ -1,5 +1,5 @@
-Install
-dotnet tool install --global --add-source ./nupkg msIdentityApp
+Install (run from the tools\app-provisioning-tool\app-provisioning-tool folder):
+dotnet tool install --global --add-source ./nupkg msidentity-app-sync
 
 To un install
-dotnet tool uninstall --global msidentityapp
+dotnet tool uninstall --global msidentity-app-sync

--- a/tools/app-provisioning-tool/app-provisioning-tool/msidentity-app-sync.csproj
+++ b/tools/app-provisioning-tool/app-provisioning-tool/msidentity-app-sync.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <Version>1.0.1</Version>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Identity.App</RootNamespace>


### PR DESCRIPTION
Fixes #1529 and #1708

## Problem:
- in .NET 6.0 the project templates for web apps and web APIs were simplified, and the content of the startup.cs moved to program.cs.
- msidentity-app-sync was looking for Microsoft.identity.web method calls in startup.cs.

## Fix:
- Augment the project descriptions for web apps and web APIs, so that net 6.0 project templates are supported (in addition to .NET 5.0 and netcoreapp3.1 
- Bump-up the version of the tool to 1.0.1 (it's a kind of bug fix to react to environment changes)
- Updates the Readme.md

## How to test:
1. Unregister the current `msidentity-app-sync` tool:
  
  ```Shell
  dotnet tool uninstall --global msidentity-app-sync
  ```

2. In the folder where the app-provisioning.sln solution is located, pack the tool:

  ```Shell
  dotnet pack app-provisioning.sln
  ```

3. Install the newly built tool (from the same folder)

  ```Shell
  dotnet tool install --global --add-source .\app-provisioning-tool\nupkg msidentity-app-sync
  msidentity-app-sync --version
  ```

4. Test:

  ```Shell
  dotnet new webapp --auth IndividualB2C ^
   --aad-b2c-instance "https://fabrikamb2c.b2clogin.com" ^
   --domain "fabrikamb2c.onmicrosoft.com" ^
   --called-api-url "https://fabrikamb2chello.azurewebsites.net/hello" ^
   --called-api-scopes "https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read"
  
   msidentity-app-sync

   dotnet run
  ```

