### PR TITLE
fix: include StatusCode in HttpRequestException for .NET 5

### DIFF
--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
@@ -124,7 +124,11 @@ namespace Microsoft.Identity.Web
             {
                 string error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
+#if DOTNET_50_AND_ABOVE
+                throw new HttpRequestException($"{(int)response.StatusCode} {response.StatusCode} {error}", null, response.StatusCode);
+#else
                 throw new HttpRequestException($"{(int)response.StatusCode} {response.StatusCode} {error}");
+#endif
             }
 
             string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiGenericExtensions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiGenericExtensions.cs
@@ -294,7 +294,11 @@ namespace Microsoft.Identity.Web
             {
                 string error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
+#if DOTNET_50_AND_ABOVE
+                throw new HttpRequestException($"{(int)response.StatusCode} {response.StatusCode} {error}", null, response.StatusCode);
+#else
                 throw new HttpRequestException($"{(int)response.StatusCode} {response.StatusCode} {error}");
+#endif
             }
 
             string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
A `StatusCode` property was introduced on `HttpRequestException` in .NET 5.  
Populate it when throwing our own `HttpRequestException` in `DownstreamWebApi` when targeting supported frameworks.