### PR TITLE
Bugfix #749  Claim Actions Missing & Not Running (#1899)

### DIFF
--- a/src/Microsoft.Identity.Web/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web/MergedOptions.cs
@@ -65,6 +65,17 @@ namespace Microsoft.Identity.Web
             mergedOptions.BackchannelHttpHandler ??= microsoftIdentityOptions.BackchannelHttpHandler;
             mergedOptions.BackchannelTimeout = microsoftIdentityOptions.BackchannelTimeout;
             mergedOptions.CallbackPath = microsoftIdentityOptions.CallbackPath;
+
+            mergedOptions.ClaimActions.Clear();
+
+            foreach (var claimAction in microsoftIdentityOptions.ClaimActions)
+            {
+                if (!mergedOptions.ClaimActions.Contains(claimAction))
+                {
+                    mergedOptions.ClaimActions.Add(claimAction);
+                }
+            }
+            
             if (string.IsNullOrEmpty(mergedOptions.ClaimsIssuer) && !string.IsNullOrEmpty(microsoftIdentityOptions.ClaimsIssuer))
             {
                 mergedOptions.ClaimsIssuer = microsoftIdentityOptions.ClaimsIssuer;


### PR DESCRIPTION
* Add in missing ClaimActions into MergedOptions

* Add unit test to verify that the merged option for ClaimAction will appear


@jmprieur - I did some local testing