### PR TITLE
Added ability to pass authentication scheme for Graph

### DIFF
--- a/src/Microsoft.Identity.Web.MicrosoftGraph/MicrosoftGraphOptions.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/MicrosoftGraphOptions.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Identity.Web
     public class MicrosoftGraphOptions
     {
         /// <summary>
+        /// Alternative authentication scheme to be used
+        /// </summary>
+        public string? AuthenticationScheme { get; set; }
+        /// <summary>
         /// Base URL for the Microsoft Graph API. By default: <c>"https://graph.microsoft.com/v1.0/"</c>
         /// but it can be changed to use the Microsoft Graph Beta endpoint or national cloud versions
         /// of MicrosoftGraph.


### PR DESCRIPTION
When you pass a custom authentication scheme to `AddMicrosoftIdentityWebApp` you cannot propagate it for Graph
```
.AddMicrosoftIdentityWebApp(
    options =>
    {
        configuration.GetSection("AzureAd").Bind(options);
        if (!options.ResponseType.Split(' ').Contains("code"))
        {
            options.ResponseType = string.Join(' ', "code", options.ResponseType);
        }
        ExternalClaimsMappings.mapMicrosoftClaims(options.ClaimActions);
        var events = options.Events;
        //events.OnTokenResponseReceived = MicrosoftAuthenticationEventsHandler.OnTokenResponseReceived;
        //events.OnTicketReceived = MicrosoftAuthenticationEventsHandler.OnTicketReceived;
    },
    openIdConnectScheme: IdentityProviders.Microsoft,
    displayName: "Microsoft Account",
    cookieScheme: null)
.EnableTokenAcquisitionToCallDownstreamApi(initialScopes)
.AddMicrosoftGraph(configuration.GetSection("MicrosoftGraph"))
.AddDownstreamWebApi("DownstreamApi", configuration.GetSection("DownstreamApi"))
.AddInMemoryTokenCaches();
```
My PR fixes that