### PR TITLE
Adding support for PodIdentity credentials

### DIFF
--- a/TokenAcquirerTests/TokenAcquirer.cs
+++ b/TokenAcquirerTests/TokenAcquirer.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Graph;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
+using Xunit;
 
 namespace TokenAcquirerTests
 {

--- a/TokenAcquirerTests/TokenAcquirerTests.csproj
+++ b/TokenAcquirerTests/TokenAcquirerTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1; net6.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/TokenAcquirerTests/Usings.cs
+++ b/TokenAcquirerTests/Usings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/src/Microsoft.Identity.Web.Certificateless/Certificateless.cd
+++ b/src/Microsoft.Identity.Web.Certificateless/Certificateless.cd
@@ -14,11 +14,11 @@
       <FileName>ClientAssertion.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Microsoft.Identity.Web.ClientAssertionDescription">
+  <Class Name="Microsoft.Identity.Web.ClientAssertionProviderBase">
     <Position X="7.25" Y="3.25" Width="3.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAABAAAAAAAAAQAAAAAAAAIBAAAAAAAAAAAAA=</HashCode>
-      <FileName>ClientAssertionDescription.cs</FileName>
+      <FileName>ClientAssertionProviderBase.cs</FileName>
     </TypeIdentifier>
     <ShowAsAssociation>
       <Field Name="_clientAssertion" />
@@ -26,14 +26,6 @@
   </Class>
   <Class Name="Microsoft.Identity.Web.ManagedIdentityClientAssertion">
     <Position X="5" Y="6.75" Width="5.75" />
-    <InheritanceLine Type="Microsoft.Identity.Web.ClientAssertionDescription" ManuallyRouted="true">
-      <Path>
-        <Point X="9" Y="4.997" />
-        <Point X="9" Y="5.232" />
-        <Point X="7.875" Y="5.232" />
-        <Point X="7.875" Y="6.75" />
-      </Path>
-    </InheritanceLine>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAIAA=</HashCode>
       <FileName>ManagedIdentityClientAssertion.cs</FileName>

--- a/src/Microsoft.Identity.Web.Certificateless/Certificateless.cd
+++ b/src/Microsoft.Identity.Web.Certificateless/Certificateless.cd
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
+  <Class Name="Microsoft.Identity.Web.CertificatelessOptions">
+    <Position X="14" Y="5.25" Width="2.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAEAAAAAAAAAACAAAAAAAAAAAAA=</HashCode>
+      <FileName>CertificatelessOptions.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.ClientAssertion">
+    <Position X="12.25" Y="3.25" Width="4.25" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAABAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>ClientAssertion.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.ClientAssertionDescription">
+    <Position X="7.25" Y="3.25" Width="3.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAABAAAAAAAAAQAAAAAAAAIBAAAAAAAAAAAAA=</HashCode>
+      <FileName>ClientAssertionDescription.cs</FileName>
+    </TypeIdentifier>
+    <ShowAsAssociation>
+      <Field Name="_clientAssertion" />
+    </ShowAsAssociation>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.ManagedIdentityClientAssertion">
+    <Position X="5" Y="6.75" Width="5.75" />
+    <InheritanceLine Type="Microsoft.Identity.Web.ClientAssertionDescription" ManuallyRouted="true">
+      <Path>
+        <Point X="9" Y="4.997" />
+        <Point X="9" Y="5.232" />
+        <Point X="7.875" Y="5.232" />
+        <Point X="7.875" Y="6.75" />
+      </Path>
+    </InheritanceLine>
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAIAA=</HashCode>
+      <FileName>ManagedIdentityClientAssertion.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.PodIdentityClientAssertion">
+    <Position X="11.25" Y="6.75" Width="5.75" />
+    <TypeIdentifier>
+      <HashCode>AAAQAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>PodIdentityClientAssertion.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Font Name="Segoe UI" Size="9" />
+</ClassDiagram>

--- a/src/Microsoft.Identity.Web.Certificateless/ClientAssertionProviderBase.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ClientAssertionProviderBase.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Web
     /// Description of a client assertion in the application configuration.
     /// See https://aka.ms/ms-id-web/client-assertions.
     /// </summary>
-    public class ClientAssertionDescription
+    public class ClientAssertionProviderBase
     {
         /// <summary>
         /// delegate to get the client assertion from a provider.
@@ -32,8 +32,8 @@ namespace Microsoft.Identity.Web
         {
             if (ClientAssertionProvider == null)
             {
-                // This error is not meant to users of ClientAssertionDescription
-                // only to extenders of ClientAssertionDescription (probably Id.Web developers)
+                // This error is not meant to users of ClientAssertionProviderBase
+                // only to extenders of ClientAssertionProviderBase (probably Id.Web developers)
                 throw new ArgumentNullException("ClientAssertionProvider must be initialized in the constructor of the derived classes");
             }
             if (_clientAssertion == null || (Expiry != null && DateTimeOffset.Now > Expiry))

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -12,13 +12,14 @@ namespace Microsoft.Identity.Web
     /// <summary>
     /// See https://aka.ms/ms-id-web/certificateless.
     /// </summary>
-    public class ManagedIdentityClientAssertion
+    public class ManagedIdentityClientAssertion : ClientAssertionDescription
     {
         /// <summary>
         /// See https://aka.ms/ms-id-web/certificateless.
         /// </summary>
-        public ManagedIdentityClientAssertion(): this(null)
-        {           
+        public ManagedIdentityClientAssertion()
+        {
+            ClientAssertionProvider = GetSignedAssertionFromFederatedTokenProvider;
         }
 
         /// <summary>
@@ -46,42 +47,6 @@ namespace Microsoft.Identity.Web
                 new TokenRequestContext(new[] { "api://AzureADTokenExchange/.default" }, null),
                 cancellationToken).ConfigureAwait(false);
             return new ClientAssertion(result.Token, result.ExpiresOn);
-        }
-
-        /// <summary>
-        /// Delegate to get the client assertion.
-        /// </summary>
-        private Func<CancellationToken, Task<ClientAssertion>> ClientAssertionProvider { get; set; }
-
-        /// <summary>
-        /// Client assertion.
-        /// </summary>
-        private ClientAssertion? _clientAssertion;
-
-        /// <summary>
-        /// Get the signed assertion (and refreshes it if needed).
-        /// </summary>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>The signed assertion.</returns>
-        public async Task<string> GetSignedAssertion(CancellationToken cancellationToken)
-        {
-            if (_clientAssertion == null || (Expiry != null && DateTimeOffset.Now > Expiry))
-            {
-                _clientAssertion = await ClientAssertionProvider(cancellationToken).ConfigureAwait(false);
-            }
-
-            return _clientAssertion.SignedAssertion;
-        }
-
-        /// <summary>
-        /// Expiry of the client assertion.
-        /// </summary>
-        private DateTimeOffset? Expiry
-        {
-            get
-            {
-                return _clientAssertion?.Expiry;
-            }
         }
     }
 }

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Web
     /// <summary>
     /// See https://aka.ms/ms-id-web/certificateless.
     /// </summary>
-    public class ManagedIdentityClientAssertion : ClientAssertionDescription
+    public class ManagedIdentityClientAssertion : ClientAssertionProviderBase
     {
         /// <summary>
         /// See https://aka.ms/ms-id-web/certificateless.

--- a/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
+++ b/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
@@ -18,5 +18,6 @@
 
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens " Version="$(IdentityModelVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Identity.Web.Certificateless/PodIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/PodIdentityClientAssertion.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Gets a signed assertion from PodIdentity when an app is running in a container
+    /// in Azure Kubernetes Services. See https://aka.ms/ms-id-web/certificateless.
+    /// </summary>
+    internal class PodIdentityClientAssertion : ClientAssertionDescription
+    {
+        /// <summary>
+        /// Gets a signed assertion from PodIdentity. The file path is provided
+        /// by an environment variable ("AZURE_FEDERATED_TOKEN_FILE")
+        /// See https://aka.ms/ms-id-web/certificateless.
+        /// </summary>
+        public PodIdentityClientAssertion()
+        {
+            // See https://blog.identitydigest.com/azuread-federate-k8s/
+            _filePath = Environment.GetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE");
+            ClientAssertionProvider = GetSignedAssertionFromFile;
+        }
+
+        /// <summary>
+        /// Gets a signed assertion from a file.
+        /// See https://aka.ms/ms-id-web/certificateless.
+        /// </summary>
+        /// <param name="filePath"></param>
+        public PodIdentityClientAssertion(string filePath)
+        {
+            _filePath = filePath;
+            ClientAssertionProvider = GetSignedAssertionFromFile;
+        }
+
+        private readonly string _filePath;
+
+        /// <summary>
+        /// Get the signed assertion from a file.
+        /// </summary>
+        /// <returns>The signed assertion.</returns>
+        private Task<ClientAssertion> GetSignedAssertionFromFile(CancellationToken cancellationToken)
+        {
+            string signedAssertion = File.ReadAllText(_filePath);
+            // Compute the expiry
+            JsonWebToken jwt = new JsonWebToken(signedAssertion);
+            return Task.FromResult(new ClientAssertion(signedAssertion, jwt.ValidTo));
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web.Certificateless/PodIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/PodIdentityClientAssertion.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Web
     /// Gets a signed assertion from PodIdentity when an app is running in a container
     /// in Azure Kubernetes Services. See https://aka.ms/ms-id-web/certificateless.
     /// </summary>
-    internal class PodIdentityClientAssertion : ClientAssertionDescription
+    internal class PodIdentityClientAssertion : ClientAssertionProviderBase
     {
         /// <summary>
         /// Gets a signed assertion from PodIdentity. The file path is provided

--- a/tests/Microsoft.Identity.Web.Test/ClientAssertionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClientAssertionTests.cs
@@ -15,14 +15,16 @@ namespace Microsoft.Identity.Web.Test
         public async Task TestClientAssertion()
         {
             int n = 0;
-            ClientAssertionDescription clientAssertionDescription = new ClientAssertionDescription(
-                cancellationToken =>
+            ClientAssertionDescription clientAssertionDescription = new ClientAssertionDescription()
+            {
+                ClientAssertionProvider = (cancellationToken =>
                 {
                     n++;
                     return Task.FromResult(new ClientAssertion(
                         n.ToString(CultureInfo.InvariantCulture),
                         DateTimeOffset.Now + TimeSpan.FromSeconds(1)));
-                });
+                })
+            };
 
             string assertion = await clientAssertionDescription.GetSignedAssertion(CancellationToken.None).ConfigureAwait(false);
 

--- a/tests/Microsoft.Identity.Web.Test/ClientAssertionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClientAssertionTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Web.Test
         public async Task TestClientAssertion()
         {
             int n = 0;
-            ClientAssertionDescription clientAssertionDescription = new ClientAssertionDescription()
+            ClientAssertionProviderBase clientAssertionDescription = new ClientAssertionProviderBase()
             {
                 ClientAssertionProvider = (cancellationToken =>
                 {


### PR DESCRIPTION
Contributes to fixing https://github.com/AzureAD/microsoft-identity-web/issues/1835 (part I: read and cache the assertion)

- Did the factorization proposed in the issue
- Updated TokenAcquirerTest as it was using the implicit usings, but this did not work across source control (Visual Studio tooling issue)

![image](https://user-images.githubusercontent.com/13203188/184451560-1f4dda03-bd50-4446-97ea-7975ffd87912.png)


Remains to do:
- In TokenAcquisition, do a similar processing as for ManagedIdentityClientAssertion, but for PodIdentityClientAssertion.
