### PR TITLE
Provides a default implementation for IAuthorizationHeaderProvider

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition.Abstractions/DownstreamRestApi/IAuthorizationHeaderProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition.Abstractions/DownstreamRestApi/IAuthorizationHeaderProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web
@@ -7,17 +8,40 @@ namespace Microsoft.Identity.Web
     /// <summary>
     /// Creates the value of an authorization header that the caller can use to call a protected web API
     /// </summary>
-    internal interface IAuthorizationHeaderProvider
+    public interface IAuthorizationHeaderProvider
     {
         /// <summary>
-        /// Creates the authorization header used to call a protected web API.
+        /// Creates the authorization header used to call a protected web API on behalf
+        /// of a user
         /// </summary>
         /// <param name="scopes">Scopes for which to request the authorization header.</param>
         /// <param name="downstreamApiOptions">Information about the API that will be called (for some
         /// protocols like Pop), and token acquisition options.</param>
         /// <param name="claimsPrincipal">Inbound authentication elements.</param>
-        /// <returns>A string containing the protocols (for instance: "Bearer token", "PoP token", etc ...)
-        /// and tokens.</returns>
-        Task<string> CreateAuthorizationHeaderAsync(IEnumerable<string> scopes, DownstreamRestApiOptions? downstreamApiOptions=null, ClaimsPrincipal? claimsPrincipal=null);
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A string containing the authorization request, that is protocol and tokens
+        /// (for instance: "Bearer token", "PoP token", etc ...)
+        /// </returns>
+        Task<string> CreateAuthorizationHeaderForUserAsync(
+            IEnumerable<string> scopes, 
+            DownstreamRestApiOptions? downstreamApiOptions=null, 
+            ClaimsPrincipal? claimsPrincipal=null,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Creates the authorization header used to call a protected web API on behalf
+        /// of the application itself
+        /// </summary>
+        /// <param name="scopes">Scopes for which to request the authorization header.</param>
+        /// <param name="downstreamApiOptions">Information about the API that will be called (for some
+        /// protocols like Pop), and token acquisition options.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A string containing the authorization request, that is protocol and tokens
+        /// (for instance: "Bearer token", "PoP token", etc ...)
+        /// </returns>
+        Task<string> CreateAuthorizationHeaderForAppAsync(
+            string scopes,
+            DownstreamRestApiOptions? downstreamApiOptions = null,
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web
+{
+    internal class DefaultAuthorizationHeaderProvider : IAuthorizationHeaderProvider
+    {
+        private readonly ITokenAcquisition _tokenAcquisition;
+
+        public DefaultAuthorizationHeaderProvider(ITokenAcquisition tokenAcquisition)
+        {
+            _tokenAcquisition = tokenAcquisition;
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> CreateAuthorizationHeaderForUserAsync(IEnumerable<string> scopes, DownstreamRestApiOptions? downstreamApiOptions = null, ClaimsPrincipal? claimsPrincipal = null, CancellationToken cancellationToken = default)
+        {
+            var result = await _tokenAcquisition.GetAuthenticationResultForUserAsync(
+                scopes,
+                downstreamApiOptions?.TokenAcquirerOptions.AuthenticationScheme,
+                downstreamApiOptions?.TokenAcquirerOptions.Tenant,
+                downstreamApiOptions?.TokenAcquirerOptions.UserFlow,
+                claimsPrincipal,
+                CreateTokenAcquisitionOptionsFromRestApiOptions(downstreamApiOptions, cancellationToken)).ConfigureAwait(false);
+            return result.CreateAuthorizationHeader();
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> CreateAuthorizationHeaderForAppAsync(string scopes, DownstreamRestApiOptions? downstreamApiOptions = null, CancellationToken cancellationToken = default)
+        {
+            var result = await _tokenAcquisition.GetAuthenticationResultForAppAsync(
+                scopes,
+                downstreamApiOptions?.TokenAcquirerOptions.Tenant,
+                downstreamApiOptions?.TokenAcquirerOptions.UserFlow,
+                CreateTokenAcquisitionOptionsFromRestApiOptions(downstreamApiOptions, cancellationToken)).ConfigureAwait(false);
+            return result.CreateAuthorizationHeader();
+        }
+
+        private static TokenAcquisitionOptions CreateTokenAcquisitionOptionsFromRestApiOptions(DownstreamRestApiOptions? downstreamApiOptions, CancellationToken cancellationToken)
+        {
+            return new TokenAcquisitionOptions()
+            {
+                AuthenticationScheme = downstreamApiOptions?.TokenAcquirerOptions.AuthenticationScheme,
+                CancellationToken = cancellationToken,
+                Claims = downstreamApiOptions?.TokenAcquirerOptions.Claims,
+                CorrelationId = downstreamApiOptions?.TokenAcquirerOptions.CorrelationId ?? default(Guid),
+                ExtraQueryParameters = downstreamApiOptions?.TokenAcquirerOptions.ExtraQueryParameters,
+                ForceRefresh = downstreamApiOptions?.TokenAcquirerOptions.ForceRefresh ?? false,
+                LongRunningWebApiSessionKey = downstreamApiOptions?.TokenAcquirerOptions.LongRunningWebApiSessionKey,
+                Tenant = downstreamApiOptions?.TokenAcquirerOptions.Tenant,
+                UserFlow = downstreamApiOptions?.TokenAcquirerOptions.UserFlow,
+                PopPublicKey = downstreamApiOptions?.TokenAcquirerOptions.PopPublicKey,
+            };
+        }
+
+
+    }
+}

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -62,7 +62,8 @@ namespace Microsoft.Identity.Web
             ServiceDescriptor? tokenAcquisitionService = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquisition));             
             ServiceDescriptor? tokenAcquisitionInternalService = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquisitionInternal));
             ServiceDescriptor? tokenAcquisitionhost = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquisitionHost));
-            if (tokenAcquisitionService != null && tokenAcquisitionInternalService != null && tokenAcquisitionhost != null)
+            ServiceDescriptor? authenticationHeaderCreator = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthorizationHeaderProvider));
+            if (tokenAcquisitionService != null && tokenAcquisitionInternalService != null && tokenAcquisitionhost != null && authenticationHeaderCreator != null)
             {
                 if (isTokenAcquisitionSingleton ^ (tokenAcquisitionService.Lifetime == ServiceLifetime.Singleton))
                 {
@@ -70,6 +71,7 @@ namespace Microsoft.Identity.Web
                     services.Remove(tokenAcquisitionService);
                     services.Remove(tokenAcquisitionInternalService);
                     services.Remove(tokenAcquisitionhost);
+                    services.Remove(authenticationHeaderCreator);
                 }
                 else
                 {
@@ -93,7 +95,7 @@ namespace Microsoft.Identity.Web
                 services.AddSingleton<ITokenAcquisitionHost, DefaultTokenAcquisitionHost>();
 #endif
                 services.AddSingleton(s => (ITokenAcquisitionInternal)s.GetRequiredService<ITokenAcquisition>());
-
+                services.AddSingleton<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
             }
             else
             {
@@ -110,6 +112,7 @@ namespace Microsoft.Identity.Web
                 services.AddScoped<ITokenAcquisitionHost, DefaultTokenAcquisitionHost>();
 #endif
                 services.AddScoped(s => (ITokenAcquisitionInternal)s.GetRequiredService<ITokenAcquisition>());
+                services.AddScoped<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
             }
 
             return services;

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -56,6 +56,14 @@ namespace Microsoft.Identity.Web.Test
                     Assert.Null(actual.ImplementationFactory);
                 },
                 actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Scoped, actual.Lifetime);
+                    Assert.Equal(typeof(IAuthorizationHeaderProvider), actual.ServiceType);
+                    Assert.Equal(typeof(DefaultAuthorizationHeaderProvider), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
                {
                    Assert.Equal(ServiceLifetime.Scoped, actual.Lifetime);
                    Assert.Equal(typeof(ITokenAcquisition), actual.ServiceType);

--- a/tests/daemon-app/Daemon-app/Daemon-app.csproj
+++ b/tests/daemon-app/Daemon-app/Daemon-app.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Program - SDK.cs" />
     <Compile Remove="Program-net60.cs" />
-    <Compile Remove="Program.cs" />
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="Program - SDK.cs" />
     <None Include="Program-net60.cs" />
-    <None Include="Program.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/daemon-app/Daemon-app/Program.cs
+++ b/tests/daemon-app/Daemon-app/Program.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#define UseMicrosoftGraphSdk
+//#define UseMicrosoftGraphSdk
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,11 +41,14 @@ namespace daemon_console
             Console.WriteLine($"{users.Count} users");
 #else
             // Get the token acquisition service
-            ITokenAcquirer tokenAcquirer = serviceProvider.GetRequiredService<ITokenAcquirer>();
-            string scope = configuration.GetValue<string>("Scopes");
+            ITokenAcquirer tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer();
             var result = await tokenAcquirer.GetTokenForAppAsync("https://graph.microsoft.com/.default");
             Console.WriteLine($"Token expires on {result.ExpiresOn}");
 
+            // Get the authorization request creator service
+            IAuthorizationHeaderProvider authorizationHeaderProvider = serviceProvider.GetRequiredService<IAuthorizationHeaderProvider>();
+            string authorizationHeader = await authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync("https://graph.microsoft.com/.default");
+            Console.WriteLine(authorizationHeader.Substring(0, authorizationHeader.IndexOf(" ")+4)+"...");
 #endif
         }
     }


### PR DESCRIPTION
Provides a default implementation for IAuthorizationHeaderProvider and a service to implement it.

Fixes IAuthorizationHeaderProvider to have both verbs (for User and for Apps) Update the daemon sample