### PR TITLE
Jennyf/scopes roles

### DIFF
--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -216,6 +216,23 @@
             <param name="httpContext">The current HTTP Context, such as req.HttpContext.</param>
             <returns>A task indicating success or failure. In case of failure <see cref="T:Microsoft.AspNetCore.Mvc.UnauthorizedObjectResult"/>.</returns>
         </member>
+        <member name="T:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential">
+            <summary>
+            Azure SDK token credential for App tokens based on the ITokenAcquisition service.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.#ctor(Microsoft.Identity.Web.ITokenAcquisition)">
+            <summary>
+            Constructor from an ITokenAcquisition service.
+            </summary>
+            <param name="tokenAcquisition">Token acquisition.</param>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.GetToken(Azure.Core.TokenRequestContext,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Microsoft.Identity.Web.TokenAcquisitionAppTokenCredential.GetTokenAsync(Azure.Core.TokenRequestContext,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="T:Microsoft.Identity.Web.TokenAcquisitionTokenCredential">
             <summary>
             Azure SDK token credential based on the ITokenAcquisition service.
@@ -1731,6 +1748,36 @@
             by spaces).
             </summary>
         </member>
+        <member name="T:Microsoft.Identity.Web.IAuthRequiredScopeOrAppPermissionMetadata">
+            <summary>
+            This is the metadata that describes required auth scopes or app permissions for a given endpoint
+            in a web API. It's the underlying data structure the requirement <see cref="T:Microsoft.Identity.Web.ScopeAuthorizationRequirement"/> will look for
+            in order to validate scopes in the scope claims.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.IAuthRequiredScopeOrAppPermissionMetadata.AcceptedAppPermission">
+            <summary>
+            App permissions accepted by this web API.
+            App permissions appear in the roles claim of the token.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.IAuthRequiredScopeOrAppPermissionMetadata.RequiredAppPermissionsConfigurationKey">
+            <summary>
+            Fully qualified name of the configuration key containing the required scopes 
+            or app permissions (separated by spaces).
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.IAuthRequiredScopeOrAppPermissionMetadata.AcceptedScope">
+            <summary>
+            Scopes accepted by this web API.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.IAuthRequiredScopeOrAppPermissionMetadata.RequiredScopesConfigurationKey">
+            <summary>
+            Fully qualified name of the configuration key containing the required scopes (separated
+            by spaces).
+            </summary>
+        </member>
         <member name="T:Microsoft.Identity.Web.PolicyBuilderExtensions">
             <summary>
             Extensions for building the RequiredScope policy during application startup.
@@ -1828,6 +1875,96 @@
             <summary>
             Unused: Compatibility of interface with the Authorization Filter.
             </summary>
+        </member>
+        <member name="T:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute">
+            <summary>
+            This attribute is used on a controller, pages, or controller actions
+            to declare (and validate) the scopes or app permissions required by a web API. 
+            These scopes or app permissions can be declared in two ways:
+            hardcoding them, or declaring them in the configuration. Depending on your
+            choice, use either one or the other of the constructors.
+            For details, see https://aka.ms/ms-id-web/required-scope-or-app-permissions-attribute.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute.AcceptedScope">
+            <summary>
+            Scopes accepted by this web API.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute.RequiredScopesConfigurationKey">
+            <summary>
+            Fully qualified name of the configuration key containing the required scopes (separated
+            by spaces).
+            </summary>
+            <example>
+            If the appsettings.json file contains a section named "AzureAd", in which
+            a property named "Scopes" contains the required scopes, the attribute on the
+            controller/page/action to protect should be set to the following:
+            <code>
+            [RequiredScope(RequiredScopesConfigurationKey="AzureAd:Scopes")]
+            </code>
+            </example>
+        </member>
+        <member name="P:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute.IsReusable">
+            <summary>
+            Unused: Compatibility of interface with the Authorization Filter.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute.AcceptedAppPermission">
+            <summary>
+            App permissions accepted by this web API.
+            App permissions appear in the roles claim of the token.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute.RequiredAppPermissionsConfigurationKey">
+            <summary>
+            Fully qualified name of the configuration key containing the required app permissions (separated
+            by spaces).
+            </summary>
+            <example>
+            If the appsettings.json file contains a section named "AzureAd", in which
+            a property named "AppPermissions" contains the required app permissions, the attribute on the
+            controller/page/action to protect should be set to the following:
+            <code>
+            [RequiredScopeOrAppPermission(RequiredAppPermissionsConfigurationKey="AzureAd:AppPermissions")]
+            </code>
+            </example>
+        </member>
+        <member name="M:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute.#ctor(System.String[],System.String[])">
+             <summary>
+             Verifies that the web API is called with the right app permissions.
+             If the token obtained for this API is on behalf of the authenticated user does not have
+             any of these <paramref name="acceptedScopes"/> in its scope claim, 
+             nor <paramref name="acceptedAppPermissions"/> in its roles claim, the
+             method updates the HTTP response providing a status code 403 (Forbidden)
+             and writes to the response body a message telling which scopes are expected in the token.
+             </summary>
+             <param name="acceptedScopes">Scopes accepted by this web API.</param>
+             <param name="acceptedAppPermissions">App permissions accepted by this web API.</param>
+             <remarks>When neither the scopes nor app permissions match, the response is a 403 (Forbidden),
+             because the user is authenticated (hence not 401), but not authorized.</remarks>
+             <example>
+             Add the following attribute on the controller/page/action to protect:
+            
+             <code>
+             [RequiredScopeOrAppPermissionAttribute(new string[] { "access_as_user" }, new string[] { "access_as_app" })]
+             </code>
+             </example>
+             <seealso cref="M:RequiredScopeOrAppPermissionAttribute()"/> and <see cref="P:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute.RequiredAppPermissionsConfigurationKey"/>
+             if you want to express the required scopes or app permissions from the configuration.
+        </member>
+        <member name="M:Microsoft.Identity.Web.Resource.RequiredScopeOrAppPermissionAttribute.#ctor">
+            <summary>
+            Default constructor.
+            </summary>
+            <example>
+            <code>
+            [RequiredScopeOrAppPermission(RequiredScopesConfigurationKey="AzureAD:Scope", RequiredAppPermissionsConfigurationKey="AzureAD:AppPermission")]
+            class Controller : BaseController
+            {
+            }
+            </code>
+            </example>
         </member>
         <member name="T:Microsoft.Identity.Web.Resource.IJwtBearerMiddlewareDiagnostics">
             <summary>
@@ -2079,6 +2216,31 @@
             <param name="scope">Scope.</param>
             <returns>Builder.</returns>
         </member>
+        <member name="T:Microsoft.Identity.Web.RequiredScopeOrAppPermissionExtensions">
+            <summary>
+            Extensions for building the required scope or app permission attribute during application startup.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.RequiredScopeOrAppPermissionExtensions.AddRequiredScopeOrAppPermissionAuthorization(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            This method adds support for the required scope or app permission attribute. It adds a default policy that
+            adds a scope requirement or app permission requirement.
+            This requirement looks for IAuthRequiredScopeOrAppPermissionMetadata on the current endpoint.
+            </summary>
+            <param name="services">The services being configured.</param>
+            <returns>Services.</returns>
+        </member>
+        <member name="M:Microsoft.Identity.Web.RequiredScopeOrAppPermissionExtensions.RequireScope``1(``0,System.String[],System.String[])">
+            <summary>
+            This method adds metadata to route endpoint to describe required scopes or app permissions. It's the imperative version of
+            the [RequiredScopeOrAppPermission] attribute.
+            </summary>
+            <typeparam name="TBuilder">Class implementing <see cref="T:Microsoft.AspNetCore.Builder.IEndpointConventionBuilder"/>.</typeparam>
+            <param name="endpointConventionBuilder">To customize the endpoints.</param>
+            <param name="scope">Scope.</param>
+            <param name="appPermission">App permission.</param>
+            <returns>Builder.</returns>
+        </member>
         <member name="T:Microsoft.Identity.Web.RequireScopeOptions">
             <summary>
             RequireScopeOptions.
@@ -2090,6 +2252,19 @@
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.RequireScopeOptions.PostConfigure(System.String,Microsoft.AspNetCore.Authorization.AuthorizationOptions)">
+            <inheritdoc/>
+        </member>
+        <member name="T:Microsoft.Identity.Web.RequireScopeOrAppPermissionOptions">
+            <summary>
+            RequireScopeOrAppPermissionOptions.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.RequireScopeOrAppPermissionOptions.#ctor">
+            <summary>
+            Sets the default policy.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.RequireScopeOrAppPermissionOptions.PostConfigure(System.String,Microsoft.AspNetCore.Authorization.AuthorizationOptions)">
             <inheritdoc/>
         </member>
         <member name="T:Microsoft.Identity.Web.ScopeAuthorizationHandler">
@@ -2136,6 +2311,63 @@
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.ScopeAuthorizationRequirement.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationHandler">
+            <summary>
+             Scope or app permission authorization handler that needs to be called for a specific requirement type.
+             In this case, <see cref="T:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement"/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationHandler.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
+            <summary>
+            Constructor for the scope authorization handler, which takes a configuration.
+            </summary>
+            <param name="configuration">Configuration.</param>
+        </member>
+        <member name="M:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationHandler.HandleRequirementAsync(Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext,Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement)">
+            <summary>
+             Makes a decision if authorization is allowed based on a specific requirement.
+            </summary>
+            <param name="context">AuthorizationHandlerContext.</param>
+            <param name="requirement">Scope authorization requirement.</param>
+            <returns>Task.</returns>
+        </member>
+        <member name="T:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement">
+            <summary>
+            Implements an <see cref="T:Microsoft.AspNetCore.Authorization.IAuthorizationRequirement"/>
+            which requires at least one instance of the specified claim type, and, if allowed values are specified,
+            the claim value must be any of the allowed values.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement.#ctor(System.Collections.Generic.IEnumerable{System.String},System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+            Creates a new instance of <see cref="T:Microsoft.Identity.Web.ScopeAuthorizationRequirement"/>.
+            </summary>
+            <param name="scopeAllowedValues">The optional list of scope values.</param>
+            <param name="appPermissionAllowedValues"></param>
+        </member>
+        <member name="P:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement.ScopeAllowedValues">
+            <summary>
+            Gets the optional list of scope values.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement.AppPermissionAllowedValues">
+            <summary>
+            Gets the optional list of app permission values.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement.RequiredScopesConfigurationKey">
+            <summary>
+            Gets the optional list of scope values from configuration.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement.RequiredAppPermissionsConfigurationKey">
+            <summary>
+            Gets the optional list of app permission values from configuration.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement.ToString">
             <inheritdoc />
         </member>
         <member name="T:Microsoft.Identity.Web.AadIssuerValidatorOptions">

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -1809,6 +1809,26 @@
             <param name="allowedValues">Values the claim must process one or more of for evaluation to succeed.</param>
             <returns>A reference to this instance after the operation has completed.</returns>
         </member>
+        <member name="M:Microsoft.Identity.Web.PolicyBuilderExtensions.RequireScopeOrAppPermission(Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder,System.String[],System.String[])">
+            <summary>
+            Adds a <see cref="T:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement"/> to the current instance which requires
+            that the current user has the specified claim and that the claim value must be one of the allowed values.
+            </summary>
+            <param name="authorizationPolicyBuilder">Used for building policies during application startup.</param>
+            <param name="allowedScopeValues">Values the claim must process one or more of for evaluation to succeed.</param>
+            <param name="allowedAppPermissionValues">Values the claim must process one or more of for evaluation to succeed.</param>
+            <returns>A reference to this instance after the operation has completed.</returns>
+        </member>
+        <member name="M:Microsoft.Identity.Web.PolicyBuilderExtensions.RequireScopeOrAppPermission(Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder,System.Collections.Generic.IEnumerable{System.String},System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+            Adds a <see cref="T:Microsoft.Identity.Web.ScopeOrAppPermissionAuthorizationRequirement"/> to the current instance which requires
+            that the current user has the specified claim and that the claim value must be one of the allowed values.
+            </summary>
+            <param name="authorizationPolicyBuilder">Used for building policies during application startup.</param>
+            <param name="allowedScopeValues">Values the claim must process one or more of for evaluation to succeed.</param>
+            <param name="allowedAppPermissionValues">Values the claim must process one or more of for evaluation to succeed.</param>
+            <returns>A reference to this instance after the operation has completed.</returns>
+        </member>
         <member name="T:Microsoft.Identity.Web.Resource.RequiredScopeAttribute">
             <summary>
             This attribute is used on a controller, pages, or controller actions

--- a/src/Microsoft.Identity.Web/Policy/IAuthRequiredScopeMetadata.cs
+++ b/src/Microsoft.Identity.Web/Policy/IAuthRequiredScopeMetadata.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Scopes accepted by this web API.
         /// </summary>
-        IEnumerable<string>? AcceptedScope { get; }
+        string[]? AcceptedScope { get; }
 
         /// <summary>
         /// Fully qualified name of the configuration key containing the required scopes (separated

--- a/src/Microsoft.Identity.Web/Policy/IAuthRequiredScopeOrAppPermissionMetadata.cs
+++ b/src/Microsoft.Identity.Web/Policy/IAuthRequiredScopeOrAppPermissionMetadata.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// This is the metadata that describes required auth scopes or app permissions for a given endpoint
+    /// in a web API. It's the underlying data structure the requirement <see cref="ScopeAuthorizationRequirement"/> will look for
+    /// in order to validate scopes in the scope claims.
+    /// </summary>
+    public interface IAuthRequiredScopeOrAppPermissionMetadata
+    {
+        /// <summary>
+        /// App permissions accepted by this web API.
+        /// App permissions appear in the roles claim of the token.
+        /// </summary>
+        IEnumerable<string>? AcceptedAppPermission { get; }
+
+        /// <summary>
+        /// Fully qualified name of the configuration key containing the required scopes 
+        /// or app permissions (separated by spaces).
+        /// </summary>
+        string? RequiredAppPermissionsConfigurationKey { get; }
+
+        /// <summary>
+        /// Scopes accepted by this web API.
+        /// </summary>
+        IEnumerable<string>? AcceptedScope { get; }
+
+        /// <summary>
+        /// Fully qualified name of the configuration key containing the required scopes (separated
+        /// by spaces).
+        /// </summary>
+        string? RequiredScopesConfigurationKey { get; }
+    }
+}

--- a/src/Microsoft.Identity.Web/Policy/IAuthRequiredScopeOrAppPermissionMetadata.cs
+++ b/src/Microsoft.Identity.Web/Policy/IAuthRequiredScopeOrAppPermissionMetadata.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Identity.Web
 {
     /// <summary>
     /// This is the metadata that describes required auth scopes or app permissions for a given endpoint
-    /// in a web API. It's the underlying data structure the requirement <see cref="ScopeAuthorizationRequirement"/> will look for
-    /// in order to validate scopes in the scope claims.
+    /// in a web API. It's the underlying data structure the requirement <see cref="ScopeOrAppPermissionAuthorizationRequirement"/> will look for
+    /// in order to validate scopes in the scope claims or app permissions in the roles claim.
     /// </summary>
     public interface IAuthRequiredScopeOrAppPermissionMetadata
     {
@@ -19,8 +19,8 @@ namespace Microsoft.Identity.Web
         string[]? AcceptedAppPermission { get; }
 
         /// <summary>
-        /// Fully qualified name of the configuration key containing the required scopes 
-        /// or app permissions (separated by spaces).
+        /// Fully qualified name of the configuration key containing the required
+        /// app permissions (separated by spaces).
         /// </summary>
         string? RequiredAppPermissionsConfigurationKey { get; }
 

--- a/src/Microsoft.Identity.Web/Policy/IAuthRequiredScopeOrAppPermissionMetadata.cs
+++ b/src/Microsoft.Identity.Web/Policy/IAuthRequiredScopeOrAppPermissionMetadata.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Web
         /// App permissions accepted by this web API.
         /// App permissions appear in the roles claim of the token.
         /// </summary>
-        IEnumerable<string>? AcceptedAppPermission { get; }
+        string[]? AcceptedAppPermission { get; }
 
         /// <summary>
         /// Fully qualified name of the configuration key containing the required scopes 
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Scopes accepted by this web API.
         /// </summary>
-        IEnumerable<string>? AcceptedScope { get; }
+        string[]? AcceptedScope { get; }
 
         /// <summary>
         /// Fully qualified name of the configuration key containing the required scopes (separated

--- a/src/Microsoft.Identity.Web/Policy/PolicyBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/Policy/PolicyBuilderExtensions.cs
@@ -64,32 +64,8 @@ namespace Microsoft.Identity.Web
         /// that the current user has the specified claim and that the claim value must be one of the allowed values.
         /// </summary>
         /// <param name="authorizationPolicyBuilder">Used for building policies during application startup.</param>
-        /// <param name="allowedScopeValues">Values the claim must process one or more of for evaluation to succeed.</param>
-        /// <param name="allowedAppPermissionValues">Values the claim must process one or more of for evaluation to succeed.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        public static AuthorizationPolicyBuilder RequireScopeOrAppPermission(
-            this AuthorizationPolicyBuilder authorizationPolicyBuilder,
-            string[] allowedScopeValues,
-            string[] allowedAppPermissionValues)
-        {
-            if (authorizationPolicyBuilder == null)
-            {
-                throw new ArgumentNullException(nameof(authorizationPolicyBuilder));
-            }
-
-            return RequireScopeOrAppPermission(
-                authorizationPolicyBuilder,
-                (IEnumerable<string>)allowedScopeValues,
-                (IEnumerable<string>)allowedAppPermissionValues);
-        }
-
-        /// <summary>
-        /// Adds a <see cref="ScopeOrAppPermissionAuthorizationRequirement"/> to the current instance which requires
-        /// that the current user has the specified claim and that the claim value must be one of the allowed values.
-        /// </summary>
-        /// <param name="authorizationPolicyBuilder">Used for building policies during application startup.</param>
-        /// <param name="allowedScopeValues">Values the claim must process one or more of for evaluation to succeed.</param>
-        /// <param name="allowedAppPermissionValues">Values the claim must process one or more of for evaluation to succeed.</param>
+        /// <param name="allowedScopeValues">scopes (the value of scope or scp) accepted by this app.</param>
+        /// <param name="allowedAppPermissionValues">App permission (in role claim) that this app accepts.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         public static AuthorizationPolicyBuilder RequireScopeOrAppPermission(
             this AuthorizationPolicyBuilder authorizationPolicyBuilder,

--- a/src/Microsoft.Identity.Web/Policy/PolicyBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/Policy/PolicyBuilderExtensions.cs
@@ -58,5 +58,53 @@ namespace Microsoft.Identity.Web
             authorizationPolicyBuilder.Requirements.Add(new ScopeAuthorizationRequirement(allowedValues));
             return authorizationPolicyBuilder;
         }
+
+        /// <summary>
+        /// Adds a <see cref="ScopeOrAppPermissionAuthorizationRequirement"/> to the current instance which requires
+        /// that the current user has the specified claim and that the claim value must be one of the allowed values.
+        /// </summary>
+        /// <param name="authorizationPolicyBuilder">Used for building policies during application startup.</param>
+        /// <param name="allowedScopeValues">Values the claim must process one or more of for evaluation to succeed.</param>
+        /// <param name="allowedAppPermissionValues">Values the claim must process one or more of for evaluation to succeed.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static AuthorizationPolicyBuilder RequireScopeOrAppPermission(
+            this AuthorizationPolicyBuilder authorizationPolicyBuilder,
+            string[] allowedScopeValues,
+            string[] allowedAppPermissionValues)
+        {
+            if (authorizationPolicyBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(authorizationPolicyBuilder));
+            }
+
+            return RequireScopeOrAppPermission(
+                authorizationPolicyBuilder,
+                (IEnumerable<string>)allowedScopeValues,
+                (IEnumerable<string>)allowedAppPermissionValues);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="ScopeOrAppPermissionAuthorizationRequirement"/> to the current instance which requires
+        /// that the current user has the specified claim and that the claim value must be one of the allowed values.
+        /// </summary>
+        /// <param name="authorizationPolicyBuilder">Used for building policies during application startup.</param>
+        /// <param name="allowedScopeValues">Values the claim must process one or more of for evaluation to succeed.</param>
+        /// <param name="allowedAppPermissionValues">Values the claim must process one or more of for evaluation to succeed.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static AuthorizationPolicyBuilder RequireScopeOrAppPermission(
+            this AuthorizationPolicyBuilder authorizationPolicyBuilder,
+            IEnumerable<string> allowedScopeValues,
+            IEnumerable<string> allowedAppPermissionValues)
+        {
+            if (authorizationPolicyBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(authorizationPolicyBuilder));
+            }
+
+            authorizationPolicyBuilder.Requirements.Add(new ScopeOrAppPermissionAuthorizationRequirement(
+                allowedScopeValues,
+                allowedAppPermissionValues));
+            return authorizationPolicyBuilder;
+        }
     }
 }

--- a/src/Microsoft.Identity.Web/Policy/RequireScopeOrAppPermissionOptions.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequireScopeOrAppPermissionOptions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// RequireScopeOrAppPermissionOptions.
+    /// </summary>
+    internal class RequireScopeOrAppPermissionOptions : IPostConfigureOptions<AuthorizationOptions>
+    {
+        private readonly AuthorizationPolicy _defaultPolicy;
+
+        /// <summary>
+        /// Sets the default policy.
+        /// </summary>
+        public RequireScopeOrAppPermissionOptions()
+        {
+            _defaultPolicy = new AuthorizationPolicyBuilder()
+                .AddRequirements(new ScopeOrAppPermissionAuthorizationRequirement())
+                .Build();
+        }
+
+        /// <inheritdoc/>
+        public void PostConfigure(
+            string name,
+            AuthorizationOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            options.DefaultPolicy = options.DefaultPolicy is null
+                                     ? _defaultPolicy
+                                     : AuthorizationPolicy.Combine(options.DefaultPolicy, _defaultPolicy);
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeAttribute.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeAttribute.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Web.Resource
         /// <summary>
         /// Scopes accepted by this web API.
         /// </summary>
-        public IEnumerable<string>? AcceptedScope { get; set; }
+        public string[]? AcceptedScope { get; set; }
 
         /// <summary>
         /// Fully qualified name of the configuration key containing the required scopes (separated

--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeExtensions.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Web
                 AcceptedScope = scope;
             }
 
-            public IEnumerable<string>? AcceptedScope { get; }
+            public string[]? AcceptedScope { get; }
 
             public string? RequiredScopesConfigurationKey { get; }
         }

--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionAttribute.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Web.Resource
         /// <summary>
         /// Scopes accepted by this web API.
         /// </summary>
-        public IEnumerable<string>? AcceptedScope { get; set; }
+        public string[]? AcceptedScope { get; set; }
 
         /// <summary>
         /// Fully qualified name of the configuration key containing the required scopes (separated
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Web.Resource
         /// App permissions accepted by this web API.
         /// App permissions appear in the roles claim of the token.
         /// </summary>
-        public IEnumerable<string>? AcceptedAppPermission { get; set; }
+        public string[]? AcceptedAppPermission { get; set; }
 
         /// <summary>
         /// Fully qualified name of the configuration key containing the required app permissions (separated

--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionAttribute.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionAttribute.cs
@@ -31,15 +31,10 @@ namespace Microsoft.Identity.Web.Resource
         /// a property named "Scopes" contains the required scopes, the attribute on the
         /// controller/page/action to protect should be set to the following:
         /// <code>
-        /// [RequiredScope(RequiredScopesConfigurationKey="AzureAd:Scopes")]
+        /// [RequiredScopeOrAppPermission(RequiredScopesConfigurationKey="AzureAd:Scopes")]
         /// </code>
         /// </example>
         public string? RequiredScopesConfigurationKey { get; set; }
-
-        /// <summary>
-        /// Unused: Compatibility of interface with the Authorization Filter.
-        /// </summary>
-        public bool IsReusable { get; set; }
 
         /// <summary>
         /// App permissions accepted by this web API.
@@ -77,7 +72,7 @@ namespace Microsoft.Identity.Web.Resource
         /// Add the following attribute on the controller/page/action to protect:
         ///
         /// <code>
-        /// [RequiredScopeOrAppPermissionAttribute(new string[] { "access_as_user" }, new string[] { "access_as_app" })]
+        /// [RequiredScopeOrAppPermission(new [] { "access_as_user" }, new [] { "access_as_app" })]
         /// </code>
         /// </example>
         /// <seealso cref="M:RequiredScopeOrAppPermissionAttribute()"/> and <see cref="RequiredAppPermissionsConfigurationKey"/>

--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionAttribute.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionAttribute.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Identity.Web.Resource
+{
+    /// <summary>
+    /// This attribute is used on a controller, pages, or controller actions
+    /// to declare (and validate) the scopes or app permissions required by a web API. 
+    /// These scopes or app permissions can be declared in two ways:
+    /// hardcoding them, or declaring them in the configuration. Depending on your
+    /// choice, use either one or the other of the constructors.
+    /// For details, see https://aka.ms/ms-id-web/required-scope-or-app-permissions-attribute.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class RequiredScopeOrAppPermissionAttribute : Attribute, IAuthRequiredScopeOrAppPermissionMetadata
+    {
+        /// <summary>
+        /// Scopes accepted by this web API.
+        /// </summary>
+        public IEnumerable<string>? AcceptedScope { get; set; }
+
+        /// <summary>
+        /// Fully qualified name of the configuration key containing the required scopes (separated
+        /// by spaces).
+        /// </summary>
+        /// <example>
+        /// If the appsettings.json file contains a section named "AzureAd", in which
+        /// a property named "Scopes" contains the required scopes, the attribute on the
+        /// controller/page/action to protect should be set to the following:
+        /// <code>
+        /// [RequiredScope(RequiredScopesConfigurationKey="AzureAd:Scopes")]
+        /// </code>
+        /// </example>
+        public string? RequiredScopesConfigurationKey { get; set; }
+
+        /// <summary>
+        /// Unused: Compatibility of interface with the Authorization Filter.
+        /// </summary>
+        public bool IsReusable { get; set; }
+
+        /// <summary>
+        /// App permissions accepted by this web API.
+        /// App permissions appear in the roles claim of the token.
+        /// </summary>
+        public IEnumerable<string>? AcceptedAppPermission { get; set; }
+
+        /// <summary>
+        /// Fully qualified name of the configuration key containing the required app permissions (separated
+        /// by spaces).
+        /// </summary>
+        /// <example>
+        /// If the appsettings.json file contains a section named "AzureAd", in which
+        /// a property named "AppPermissions" contains the required app permissions, the attribute on the
+        /// controller/page/action to protect should be set to the following:
+        /// <code>
+        /// [RequiredScopeOrAppPermission(RequiredAppPermissionsConfigurationKey="AzureAd:AppPermissions")]
+        /// </code>
+        /// </example>
+        public string? RequiredAppPermissionsConfigurationKey { get; set; }
+
+        /// <summary>
+        /// Verifies that the web API is called with the right app permissions.
+        /// If the token obtained for this API is on behalf of the authenticated user does not have
+        /// any of these <paramref name="acceptedScopes"/> in its scope claim, 
+        /// nor <paramref name="acceptedAppPermissions"/> in its roles claim, the
+        /// method updates the HTTP response providing a status code 403 (Forbidden)
+        /// and writes to the response body a message telling which scopes are expected in the token.
+        /// </summary>
+        /// <param name="acceptedScopes">Scopes accepted by this web API.</param>
+        /// <param name="acceptedAppPermissions">App permissions accepted by this web API.</param>
+        /// <remarks>When neither the scopes nor app permissions match, the response is a 403 (Forbidden),
+        /// because the user is authenticated (hence not 401), but not authorized.</remarks>
+        /// <example>
+        /// Add the following attribute on the controller/page/action to protect:
+        ///
+        /// <code>
+        /// [RequiredScopeOrAppPermissionAttribute(new string[] { "access_as_user" }, new string[] { "access_as_app" })]
+        /// </code>
+        /// </example>
+        /// <seealso cref="M:RequiredScopeOrAppPermissionAttribute()"/> and <see cref="RequiredAppPermissionsConfigurationKey"/>
+        /// if you want to express the required scopes or app permissions from the configuration.
+        public RequiredScopeOrAppPermissionAttribute(string[] acceptedScopes, string[] acceptedAppPermissions)
+        {
+            AcceptedScope = acceptedScopes ?? throw new ArgumentNullException(nameof(acceptedScopes));
+            AcceptedAppPermission = acceptedAppPermissions ?? throw new ArgumentNullException(nameof(acceptedAppPermissions));
+        }
+
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// [RequiredScopeOrAppPermission(RequiredScopesConfigurationKey="AzureAD:Scope", RequiredAppPermissionsConfigurationKey="AzureAD:AppPermission")]
+        /// class Controller : BaseController
+        /// {
+        /// }
+        /// </code>
+        /// </example>
+        public RequiredScopeOrAppPermissionAttribute()
+        {
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Web
         /// <param name="scope">Scope.</param>
         /// <param name="appPermission">App permission.</param>
         /// <returns>Builder.</returns>
-        public static TBuilder RequireScope<TBuilder>(this TBuilder endpointConventionBuilder, string[] scope, string[] appPermission)
+        public static TBuilder RequireScopeOrAppPermission<TBuilder>(this TBuilder endpointConventionBuilder, string[] scope, string[] appPermission)
             where TBuilder : IEndpointConventionBuilder
         {
             return endpointConventionBuilder.WithMetadata(new RequiredScopeOrAppPermissionMetadata(scope, appPermission));

--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Extensions for building the required scope or app permission attribute during application startup.
+    /// </summary>
+    public static class RequiredScopeOrAppPermissionExtensions
+    {
+        /// <summary>
+        /// This method adds support for the required scope or app permission attribute. It adds a default policy that
+        /// adds a scope requirement or app permission requirement.
+        /// This requirement looks for IAuthRequiredScopeOrAppPermissionMetadata on the current endpoint.
+        /// </summary>
+        /// <param name="services">The services being configured.</param>
+        /// <returns>Services.</returns>
+        public static IServiceCollection AddRequiredScopeOrAppPermissionAuthorization(this IServiceCollection services)
+        {
+            services.AddAuthorization();
+
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<AuthorizationOptions>, RequireScopeOrAppPermissionOptions>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IAuthorizationHandler, ScopeOrAppPermissionAuthorizationHandler>());
+            return services;
+        }
+
+        /// <summary>
+        /// This method adds metadata to route endpoint to describe required scopes or app permissions. It's the imperative version of
+        /// the [RequiredScopeOrAppPermission] attribute.
+        /// </summary>
+        /// <typeparam name="TBuilder">Class implementing <see cref="IEndpointConventionBuilder"/>.</typeparam>
+        /// <param name="endpointConventionBuilder">To customize the endpoints.</param>
+        /// <param name="scope">Scope.</param>
+        /// <param name="appPermission">App permission.</param>
+        /// <returns>Builder.</returns>
+        public static TBuilder RequireScope<TBuilder>(this TBuilder endpointConventionBuilder, string[] scope, string[] appPermission)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            return endpointConventionBuilder.WithMetadata(new RequiredScopeOrAppPermissionMetadata(scope, appPermission));
+        }
+
+        private sealed class RequiredScopeOrAppPermissionMetadata : IAuthRequiredScopeMetadata
+        {
+            public RequiredScopeOrAppPermissionMetadata(string[] scope, string[] appPermission)
+            {
+                AcceptedScope = scope;
+                AcceptedAppPermission = appPermission;
+            }
+
+            public IEnumerable<string>? AcceptedScope { get; }
+            public IEnumerable<string>? AcceptedAppPermission { get; }
+
+            public string? RequiredScopesConfigurationKey { get; }
+            public string? RequiredAppPermissionsConfigurationKey { get; }
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Identity.Web
                 AcceptedAppPermission = appPermission;
             }
 
-            public IEnumerable<string>? AcceptedScope { get; }
-            public IEnumerable<string>? AcceptedAppPermission { get; }
+            public string[]? AcceptedScope { get; }
+            public string[]? AcceptedAppPermission { get; }
 
             public string? RequiredScopesConfigurationKey { get; }
             public string? RequiredAppPermissionsConfigurationKey { get; }

--- a/src/Microsoft.Identity.Web/Policy/ScopeOrAppPermissionAuthorizationHandler.cs
+++ b/src/Microsoft.Identity.Web/Policy/ScopeOrAppPermissionAuthorizationHandler.cs
@@ -98,16 +98,20 @@ namespace Microsoft.Identity.Web
               .Union(context.User.FindAll(ClaimConstants.Scope))
               .ToList();
 
-            bool appPermissionMatch = appPermissions.Any(p => context.User.IsInRole(p));
+           var appPermissionClaims = context.User.FindAll(ClaimConstants.Role)
+              .Union(context.User.FindAll(ClaimConstants.Roles))
+              .ToList();
 
-            if (!scopeClaims.Any() && !appPermissionMatch)
+            if (!scopeClaims.Any() && !appPermissionClaims.Any())
             {
                 return Task.CompletedTask;
             }
+            
+            var hasScope = scopes != null && scopeClaims.SelectMany(s => s.Value.Split(' ')).Intersect(scopes).Any();
 
-            var hasScope = scopeClaims.SelectMany(s => s.Value.Split(' ')).Intersect(scopes).Any();
+            var hasAppPermission = appPermissions != null && appPermissionClaims.SelectMany(s => s.Value.Split(' ')).Intersect(appPermissions).Any();
 
-            if (hasScope || appPermissionMatch)
+            if (hasScope || hasAppPermission)
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;

--- a/src/Microsoft.Identity.Web/Policy/ScopeOrAppPermissionAuthorizationRequirement.cs
+++ b/src/Microsoft.Identity.Web/Policy/ScopeOrAppPermissionAuthorizationRequirement.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Web
             }
             else
             {
-                value = $"TokenValidationParameters.RoleClaimType is one of th following values:  ({string.Join("|", AppPermissionAllowedValues)})";
+                value = $" and `{ClaimConstants.Roles}` or `{ClaimConstants.Roles}` is one of the following values: ({string.Join("|", AppPermissionAllowedValues!)})";
             }
 
             return $"{nameof(ScopeOrAppPermissionAuthorizationRequirement)}:Scope/AppPermission={value}";

--- a/src/Microsoft.Identity.Web/Policy/ScopeOrAppPermissionAuthorizationRequirement.cs
+++ b/src/Microsoft.Identity.Web/Policy/ScopeOrAppPermissionAuthorizationRequirement.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Implements an <see cref="IAuthorizationRequirement"/>
+    /// which requires at least one instance of the specified claim type, and, if allowed values are specified,
+    /// the claim value must be any of the allowed values.
+    /// </summary>
+    public class ScopeOrAppPermissionAuthorizationRequirement : IAuthorizationRequirement
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ScopeAuthorizationRequirement"/>.
+        /// </summary>
+        /// <param name="scopeAllowedValues">The optional list of scope values.</param>
+        /// <param name="appPermissionAllowedValues"></param>
+        public ScopeOrAppPermissionAuthorizationRequirement(
+            IEnumerable<string>? scopeAllowedValues = null,
+            IEnumerable<string>? appPermissionAllowedValues = null)
+        {
+            ScopeAllowedValues = scopeAllowedValues;
+            AppPermissionAllowedValues = appPermissionAllowedValues;
+        }
+
+        /// <summary>
+        /// Gets the optional list of scope values.
+        /// </summary>
+        public IEnumerable<string>? ScopeAllowedValues { get; }
+
+        /// <summary>
+        /// Gets the optional list of app permission values.
+        /// </summary>
+        public IEnumerable<string>? AppPermissionAllowedValues { get; }
+
+        /// <summary>
+        /// Gets the optional list of scope values from configuration.
+        /// </summary>
+        public string? RequiredScopesConfigurationKey { get; set; }
+
+        /// <summary>
+        /// Gets the optional list of app permission values from configuration.
+        /// </summary>
+        public string? RequiredAppPermissionsConfigurationKey { get; set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            string value;
+
+            if (ScopeAllowedValues == null && AppPermissionAllowedValues == null)
+            {
+                value = string.Empty;
+            }
+            else if (ScopeAllowedValues != null && AppPermissionAllowedValues != null)
+            {
+                value = $" and `{ClaimConstants.Scp}` or `{ClaimConstants.Scope}` is one of the following values: ({string.Join("|", ScopeAllowedValues)}) or " +
+                    $"TokenValidationParameters.RoleClaimType is one of th following values:  ({string.Join("|", AppPermissionAllowedValues)})";
+            }
+            else if (ScopeAllowedValues != null)
+            {
+                value = $" and `{ClaimConstants.Scp}` or `{ClaimConstants.Scope}` is one of the following values: ({string.Join("|", ScopeAllowedValues)})";
+            }
+            else
+            {
+                value = $"TokenValidationParameters.RoleClaimType is one of th following values:  ({string.Join("|", AppPermissionAllowedValues)})";
+            }
+
+            return $"{nameof(ScopeOrAppPermissionAuthorizationRequirement)}:Scope/AppPermission={value}";
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Identity.Web
             builder.Services.AddHttpClient();
             builder.Services.TryAddSingleton<MicrosoftIdentityIssuerValidatorFactory>();
             builder.Services.AddRequiredScopeAuthorization();
+            builder.Services.AddRequiredScopeOrAppPermissionAuthorization();
             builder.Services.AddOptions<AadIssuerValidatorOptions>();
 
             if (subscribeToJwtBearerMiddlewareDiagnosticsEvents)

--- a/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopeOrAppPermissionPolicyTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopeOrAppPermissionPolicyTests.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Identity.Web.Resource;
+using Microsoft.Identity.Web.Test.Common;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test.Resource
+{
+    [RequiredScopeOrAppPermission(new string[] { "access_as_user" }, new string[] { "access_as_app" })]
+    public class RequiredScopeOrAppPermissionPolicyTests
+    {
+        private IServiceProvider _provider;
+        private const string ConfigSectionName = "AzureAd";
+        private const string MultipleAppPermissions = "access_as_app_read_only access_as_app";
+        private const string AppPermission = "access_as_app";
+        private const string Scope = "user.read";
+        private const string PolicyName = "foo";
+
+        [Theory]
+        [InlineData(ClaimConstants.Role)]
+        [InlineData(ClaimConstants.Role, true)]
+        [InlineData(ClaimConstants.Roles)]
+        [InlineData(ClaimConstants.Roles, true)]
+        [RequiredScopeOrAppPermission(RequiredAppPermissionsConfigurationKey = "AzureAd:AppPermission")]
+        public async void VerifyAppHasAnyAcceptedAppPermission_TestAsync(
+            string claimType,
+            bool withConfig = false)
+        {
+            // Arrange
+            var authorizationService = BuildAuthorizationService(
+                PolicyName,
+                AppPermission,
+                null,
+                withConfig);
+
+            var user = new ClaimsPrincipal(
+                new ClaimsIdentity(new Claim[] { new Claim(claimType, AppPermission) }));
+
+            // Act
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(allowed.Succeeded);
+        }
+
+        [Theory]
+        [InlineData(ClaimConstants.Role)]
+        [InlineData(ClaimConstants.Role, true)]
+        [InlineData(ClaimConstants.Roles)]
+        [InlineData(ClaimConstants.Roles, true)]
+        public async void VerifyAppHasAnyAcceptedAppPermission_OneAppPermissionMatches_TestAsync(
+            string claimType,
+            bool withConfig = false)
+        {
+            // Arrange
+            var authorizationService = BuildAuthorizationService(
+                PolicyName,
+                AppPermission,
+                null,
+                withConfig);
+
+            var user = new ClaimsPrincipal(
+                new ClaimsIdentity(new Claim[] { new Claim(claimType, MultipleAppPermissions) }));
+
+            // Act
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(allowed.Succeeded);
+        }
+
+        [Fact]
+        public async void VerifyAppHasAnyAcceptedAppPermission_WithMismatchAppPermissionTest_FailsAsync()
+        {
+            // Arrange
+            var authorizationService = BuildAuthorizationService(
+                PolicyName,
+                AppPermission,
+                null);
+
+            var user = new ClaimsPrincipal(
+                new ClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Role, "access_as_app2") }));
+
+            // Act
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+
+            // Assert
+            Assert.False(allowed.Succeeded);
+        }
+
+        [Fact]
+        public async void VerifyAppHasAnyAcceptedAppPermission_RequiredAppPermissionMissingAsync()
+        {
+            // Arrange
+            var authorizationService = BuildAuthorizationService(
+                PolicyName,
+                null,
+                null);
+
+            var user = new ClaimsPrincipal(
+                new ClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Role, AppPermission) }));
+
+            // Act
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(allowed.Succeeded);
+        }
+
+        [Fact]
+        public async void IncorrectPolicyName_FailsAsync()
+        {
+            // Arrange
+            var authorizationService = BuildAuthorizationService(
+                "foobar",
+                AppPermission,
+                null);
+
+            var user = new ClaimsPrincipal(
+                new ClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Role, AppPermission) }));
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => authorizationService.AuthorizeAsync(user, PolicyName)).ConfigureAwait(false);
+            Assert.Equal("No policy found: foo.", exception.Message);
+        }
+
+        [Fact]
+        public async void VerifyAppHasAnyAcceptedScopeOrAppPermission_TestAsync()
+        {
+            // Arrange
+            var authorizationService = BuildAuthorizationService(
+                PolicyName,
+                AppPermission,
+                Scope);
+
+            var user = new ClaimsPrincipal(
+                new ClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Role, AppPermission), new Claim(ClaimConstants.Scp, Scope) }));
+
+            // Act
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(allowed.Succeeded);
+        }
+
+        private IAuthorizationService BuildAuthorizationService(
+        string policy,
+        string appPermission,
+        string scope,
+        bool withConfig = false)
+        {
+            var configAsDictionary = new Dictionary<string, string>()
+            {
+                { ConfigSectionName, null },
+                { $"{ConfigSectionName}:Instance", TestConstants.AadInstance },
+                { $"{ConfigSectionName}:TenantId", TestConstants.TenantIdAsGuid },
+                { $"{ConfigSectionName}:ClientId", TestConstants.ClientId },
+                { $"{ConfigSectionName}:AppPermission", appPermission },
+                { $"{ConfigSectionName}:Scope", scope },
+            };
+            var memoryConfigSource = new MemoryConfigurationSource { InitialData = configAsDictionary };
+
+            IHostBuilder hostBuilder = Host.CreateDefaultBuilder()
+                .ConfigureHostConfiguration(configBuilder =>
+                {
+                    configBuilder.Add(memoryConfigSource);
+                    configBuilder.Build().GetSection(ConfigSectionName);
+                })
+            .ConfigureServices(services =>
+            {
+                services.AddAuthorization(options =>
+                {
+                    options.AddPolicy(policy, policyBuilder =>
+                    {
+                        if (withConfig)
+                        {
+                            policyBuilder.Requirements.Add(new ScopeOrAppPermissionAuthorizationRequirement() { RequiredAppPermissionsConfigurationKey = $"{ConfigSectionName}:AppPermission" });
+                        }
+                        else
+                        {
+                            policyBuilder.RequireScopeOrAppPermission(scope?.Split(' '), appPermission?.Split(' '));
+                        }
+                    });
+                });
+                services.AddLogging();
+                services.AddOptions();
+                services.AddSingleton<IAuthorizationHandler, ScopeOrAppPermissionAuthorizationHandler>();
+                services.AddRequiredScopeOrAppPermissionAuthorization();
+            });
+            _provider = hostBuilder.Build().Services;
+            return _provider.GetRequiredService<IAuthorizationService>();
+        }
+    }
+}


### PR DESCRIPTION
#1641 

Adds `RequiredScopeOrAppPermissionAttribute(string[] acceptedScopes, string[] acceptedAppPermissions)` and the associated handler, requirement etc ...

Additional todo to plan:
- [ ] Create the following aka.ms link: https://aka.ms/ms-id-web/required-scope-or-app-permissions-attribute
- [ ] Update the wiki: 
  - Validation of app roles: https://github.com/AzureAD/microsoft-identity-web/wiki/web-apis#verification-of-app-roles
  - https://github.com/AzureAD/microsoft-identity-web/wiki/web-apis#verify-scopes-in-web-apis-called-on-behalf-of-users
- [ ] Update the docs.ms documentation: https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-protected-web-api-verification-scope-app-roles?tabs=aspnetcore