### PR TITLE
fix: AzureApp RoleClaimType with IdentityProvider

### DIFF
--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationHandler.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Web
         {
             if (AppServicesAuthenticationInformation.IsAppServicesAadAuthenticationEnabled)
             {
-                ClaimsPrincipal? claimsPrincipal = AppServicesAuthenticationInformation.GetUser(Context.Request.Headers);
+                ClaimsPrincipal? claimsPrincipal = AppServicesAuthenticationInformation.GetUser(Context.Request.Headers, Options.RoleClaimType);
                 if (claimsPrincipal != null)
                 {
                     AuthenticationTicket ticket = new AuthenticationTicket(claimsPrincipal, AppServicesAuthenticationDefaults.AuthenticationScheme);

--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
@@ -175,8 +175,9 @@ namespace Microsoft.Identity.Web
         /// Get the user claims from the headers and environment variables.
         /// </summary>
         /// <param name="headers">Headers.</param>
+        /// <param name="roleClaimType">RoleClaimType. The default is <see cref="ClaimsIdentity.DefaultRoleClaimType"/>.</param>
         /// <returns>User claims.</returns>
-        internal static ClaimsPrincipal? GetUser(IDictionary<string, StringValues> headers)
+        internal static ClaimsPrincipal? GetUser(IDictionary<string, StringValues> headers, string? roleClaimType = null)
         {
             ClaimsPrincipal? claimsPrincipal;
             string? idToken = GetIdToken(headers);
@@ -190,7 +191,7 @@ namespace Microsoft.Identity.Web
                     jsonWebToken.Claims,
                     idp,
                     isAadV1Token ? Constants.NameClaim : Constants.PreferredUserName,
-                    ClaimsIdentity.DefaultRoleClaimType));
+                    roleClaimType ?? ClaimsIdentity.DefaultRoleClaimType));
             }
             else
             {

--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationOptions.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationOptions.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Security.Claims;
+using System;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.Identity.Web
 {
@@ -10,5 +13,30 @@ namespace Microsoft.Identity.Web
     /// </summary>
     public class AppServicesAuthenticationOptions : AuthenticationSchemeOptions
     {
+        private string _roleClaimType = ClaimsIdentity.DefaultRoleClaimType;
+
+        /// <summary>
+        /// Gets or sets the <see cref="string"/> that defines the <see cref="ClaimsIdentity.RoleClaimType"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>Controls the results of <see cref="ClaimsPrincipal.IsInRole( string )"/>.</para>
+        /// <para>Each <see cref="Claim"/> where <see cref="Claim.Type"/> == <see cref="RoleClaimType"/> will be checked for a match against the 'string' passed to <see cref="ClaimsPrincipal.IsInRole(string)"/>.</para>
+        /// The default is <see cref="ClaimsIdentity.DefaultRoleClaimType"/>.
+        /// </remarks>
+        public string RoleClaimType
+        {
+            get
+            {
+                return _roleClaimType;
+            }
+
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), "RoleClaimType cannot be null or whitespace."));
+
+                _roleClaimType = value;
+            }
+        }
     }
 }


### PR DESCRIPTION
Adding option to set the default RoleClaimType via AppServicesAuthenticationOptions to use correct roles claim with Microsoft Identity Provider. Fixes #1983 

Can be set via
```csharp
builder.Services.Configure<AppServicesAuthenticationOptions>(AppServicesAuthenticationDefaults.AuthenticationScheme, options =>
{
    options.RoleClaimType = "roles";
});
```