### PR TITLE
Fix a few warnings:

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -99,6 +99,8 @@
     <MicrosoftExtensionsCachingMemoryVersion>2.1.0</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>2.1.0</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsConfigurationBinderVersion>2.2.4</MicrosoftExtensionsConfigurationBinderVersion>
+
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
+++ b/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Identity.Web
 
                         string? clientInfo = httpContext.Session[ClaimConstants.ClientInfo] as string;
 
-                        if (!string.IsNullOrEmpty(clientInfo))
+                        if (clientInfo!=null && !string.IsNullOrEmpty(clientInfo))
                         {
                             ClientInfo? clientInfoFromServer = ClientInfo.CreateFromJson(clientInfo);
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModelVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
   </ItemGroup>
 
@@ -35,8 +35,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
     <Compile Remove="AspNetCore\*.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// <param name="cacheKey">Key of the cache item to retrieve.</param>
         /// <returns>Read blob representing a token cache for the cache key
         /// (account or app).</returns>
-        protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey)
+        protected override async Task<byte[]?> ReadCacheBytesAsync(string cacheKey)
         {
             return await ReadCacheBytesAsync(cacheKey, new CacheSerializerHints()).ConfigureAwait(false);
         }
@@ -149,7 +149,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// <param name="cacheSerializerHints">Hints for the cache serialization implementation optimization.</param>
         /// <returns>Read blob representing a token cache for the cache key
         /// (account or app).</returns>
-        protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
+        protected override async Task<byte[]?> ReadCacheBytesAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
         {
             const string read = "Read";
             byte[]? result = null;

--- a/src/Microsoft.Identity.Web.TokenCache/InMemory/MsalMemoryTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/InMemory/MsalMemoryTokenCacheProvider.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.InMemory
         /// </summary>
         /// <param name="cacheKey">Token cache key.</param>
         /// <returns>Read Bytes.</returns>
-        protected override Task<byte[]> ReadCacheBytesAsync(string cacheKey)
+        protected override Task<byte[]?> ReadCacheBytesAsync(string cacheKey)
         {
-            byte[] tokenCacheBytes = (byte[])_memoryCache.Get(cacheKey);
+            byte[]? tokenCacheBytes = (byte[]?)_memoryCache.Get(cacheKey);
             return Task.FromResult(tokenCacheBytes);
         }
 

--- a/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
@@ -110,7 +110,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         {
             if (!string.IsNullOrEmpty(args.SuggestedCacheKey))
             {
-                byte[] tokenCacheBytes = await ReadCacheBytesAsync(args.SuggestedCacheKey, CreateHintsFromArgs(args)).ConfigureAwait(false);
+                byte[]? tokenCacheBytes = await ReadCacheBytesAsync(args.SuggestedCacheKey, CreateHintsFromArgs(args)).ConfigureAwait(false);
+                if (tokenCacheBytes == null)
+                {
+                    return;
+                }
 
                 try
                 {
@@ -137,7 +141,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
             }
         }
 
-        private byte[] UnprotectBytes(byte[] msalBytes)
+        private byte[] UnprotectBytes(byte[]? msalBytes)
         {
             if (msalBytes != null && _protector != null)
             {
@@ -204,7 +208,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// </summary>
         /// <param name="cacheKey">Cache key.</param>
         /// <returns>Read bytes.</returns>
-        protected abstract Task<byte[]> ReadCacheBytesAsync(string cacheKey);
+        protected abstract Task<byte[]?> ReadCacheBytesAsync(string cacheKey);
 
         /// <summary>
         /// Method to be overridden by concrete cache serializers to Read the cache bytes.
@@ -212,7 +216,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// <param name="cacheKey">Cache key.</param>
         /// <param name="cacheSerializerHints">Hints for the cache serialization implementation optimization.</param>
         /// <returns>Read bytes.</returns>
-        protected virtual Task<byte[]> ReadCacheBytesAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
+        protected virtual Task<byte[]?> ReadCacheBytesAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
         {
             return ReadCacheBytesAsync(cacheKey); // default implementation avoids a breaking change.
         }

--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -95,7 +95,10 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
             };
 
             OAuthChallengeProperties oAuthChallengeProperties = new OAuthChallengeProperties(items, parameters);
-            oAuthChallengeProperties.Scope = scope?.Split(" ");
+            if (scope != null)
+            {
+                oAuthChallengeProperties.Scope = scope.Split(" ");
+            }
             oAuthChallengeProperties.RedirectUri = redirectUri;
 
             return Challenge(
@@ -114,7 +117,11 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
         {
             if (AppServicesAuthenticationInformation.IsAppServicesAadAuthenticationEnabled)
             {
-                return LocalRedirect(AppServicesAuthenticationInformation.LogoutUrl);
+                if (AppServicesAuthenticationInformation.LogoutUrl != null)
+                {
+                    return LocalRedirect(AppServicesAuthenticationInformation.LogoutUrl);
+                }
+                return Ok();
             }
             else
             {

--- a/src/Microsoft.Identity.Web/AuthorizeForScopesAttribute.cs
+++ b/src/Microsoft.Identity.Web/AuthorizeForScopesAttribute.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Identity.Web
                 }
             }
 
-            base.OnException(context);
+            base.OnException(context!);
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         /// <param name="cacheKey">Key representing the token cache
         /// (account or app).</param>
         /// <returns>Read blob.</returns>
-        protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey)
+        protected override async Task<byte[]?> ReadCacheBytesAsync(string cacheKey)
         {
             return await ReadCacheBytesAsync(cacheKey, new CacheSerializerHints()).ConfigureAwait(false);
         }
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         /// (account or app).</param>
         /// <param name="cacheSerializerHints">Hints for the cache serialization implementation optimization.</param>
         /// <returns>Read blob.</returns>
-        protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
+        protected override async Task<byte[]?> ReadCacheBytesAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
         {
 #pragma warning disable CA1062 // Validate arguments of public methods
             await _session.LoadAsync(cacheSerializerHints.CancellationToken).ConfigureAwait(false);
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
             _sessionLock.EnterReadLock();
             try
             {
-                if (_session.TryGetValue(cacheKey, out byte[] blob))
+                if (_session.TryGetValue(cacheKey, out byte[]? blob))
                 {
                     Logger.SessionCache(_logger, "Read", _session.Id, cacheKey, null);
                 }

--- a/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
@@ -78,11 +78,9 @@ namespace Microsoft.Identity.Web.Test.Certificates
         [Fact]
         public void TestFromCertificate()
         {
-            using (X509Certificate2 certificate2 = new X509Certificate2())
-            {
-                CertificateDescription certificateDescription =
-                    CertificateDescription.FromCertificate(certificate2);
-            }
+            using X509Certificate2 certificate2 = new X509Certificate2(new byte[0]);
+            CertificateDescription certificateDescription =
+                CertificateDescription.FromCertificate(certificate2);
         }
     }
 }

--- a/tests/aspnet-mvc/OwinWebApp/Web.config
+++ b/tests/aspnet-mvc/OwinWebApp/Web.config
@@ -51,7 +51,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.23.1.0" newVersion="6.23.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -67,7 +67,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.23.1.0" newVersion="6.23.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.WsFederation" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -75,23 +75,23 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.23.1.0" newVersion="6.23.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.23.1.0" newVersion="6.23.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.23.1.0" newVersion="6.23.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.23.1.0" newVersion="6.23.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.46.0.0" newVersion="4.46.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.47.2.0" newVersion="4.47.2.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>


### PR DESCRIPTION
- Nullability contract in cache classes
- Adding missing MicrosoftExtensionsConfigurationBinderVersion in Directory.Builds.props for netstandard2.0
- Updating Web.Config for OWIN web app
- Updating CertificateDescriptionTest (to avoid obsolete constructor)