### PR TITLE
- Integrating the PodIdentityClientAssertion to token acquisition.

### DIFF
--- a/src/Microsoft.Identity.Web.Certificateless/PodIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/PodIdentityClientAssertion.cs
@@ -13,18 +13,15 @@ namespace Microsoft.Identity.Web
     /// Gets a signed assertion from PodIdentity when an app is running in a container
     /// in Azure Kubernetes Services. See https://aka.ms/ms-id-web/certificateless.
     /// </summary>
-    internal class PodIdentityClientAssertion : ClientAssertionProviderBase
+    public class PodIdentityClientAssertion : ClientAssertionProviderBase
     {
         /// <summary>
         /// Gets a signed assertion from PodIdentity. The file path is provided
         /// by an environment variable ("AZURE_FEDERATED_TOKEN_FILE")
         /// See https://aka.ms/ms-id-web/certificateless.
         /// </summary>
-        public PodIdentityClientAssertion()
+        public PodIdentityClientAssertion() : this(null)
         {
-            // See https://blog.identitydigest.com/azuread-federate-k8s/
-            _filePath = Environment.GetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE");
-            ClientAssertionProvider = GetSignedAssertionFromFile;
         }
 
         /// <summary>
@@ -32,9 +29,10 @@ namespace Microsoft.Identity.Web
         /// See https://aka.ms/ms-id-web/certificateless.
         /// </summary>
         /// <param name="filePath"></param>
-        public PodIdentityClientAssertion(string filePath)
+        public PodIdentityClientAssertion(string? filePath)
         {
-            _filePath = filePath;
+            // See https://blog.identitydigest.com/azuread-federate-k8s/
+            _filePath = filePath ?? Environment.GetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE");
             ClientAssertionProvider = GetSignedAssertionFromFile;
         }
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ConfidentialClientApplicationBuilderExtension.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ConfidentialClientApplicationBuilderExtension.cs
@@ -24,6 +24,14 @@ namespace Microsoft.Identity.Web
                     }
                     return builder.WithClientAssertion((credential.CachedValue as ManagedIdentityClientAssertion)!.GetSignedAssertion);
                 }
+                if (credential.SourceType == CredentialSource.SignedAssertionFilePath)
+                {
+                    if (credential.CachedValue == null)
+                    {
+                        credential.CachedValue = new PodIdentityClientAssertion(credential.SignedAssertionFileDiskPath);
+                    }
+                    return builder.WithClientAssertion((credential.CachedValue as PodIdentityClientAssertion)!.GetSignedAssertion);
+                }
 
                 if (credential.CredentialType == CredentialType.Certificate)
                 {

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -532,11 +532,6 @@ namespace Microsoft.Identity.Web
                             enablePiiLogging: mergedOptions.ConfidentialClientApplicationOptions.EnablePiiLogging)
                         .WithExperimentalFeatures();
 
-                if (mergedOptions.ClientCredentialsUsingManagedIdentity != null && mergedOptions.ClientCredentialsUsingManagedIdentity.IsEnabled)
-                {
-                    builder.WithExtraQueryParameters("dc=ESTS-PUB-WUS2-AZ1-FD000-TEST2");
-                }
-
                 if (_tokenCacheProvider is MsalMemoryTokenCacheProvider)
                 {
                     builder.WithCacheOptions(CacheOptions.EnableSharedCacheOptions);


### PR DESCRIPTION
- Removing the test slice for MSI client assertion (no longer needed)
#1835 