### PR TITLE
Rename AuthenticationScheme to AuthenticationOptionsName

### DIFF
--- a/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionAuthenticationProvider.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/TokenAcquisitionAuthenticationProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Web
             }
 
             DownstreamRestApiOptions? downstreamRestApiOptions = new DownstreamRestApiOptions() { BaseUrl = "https://graph.microsoft.com", Scopes = scopes };
-            downstreamRestApiOptions.TokenAcquirerOptions.AuthenticationScheme = scheme;
+            downstreamRestApiOptions.TokenAcquirerOptions.AuthenticationOptionsName = scheme;
             downstreamRestApiOptions.TokenAcquirerOptions.Tenant = tenant;
 
             if (msalAuthProviderOption?.DownstreamRestApiOptions != null)

--- a/src/Microsoft.Identity.Web.TokenAcquisition.Abstractions/TokenAcquisition/AcquireTokenOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition.Abstractions/TokenAcquisition/AcquireTokenOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Web
         /// Region, Authority, client credentials) from a particular 
         /// (ASP.NET Core) authentication scheme / settings.
         /// </summary>
-        public string? AuthenticationScheme { get; set; }
+        public string? AuthenticationOptionsName { get; set; }
 
         /// <summary>
         /// Sets the correlation id to be used in the request to the STS "/token" endpoint.
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Web
             {
                 Tenant = Tenant,
                 UserFlow = UserFlow,
-                AuthenticationScheme = AuthenticationScheme,
+                AuthenticationOptionsName = AuthenticationOptionsName,
                 CorrelationId = CorrelationId,
                 ExtraQueryParameters = ExtraQueryParameters,
                 ExtraHeadersParameters = ExtraHeadersParameters,

--- a/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Web
         {
             var result = await _tokenAcquisition.GetAuthenticationResultForUserAsync(
                 scopes,
-                downstreamApiOptions?.TokenAcquirerOptions.AuthenticationScheme,
+                downstreamApiOptions?.TokenAcquirerOptions.AuthenticationOptionsName,
                 downstreamApiOptions?.TokenAcquirerOptions.Tenant,
                 downstreamApiOptions?.TokenAcquirerOptions.UserFlow,
                 claimsPrincipal,
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Web
         {
             return new TokenAcquisitionOptions()
             {
-                AuthenticationScheme = downstreamApiOptions?.TokenAcquirerOptions.AuthenticationScheme,
+                AuthenticationOptionsName = downstreamApiOptions?.TokenAcquirerOptions.AuthenticationOptionsName,
                 CancellationToken = cancellationToken,
                 Claims = downstreamApiOptions?.TokenAcquirerOptions.Claims,
                 CorrelationId = downstreamApiOptions?.TokenAcquirerOptions.CorrelationId ?? default(Guid),

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirer.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirer.cs
@@ -29,13 +29,13 @@ namespace Microsoft.Identity.Web
         {
             var result = await _tokenAcquisition.GetAuthenticationResultForUserAsync(
                 scopes,
-                tokenAcquisitionOptions?.AuthenticationScheme ?? _authenticationScheme,
+                tokenAcquisitionOptions?.AuthenticationOptionsName ?? _authenticationScheme,
                 tokenAcquisitionOptions?.Tenant,
                 tokenAcquisitionOptions?.UserFlow,
                 user,
                 (tokenAcquisitionOptions == null) ? null : new TokenAcquisitionOptions()
                 {
-                    AuthenticationScheme = tokenAcquisitionOptions?.AuthenticationScheme ?? _authenticationScheme,
+                    AuthenticationOptionsName = tokenAcquisitionOptions?.AuthenticationOptionsName ?? _authenticationScheme,
                     CancellationToken = cancellationToken,
                     Claims = tokenAcquisitionOptions!.Claims,
                     CorrelationId = tokenAcquisitionOptions!.CorrelationId,
@@ -60,11 +60,11 @@ namespace Microsoft.Identity.Web
         {
             var result = await _tokenAcquisition.GetAuthenticationResultForAppAsync(
                 scope,
-                tokenAcquisitionOptions?.AuthenticationScheme ?? _authenticationScheme,
+                tokenAcquisitionOptions?.AuthenticationOptionsName ?? _authenticationScheme,
                 tokenAcquisitionOptions?.Tenant,
                 (tokenAcquisitionOptions == null) ? null : new TokenAcquisitionOptions()
                 {
-                    AuthenticationScheme = tokenAcquisitionOptions?.AuthenticationScheme ?? _authenticationScheme,
+                    AuthenticationOptionsName = tokenAcquisitionOptions?.AuthenticationOptionsName ?? _authenticationScheme,
                     CancellationToken = cancellationToken,
                     Claims = tokenAcquisitionOptions!.Claims,
                     CorrelationId = tokenAcquisitionOptions.CorrelationId,

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisitionOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisitionOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Web
             {
                 Tenant = Tenant,
                 UserFlow = UserFlow,
-                AuthenticationScheme = AuthenticationScheme,
+                AuthenticationOptionsName = AuthenticationOptionsName,
                 CorrelationId = CorrelationId,
                 ExtraQueryParameters = ExtraQueryParameters,
                 ForceRefresh = ForceRefresh,


### PR DESCRIPTION
Rename AuthenticationScheme to AuthenticationOptionsName in TokenAcquisitionOptions
(those are really a reference to named options)