### PR TITLE
fix for claimAction and Scope with .NET 7

### DIFF
--- a/src/Microsoft.Identity.Web/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web/MergedOptions.cs
@@ -66,16 +66,17 @@ namespace Microsoft.Identity.Web
             mergedOptions.BackchannelTimeout = microsoftIdentityOptions.BackchannelTimeout;
             mergedOptions.CallbackPath = microsoftIdentityOptions.CallbackPath;
 
-            mergedOptions.ClaimActions.Clear();
-
-            foreach (var claimAction in microsoftIdentityOptions.ClaimActions)
+            if (mergedOptions.ClaimActions != microsoftIdentityOptions.ClaimActions)
             {
-                if (!mergedOptions.ClaimActions.Contains(claimAction))
+                foreach (var claimAction in microsoftIdentityOptions.ClaimActions.ToArray())
                 {
-                    mergedOptions.ClaimActions.Add(claimAction);
+                    if (!mergedOptions.ClaimActions.Any(c => c.ClaimType == claimAction.ClaimType && c.ValueType == claimAction.ValueType))
+                    {
+                        mergedOptions.ClaimActions.Add(claimAction);
+                    }
                 }
             }
-            
+
             if (string.IsNullOrEmpty(mergedOptions.ClaimsIssuer) && !string.IsNullOrEmpty(microsoftIdentityOptions.ClaimsIssuer))
             {
                 mergedOptions.ClaimsIssuer = microsoftIdentityOptions.ClaimsIssuer;
@@ -257,11 +258,14 @@ namespace Microsoft.Identity.Web
 
             mergedOptions.Scope.Clear();
 
-            foreach (var scope in microsoftIdentityOptions.Scope)
+            if (mergedOptions.Scope != microsoftIdentityOptions.Scope)
             {
-                if (!string.IsNullOrWhiteSpace(scope) && !mergedOptions.Scope.Any(s => string.Equals(s, scope, StringComparison.OrdinalIgnoreCase)))
+                foreach (var scope in microsoftIdentityOptions.Scope.ToArray())
                 {
-                    mergedOptions.Scope.Add(scope);
+                    if (!string.IsNullOrWhiteSpace(scope) && !mergedOptions.Scope.Any(s => string.Equals(s, scope, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        mergedOptions.Scope.Add(scope);
+                    }
                 }
             }
         }

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -18,6 +18,7 @@ using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.LoggingExtensions;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Linq;
 
 namespace Microsoft.Identity.Web
 {
@@ -428,9 +429,16 @@ namespace Microsoft.Identity.Web
             options.Configuration = mergedOptions.Configuration;
             options.ConfigurationManager = mergedOptions.ConfigurationManager;
             options.GetClaimsFromUserInfoEndpoint = mergedOptions.GetClaimsFromUserInfoEndpoint;
-            foreach (ClaimAction c in mergedOptions.ClaimActions)
+
+            if (options.ClaimActions != mergedOptions.ClaimActions)
             {
-                options.ClaimActions.Add(c);
+                foreach (ClaimAction claimAction in mergedOptions.ClaimActions.ToArray())
+                {
+                    if (!options.ClaimActions.Any((c => c.ClaimType == claimAction.ClaimType && c.ValueType == claimAction.ValueType)))
+                    {
+                        options.ClaimActions.Add(claimAction);
+                    }
+                }
             }
 
             options.RequireHttpsMetadata = mergedOptions.RequireHttpsMetadata;
@@ -446,9 +454,15 @@ namespace Microsoft.Identity.Web
             options.ResponseType = mergedOptions.ResponseType;
             options.Prompt = mergedOptions.Prompt;
 
-            foreach (string scope in mergedOptions.Scope)
+            if (options.Scope != mergedOptions.Scope)
             {
-                options.Scope.Add(scope);
+                foreach (string scope in mergedOptions.Scope.ToArray())
+                {
+                    if (!string.IsNullOrWhiteSpace(scope) && !options.Scope.Any(s => string.Equals(s, scope, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        options.Scope.Add(scope);
+                    }
+                }
             }
 
             options.RemoteSignOutPath = mergedOptions.RemoteSignOutPath;


### PR DESCRIPTION
fix for #1957 tested w/ Blazor server .NET 7 using the hot reload shared by a customer w/several browser tabs opened.