### PR TITLE
Make LoggingOptions internal

### DIFF
--- a/src/Microsoft.Identity.Web/LoggingOptions.cs
+++ b/src/Microsoft.Identity.Web/LoggingOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Identity.Web
     /// <summary>
     /// LoggingOptions class for passing in Identity specific logging options.
     /// </summary>
-    public class LoggingOptions
+    internal class LoggingOptions
     {
         /// <summary>
         /// Enable Pii Logging from configuration.


### PR DESCRIPTION
I was going to run a release build and noticed the LoggingOptions is public, I don't think it needs to be, so marking as internal.