### PR TITLE
Bugfix #749  Claim Actions Missing & Not Running

### DIFF
--- a/src/Microsoft.Identity.Web/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web/MergedOptions.cs
@@ -65,6 +65,17 @@ namespace Microsoft.Identity.Web
             mergedOptions.BackchannelHttpHandler ??= microsoftIdentityOptions.BackchannelHttpHandler;
             mergedOptions.BackchannelTimeout = microsoftIdentityOptions.BackchannelTimeout;
             mergedOptions.CallbackPath = microsoftIdentityOptions.CallbackPath;
+
+            mergedOptions.ClaimActions.Clear();
+
+            foreach (var claimAction in microsoftIdentityOptions.ClaimActions)
+            {
+                if (!mergedOptions.ClaimActions.Contains(claimAction))
+                {
+                    mergedOptions.ClaimActions.Add(claimAction);
+                }
+            }
+            
             if (string.IsNullOrEmpty(mergedOptions.ClaimsIssuer) && !string.IsNullOrEmpty(microsoftIdentityOptions.ClaimsIssuer))
             {
                 mergedOptions.ClaimsIssuer = microsoftIdentityOptions.ClaimsIssuer;


### PR DESCRIPTION
Hello :wave: @jennyf19 
I believe this PR will fix the following issue #749 where ClaimActions are not run if you alter these when setting up Microsoft.Identity.Web in configuration/options.

I have unable to test this easily with my own code project, but with ClaimActions totally missing in the MergedOptions class I would believe this is the problem that myself and others are having.

Look forward to your feedback and input

Thanks,
Warren :)