### PR TITLE
Routing log always messages from MSAL to critical in logger extensions

### DIFF
--- a/src/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -1093,6 +1093,9 @@ namespace Microsoft.Identity.Web
         {
             switch (level)
             {
+                case Client.LogLevel.Always:
+                    _logger.LogCritical(message);
+                    break;
                 case Client.LogLevel.Error:
                     _logger.LogError(message);
                     break;


### PR DESCRIPTION
I noticed that the log messages for log.always are not included in the switch statement in the code. Since the log always information is very important for diagnosing some issues, I added it. 