### PR TITLE
Fix a race condition.

### DIFF
--- a/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Web
         /// <remarks>This code is inspired by Heath Stewart's code in:
         /// https://github.com/heaths/azsdk-sample-getcert/blob/master/Program.cs#L46-L82.
         /// </remarks>
-        internal async static Task<X509Certificate2?> LoadFromKeyVault(
+        internal static Task<X509Certificate2?> LoadFromKeyVault(
             string keyVaultUrl,
             string certificateName,
             string? managedIdentityClientId,
@@ -54,7 +54,7 @@ namespace Microsoft.Identity.Web
             CertificateClient certificateClient = new(keyVaultUri, credential);
             SecretClient secretClient = new(keyVaultUri, credential);
 
-            KeyVaultCertificateWithPolicy certificate = await certificateClient.GetCertificateAsync(certificateName);
+            KeyVaultCertificateWithPolicy certificate = certificateClient.GetCertificate(certificateName);
 
             if (certificate.Properties.NotBefore == null || certificate.Properties.ExpiresOn == null)
             {
@@ -69,10 +69,10 @@ namespace Microsoft.Identity.Web
             // Return a certificate with only the public key if the private key is not exportable.
             if (certificate.Policy?.Exportable != true)
             {
-                return new X509Certificate2(
+                return Task.FromResult<X509Certificate2?>(new X509Certificate2(
                     certificate.Cer,
                     (string?)null,
-                    x509KeyStorageFlags);
+                    x509KeyStorageFlags));
             }
 
             // Parse the secret ID and version to retrieve the private key.
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Web
             // .NET 5.0 preview introduces the System.Security.Cryptography.PemEncoding class to make this easier.
             if (CertificateConstants.MediaTypePksc12.Equals(secret.Properties.ContentType, StringComparison.OrdinalIgnoreCase))
             {
-                return Base64EncodedCertificateLoader.LoadFromBase64Encoded(secret.Value, x509KeyStorageFlags);
+                return Task.FromResult<X509Certificate2?>(Base64EncodedCertificateLoader.LoadFromBase64Encoded(secret.Value, x509KeyStorageFlags));
             }
 
             throw new NotSupportedException(

--- a/tests/aspnet-mvc/OwinWebApp/App_Start/Startup.Auth.cs
+++ b/tests/aspnet-mvc/OwinWebApp/App_Start/Startup.Auth.cs
@@ -5,6 +5,9 @@ using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Web.OWIN;
+using System.Web.Services.Description;
 
 namespace OwinWebApp
 {
@@ -16,13 +19,28 @@ namespace OwinWebApp
 
             app.UseCookieAuthentication(new CookieAuthenticationOptions());
 
+            /*
+             // What about this exeprience?
+                        OwinTokenAcquirerFactory factory = OwinTokenAcquirerFactory.GetDefaultInstance<OwinTokenAcquirerFactory>();
+
+                        app.AddMicrosoftIdentityWebApp(factory);
+                        factory.Services
+                            .Configure<ConfidentialClientApplicationOptions>(options => { options.RedirectUri = "https://localhost:44386/"; })
+                            .AddMicrosoftGraph()
+                            .AddInMemoryTokenCaches();
+                        factory.Build();
+            */
+
             app.AddMicrosoftIdentityWebApp(configureServices: services =>
             {
-                services.Configure<ConfidentialClientApplicationOptions>(options => { options.RedirectUri = "https://localhost:44386/"; });
-                services.AddMicrosoftGraph();
-                services.AddInMemoryTokenCaches();
+                services
+                .Configure<ConfidentialClientApplicationOptions>(options => { options.RedirectUri = "https://localhost:44386/"; })
+                .AddMicrosoftGraph()
+               // WE cannot do that today: Configuration is not available.
+               // .AddDownstreamRestApi("CalledApi", null)
+                .AddInMemoryTokenCaches();
             });
-                 
+
         }
     }
 }

--- a/tests/aspnet-mvc/OwinWebApp/Controllers/HomeController.cs
+++ b/tests/aspnet-mvc/OwinWebApp/Controllers/HomeController.cs
@@ -24,7 +24,9 @@ namespace OwinWebApp.Controllers
                 // OR - Example calling a downstream directly with the IDownstreamRestApi helper (uses the
                 // authorization header provider, encapsulates MSAL.NET)
                 IDownstreamRestApi downstreamRestApi = this.GetDownstreamRestApi();
-                var result = await downstreamRestApi.CallRestApiForUserAsync("DownstreamAPI");
+
+                // Not initialized yet
+                // var result = await downstreamRestApi.CallRestApiForUserAsync("CalledApi");
 
                 // OR - Get an authorization header (uses the token acquirer)
                 IAuthorizationHeaderProvider authorizationHeaderProvider =

--- a/tests/aspnet-mvc/OwinWebApp/OwinWebApp.csproj
+++ b/tests/aspnet-mvc/OwinWebApp/OwinWebApp.csproj
@@ -79,6 +79,10 @@
       <Project>{1e0b96cd-fdbf-482c-996a-775f691d984e}</Project>
       <Name>Microsoft.Identity.Web.Certificate</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.DownstreamRestApi\Microsoft.Identity.Web.DownstreamRestApi.csproj">
+      <Project>{a123bd94-812d-40ec-9576-1a7ab5c59913}</Project>
+      <Name>Microsoft.Identity.Web.DownstreamRestApi</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.MicrosoftGraph\Microsoft.Identity.Web.MicrosoftGraph.csproj">
       <Project>{e4bc2331-6822-45c3-9702-d76dd0556532}</Project>
       <Name>Microsoft.Identity.Web.MicrosoftGraph</Name>

--- a/tests/aspnet-mvc/OwinWebApp/Web.config
+++ b/tests/aspnet-mvc/OwinWebApp/Web.config
@@ -134,10 +134,6 @@
 				<bindingRedirect oldVersion="0.0.0.0-3.1.24.0" newVersion="3.1.24.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
 			</dependentAssembly>
@@ -157,8 +153,6 @@
 				<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
 			</dependentAssembly>
-			
-			
 			
     </assemblyBinding>
   </runtime>

--- a/tests/aspnet-mvc/OwinWebApp/appsettings.json
+++ b/tests/aspnet-mvc/OwinWebApp/appsettings.json
@@ -23,8 +23,8 @@
         App ID URI of a legacy v1 Web application
       Applications are registered in the https:portal.azure.com portal.
     */
-        "CalledApiScopes": "user.read",
-        "CalledApiUrl": "https://graph.microsoft.com/beta/"
+        "Scopes": ["user.read"],
+        "BaseUrl": "https://graph.microsoft.com/beta/"
     },
     "Logging": {
         "LogLevel": {


### PR DESCRIPTION
Fixes a race condition which could happen in OWIN apps (not ASP.NET Core)

## Reason
It's not possible to call async methods from `TokenAcquisition.BuildConfidentialClientApplication`, because of the lock line 528.
s

```CSharp
           if (!_applicationsByAuthorityClientId.TryGetValue(GetApplicationKey(mergedOptions), out application) || application == null)
            {
                lock (_applicationSyncObj)
                {
                    application = BuildConfidentialClientApplication(mergedOptions);
                    _applicationsByAuthorityClientId.TryAdd(GetApplicationKey(mergedOptions), application);
                }
            }
```

## Fix:
Removing the async loading of certificate