### PR TITLE
Remove all TSA warnings

### DIFF
--- a/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
+++ b/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Identity.Web
                 context.TokenEndpointRequest.Parameters.TryGetValue("code_verifier", out string codeVerifier);
                 var tokenAcquisition = tokenAcquirerFactory?.ServiceProvider?.GetRequiredService<ITokenAcquisitionInternal>();
                 var msIdentityOptions = tokenAcquirerFactory?.ServiceProvider?.GetRequiredService<IOptions<MicrosoftIdentityOptions>>();
-                var idToken = await (tokenAcquisition!.AddAccountToCacheFromAuthorizationCodeAsync(
+                var result = await (tokenAcquisition!.AddAccountToCacheFromAuthorizationCodeAsync(
                     new string[] { options.Scope },
                     context.Code,
                     string.Empty,
@@ -198,7 +198,7 @@ namespace Microsoft.Identity.Web
                     msIdentityOptions?.Value.DefaultUserFlow)).ConfigureAwait(false);
                 HttpContextBase httpContext = context.OwinContext.Get<HttpContextBase>(typeof(HttpContextBase).FullName);
                 httpContext.Session.Add(ClaimConstants.ClientInfo, context.ProtocolMessage.GetParameter(ClaimConstants.ClientInfo));
-                context.HandleCodeRedemption(null, idToken);
+                context.HandleCodeRedemption(result.AccessToken, result.IdToken);
             };
 
             updateOptions?.Invoke(options);

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisition-AspnetCore.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisition-AspnetCore.cs
@@ -151,8 +151,8 @@ namespace Microsoft.Identity.Web
             string authCode = context!.ProtocolMessage!.Code;
             string? userFlow = context.Principal?.GetUserFlowId();
 
-            string idToken = await AddAccountToCacheFromAuthorizationCodeAsync(scopes, authCode, authenticationScheme, clientInfo, codeVerifier, userFlow).ConfigureAwait(false);
-            context.HandleCodeRedemption(null, idToken);
+            AcquireTokenResult result = await AddAccountToCacheFromAuthorizationCodeAsync(scopes, authCode, authenticationScheme, clientInfo, codeVerifier, userFlow).ConfigureAwait(false);
+            context.HandleCodeRedemption(result.AccessToken!, result.IdToken!);
         }
 
         TokenAcquirerFactory_GetTokenAcquirers? _implementation;

--- a/src/Microsoft.Identity.Web.TokenAcquisition/Base64UrlHelpers.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/Base64UrlHelpers.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Web.Util
         /// </summary>
         /// <param name="arg">string to encode.</param>
         /// <returns>Base64Url encoding of the UTF8 bytes.</returns>
-        public static string? Encode(string arg)
+        public static string? Encode(string? arg)
         {
             if (arg == null)
             {
@@ -143,7 +143,7 @@ namespace Microsoft.Identity.Web.Util
         /// <returns>The string representation in base 64 url encoding of length elements of inArray, starting at position offset.</returns>
         /// <exception cref="ArgumentNullException">'inArray' is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">offset or length is negative OR offset plus length is greater than the length of inArray.</exception>
-        public static string? Encode(byte[] inArray)
+        public static string? Encode(byte[]? inArray)
         {
             if (inArray == null)
             {
@@ -153,7 +153,7 @@ namespace Microsoft.Identity.Web.Util
             return Encode(inArray, 0, inArray.Length);
         }
 
-        internal static string? EncodeString(string str)
+        internal static string? EncodeString(string? str)
         {
             if (str == null)
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Identity.Web.Util
         ///  Converts the specified string, which encodes binary data as base-64-url digits, to an equivalent 8-bit unsigned integer array.</summary>
         /// <param name="str">base64Url encoded string.</param>
         /// <returns>UTF8 bytes.</returns>
-        public static byte[]? DecodeBytes(string str)
+        public static byte[]? DecodeBytes(string? str)
         {
             if (str == null)
             {

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ClientInfo.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ClientInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Web
         [JsonPropertyName(ClaimConstants.UniqueTenantIdentifier)]
         public string? UniqueTenantIdentifier { get; set; } = null;
 
-        public static ClientInfo? CreateFromJson(string clientInfo)
+        public static ClientInfo? CreateFromJson(string? clientInfo)
         {
             if (string.IsNullOrEmpty(clientInfo))
             {
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Web
             return bytes != null ? DeserializeFromJson(bytes) : null;
         }
 
-        internal static ClientInfo? DeserializeFromJson(byte[] jsonByteArray)
+        internal static ClientInfo? DeserializeFromJson(byte[]? jsonByteArray)
         {
             if (jsonByteArray == null || jsonByteArray.Length == 0)
             {

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ITokenAcquisitionInternal.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ITokenAcquisitionInternal.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 #endif
 
+using Microsoft.Identity.Abstractions;
+
 namespace Microsoft.Identity.Web
 {
     /// <summary>
@@ -63,8 +65,8 @@ namespace Microsoft.Identity.Web
         /// <param name="clientInfo">Client Info obtained with the code</param>
         /// <param name="codeVerifier">PKCE code verifier</param>
         /// <param name="userFlow">User flow in the case of B2C</param>
-        /// <returns>The ID Token.</returns>
-        Task<string> AddAccountToCacheFromAuthorizationCodeAsync(
+        /// <returns>The token acquirer result.</returns>
+        Task<AcquireTokenResult> AddAccountToCacheFromAuthorizationCodeAsync(
             IEnumerable<string> scopes, 
             string authCode, 
             string authenticationScheme, 

--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         protected override async Task WriteCacheBytesAsync(
             string cacheKey,
             byte[] bytes,
-            CacheSerializerHints cacheSerializerHints)
+            CacheSerializerHints? cacheSerializerHints)
         {
             const string write = "Write";
 
@@ -263,7 +263,8 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                     write,
                     (cacheKey) => _distributedCache.SetAsync(
                         cacheKey,
-                        bytes,
+                        bytes!, // We know that in the Write case, the bytes won't be null 
+                                // the parent class 
                         distributedCacheEntryOptions,
                         cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
                     cacheKey).Measure().ConfigureAwait(false);
@@ -275,7 +276,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                  write,
                  (cacheKey) => _distributedCache.SetAsync(
                      cacheKey,
-                     bytes,
+                     bytes!,
                      distributedCacheEntryOptions,
                      cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
                  cacheKey).Measure().ConfigureAwait(false));

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApi.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
@@ -16,7 +17,12 @@ namespace Microsoft.Identity.Web
     /// <summary>
     /// Implementation for the downstream web API.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
+    [Obsolete("Use DownstreamRestApi in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
+        "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class DownstreamWebApi : IDownstreamWebApi
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         private readonly ITokenAcquisition _tokenAcquisition;
         private readonly HttpClient _httpClient;

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,6 +23,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The builder for chaining.</returns>
         [Obsolete("Use AddDownstreamRestApi in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static MicrosoftIdentityAppCallsWebApiAuthenticationBuilder AddDownstreamWebApi(
             this MicrosoftIdentityAppCallsWebApiAuthenticationBuilder builder,
             string serviceName,
@@ -44,6 +46,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The builder for chaining.</returns>
         [Obsolete("Use AddDownstreamRestApi in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static MicrosoftIdentityAppCallsWebApiAuthenticationBuilder AddDownstreamWebApi(
             this MicrosoftIdentityAppCallsWebApiAuthenticationBuilder builder,
             string serviceName,

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiGenericExtensions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiGenericExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
@@ -35,6 +36,7 @@ namespace Microsoft.Identity.Web
         /// <returns>A strongly typed response from the web API.</returns>
         [Obsolete("Use IDownstreamRestApi.GetForUserAsync in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task<TOutput?> GetForUserAsync<TOutput>(
             this IDownstreamWebApi downstreamWebApi,
             string serviceName,
@@ -75,6 +77,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The value returned by the downstream web API.</returns>
         [Obsolete("Use IDownstreamRestApi.GetForUserAsync in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task GetForUserAsync<TInput>(
             this IDownstreamWebApi downstreamWebApi,
             string serviceName,
@@ -118,6 +121,7 @@ namespace Microsoft.Identity.Web
         /// <returns>A strongly typed response from the web API.</returns>
         [Obsolete("Use IDownstreamRestApi.PostForUserAsync in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task<TOutput?> PostForUserAsync<TOutput, TInput>(
             this IDownstreamWebApi downstreamWebApi,
             string serviceName,
@@ -163,6 +167,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The value returned by the downstream web API.</returns>
         [Obsolete("Use IDownstreamRestApi.PutForUserAsync in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task PutForUserAsync<TInput>(
             this IDownstreamWebApi downstreamWebApi,
             string serviceName,
@@ -207,6 +212,7 @@ namespace Microsoft.Identity.Web
         /// <returns>A strongly typed response from the web API.</returns>
         [Obsolete("Use IDownstreamRestApi.PutForUserAsync in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task<TOutput?> PutForUserAsync<TOutput, TInput>(
             this IDownstreamWebApi downstreamWebApi,
             string serviceName,
@@ -251,6 +257,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The value returned by the downstream web API.</returns>
         [Obsolete("Use IDownstreamRestApi.CallWebApiForUserAsync in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task<TOutput?> CallWebApiForUserAsync<TOutput>(
             this IDownstreamWebApi downstreamWebApi,
             string serviceName,

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/IDownstreamWebApi.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/IDownstreamWebApi.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ namespace Microsoft.Identity.Web
     /// </summary>
     [Obsolete("Use IDownstreamRestApi in Microsoft.Identity.Abstractions, implemented in Microsoft.Identity.Web.DownstreamRestApi." +
         "See aka.ms/id-web-downstream-api-v2 for migration details.", false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public interface IDownstreamWebApi
     {
         /// <summary>

--- a/src/Microsoft.Identity.Web/IncrementalConsentAndConditionalAccessHelper.cs
+++ b/src/Microsoft.Identity.Web/IncrementalConsentAndConditionalAccessHelper.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Web
                  OidcConstants.ScopeProfile,
             };
 
-            HashSet<string> oidcParams = new HashSet<string>(scopes);
+            HashSet<string> oidcParams = new(scopes);
             oidcParams.UnionWith(additionalBuiltInScopes);
             properties.SetParameter(OpenIdConnectParameterNames.Scope, oidcParams.ToList());
 

--- a/tests/DevApps/B2CWebAppCallsWebApi/Client/Startup.cs
+++ b/tests/DevApps/B2CWebAppCallsWebApi/Client/Startup.cs
@@ -43,7 +43,7 @@ namespace WebApp_OpenIDConnect_DotNet
             services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
                     .AddMicrosoftIdentityWebApp(Configuration, "AzureAdB2C")
                         .EnableTokenAcquisitionToCallDownstreamApi(initialScopes: new string[] { Configuration["TodoList:Scopes"] })
-                        .AddDownstreamWebApi("TodoList", Configuration.GetSection("TodoList"))
+                        .AddDownstreamRestApi("TodoList", Configuration.GetSection("TodoList"))
                         .AddInMemoryTokenCaches();
 
             services.AddControllersWithViews(options =>

--- a/tests/DevApps/B2CWebAppCallsWebApi/Client/TodoListClient.csproj
+++ b/tests/DevApps/B2CWebAppCallsWebApi/Client/TodoListClient.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Microsoft.Identity.Web.DownstreamRestApi\Microsoft.Identity.Web.DownstreamRestApi.csproj" />
     <ProjectReference Include="..\..\..\..\src\Microsoft.Identity.Web.UI\Microsoft.Identity.Web.UI.csproj" />
     <ProjectReference Include="..\..\..\..\src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />
   </ItemGroup>

--- a/tests/DevApps/BlazorServerCallsGraph/Startup.cs
+++ b/tests/DevApps/BlazorServerCallsGraph/Startup.cs
@@ -30,7 +30,7 @@ namespace blazor
                     .AddMicrosoftIdentityWebApp(Configuration, "AzureAd", subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: true)
                         .EnableTokenAcquisitionToCallDownstreamApi()
                             .AddMicrosoftGraph(Configuration.GetSection("GraphBeta"))
-                            .AddDownstreamWebApi("CalledApi", Configuration.GetSection("CalledApi"))
+                            .AddDownstreamRestApi("CalledApi", Configuration.GetSection("CalledApi"))
                         .AddInMemoryTokenCaches();
 
             services.AddControllersWithViews()

--- a/tests/DevApps/BlazorServerCallsGraph/blazor.csproj
+++ b/tests/DevApps/BlazorServerCallsGraph/blazor.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="Microsoft.Azure.SignalR" Version="1.5.1" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.DownstreamRestApi\Microsoft.Identity.Web.DownstreamRestApi.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.MicrosoftGraph\Microsoft.Identity.Web.MicrosoftGraph.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.UI\Microsoft.Identity.Web.UI.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />

--- a/tests/DevApps/MultipleAuthSchemes/Startup.cs
+++ b/tests/DevApps/MultipleAuthSchemes/Startup.cs
@@ -41,7 +41,7 @@ namespace mvcwebapp_graph
             services.AddAuthentication()
                 .AddMicrosoftIdentityWebApp(Configuration.GetSection("AzureAdB2C"), "B2C", "cookiesB2C")
                     .EnableTokenAcquisitionToCallDownstreamApi(Configuration.GetValue<string>("DownstreamB2CApi:Scopes")?.Split(' '))
-                    .AddDownstreamWebApi("DownstreamB2CApi", Configuration.GetSection("DownstreamB2CApi"))
+                    .AddDownstreamRestApi("DownstreamB2CApi", Configuration.GetSection("DownstreamB2CApi"))
                     .AddInMemoryTokenCaches();
 
             //services.Configure<MicrosoftIdentityOptions>(OpenIdConnectDefaults.AuthenticationScheme,

--- a/tests/DevApps/MultipleAuthSchemes/mvcwebapp-graph.csproj
+++ b/tests/DevApps/MultipleAuthSchemes/mvcwebapp-graph.csproj
@@ -3,6 +3,7 @@
      <UserSecretsId>5d200413-0b8e-40d1-b1e9-1874fe6e8bde</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.DownstreamRestApi\Microsoft.Identity.Web.DownstreamRestApi.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.MicrosoftGraph\Microsoft.Identity.Web.MicrosoftGraph.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.UI\Microsoft.Identity.Web.UI.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />

--- a/tests/DevApps/WebAppCallsMicrosoftGraph/Startup.cs
+++ b/tests/DevApps/WebAppCallsMicrosoftGraph/Startup.cs
@@ -37,10 +37,8 @@ namespace WebAppCallsMicrosoftGraph
                     .AddMicrosoftIdentityWebApp(Configuration.GetSection(configSection))
                         .EnableTokenAcquisitionToCallDownstreamApi()
                            .AddMicrosoftGraph(Configuration.GetSection("GraphBeta"))
-                           .AddDownstreamWebApi("GraphBeta", Configuration.GetSection("GraphBeta"))
+                           .AddDownstreamRestApi("GraphBeta", Configuration.GetSection("GraphBeta"))
                            .AddInMemoryTokenCaches();
-
-            services.AddDownstreamRestApi("GraphBeta", Configuration.GetSection("GraphBeta"));
 
             //services.Configure<ConfidentialClientApplicationOptions>(OpenIdConnectDefaults.AuthenticationScheme,
             //    options => { options.AzureRegion = ConfidentialClientApplication.AttemptRegionDiscovery; });

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Startup.cs
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Startup.cs
@@ -67,9 +67,9 @@ namespace WebApp_OpenIDConnect_DotNet
             services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
               .AddMicrosoftIdentityWebApp(Configuration)
                  .EnableTokenAcquisitionToCallDownstreamApi()
-                     .AddDownstreamWebApi("SayHello", Configuration.GetSection("SayHello"))
-                     .AddDownstreamWebApi("TodoListJwe", Configuration.GetSection("TodoListJwe"))
-                     .AddDownstreamWebApi("AzureFunction", Configuration.GetSection("AzureFunction"))
+                     .AddDownstreamRestApi("SayHello", Configuration.GetSection("SayHello"))
+                     .AddDownstreamRestApi("TodoListJwe", Configuration.GetSection("TodoListJwe"))
+                     .AddDownstreamRestApi("AzureFunction", Configuration.GetSection("AzureFunction"))
 
 #if UseRedisCache
                      .AddDistributedTokenCaches();

--- a/tests/IntegrationTests/WebAppUiTests/TestingWebAppLocally.cs
+++ b/tests/IntegrationTests/WebAppUiTests/TestingWebAppLocally.cs
@@ -27,7 +27,7 @@ public class TestingWebAppLocally
 
         string uiTestAssemblyLocation = typeof(TestingWebAppLocally).Assembly.Location;
         // e.g. C:\gh\microsoft-identity-web\tests\IntegrationTests\WebAppUiTests\bin\Debug\net6.0\WebAppUiTests.dll
-        string testedAppLocation = Path.Combine(Path.GetDirectoryName(uiTestAssemblyLocation));
+        string testedAppLocation = Path.Combine(Path.GetDirectoryName(uiTestAssemblyLocation)!);
         // e.g. C:\gh\microsoft-identity-web\tests\IntegrationTests\WebAppUiTests\bin\Debug\net6.0
         string[] segments = testedAppLocation.Split(Path.DirectorySeparatorChar);
         int numberSegments = segments.Length;

--- a/tests/IntegrationTests/WebAppUiTests/WebAppIntegrationTests.cs
+++ b/tests/IntegrationTests/WebAppUiTests/WebAppIntegrationTests.cs
@@ -112,10 +112,8 @@ namespace WebAppUiTests
             try
             {
                 element = wait.Until(drv => drv.FindElement(By.Id(elementName)));
-                IWebElement e;
-                   
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 element = wait.Until(drv => drv.FindElement(By.Id(elementName)));
             }

--- a/tests/Microsoft.Identity.Web.Test.Common/Mocks/LoggerMock.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/Mocks/LoggerMock.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
     /// https://github.com/nsubstitute/NSubstitute/issues/597
     /// https://github.com/moq/moq4/issues/918.
     /// </remarks>
+#pragma warning disable CS8603 // Possible null reference return.
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
+#pragma warning disable CS8633 // Nullability in constraints for type parameter doesn't match the constraints for type parameter in implicitly implemented interface method'.
+#pragma warning disable CS8604 // Possible null reference argument.
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
     public class LoggerMock<T> : ILogger<T>
     {
         private ILogger<T> _logger;
@@ -35,4 +40,9 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             => _logger.Log<object>(logLevel, eventId, state, exception, (s, e) => string.Empty);
     }
+#pragma warning restore CS8603 // Possible null reference return.
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
+#pragma warning restore CS8633 // Nullability in constraints for type parameter doesn't match the constraints for type parameter in implicitly implemented interface method'.
+#pragma warning restore CS8604 // Possible null reference argument.
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
 }

--- a/tests/Microsoft.Identity.Web.Test.Common/Mocks/MockHttpCreator.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/Mocks/MockHttpCreator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
 
         private static string CreateClientInfo(string uid = TestConstants.Uid, string utid = TestConstants.Utid)
         {
-            return Base64UrlHelpers.Encode("{\"uid\":\"" + uid + "\",\"utid\":\"" + utid + "\"}");
+            return Base64UrlHelpers.Encode("{\"uid\":\"" + uid + "\",\"utid\":\"" + utid + "\"}")!;
         }
 
         public static MockHttpMessageHandler CreateInstanceDiscoveryMockHandler(

--- a/tests/Microsoft.Identity.Web.Test.Common/Mocks/MockHttpMessageHandler.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/Mocks/MockHttpMessageHandler.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
 {
     public class MockHttpMessageHandler : HttpMessageHandler
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public MockHttpMessageHandler()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+
+        }
         public HttpResponseMessage ResponseMessage { get; set; }
 
         public string ExpectedUrl { get; set; }
@@ -34,6 +40,7 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
             }
 
             var uri = request.RequestUri;
+            Assert.NotNull(uri);
             if (!string.IsNullOrEmpty(ExpectedUrl))
             {
                 Assert.Equal(

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/InMemoryTokenCache.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/InMemoryTokenCache.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
 {
     public class InMemoryTokenCache
     {
-        private byte[] _cacheData;
+        private byte[]? _cacheData;
 
         /// <summary>
         /// Path to the token cache.

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/MsalTestTokenCacheProvider.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/MsalTestTokenCacheProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
             : base(null)
         {
             MemoryCache = memoryCache;
-            _cacheOptions = cacheOptions?.Value;
+            _cacheOptions = cacheOptions.Value;
         }
 
         public IMemoryCache MemoryCache { get; }
@@ -27,9 +27,9 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
 
         private readonly MsalMemoryTokenCacheOptions _cacheOptions;
 
-        protected override Task<byte[]> ReadCacheBytesAsync(string cacheKey)
+        protected override Task<byte[]?> ReadCacheBytesAsync(string cacheKey)
         {
-            byte[] tokenCacheBytes = (byte[])MemoryCache.Get(cacheKey);
+            byte[]? tokenCacheBytes = (byte[]?)MemoryCache.Get(cacheKey);
             return Task.FromResult(tokenCacheBytes);
         }
 

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/TestMsalDistributedTokenCacheAdapter.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/TestMsalDistributedTokenCacheAdapter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
             IDistributedCache distributedCache,
             IOptions<MsalDistributedTokenCacheAdapterOptions> distributedCacheOptions,
             ILogger<MsalDistributedTokenCacheAdapter> logger,
-            IServiceProvider serviceProvider = null)
+            IServiceProvider? serviceProvider=null)
             : base(distributedCache, distributedCacheOptions, logger, serviceProvider)
         {
         }
@@ -33,12 +33,12 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
             await RemoveKeyAsync(cacheKey).ConfigureAwait(false);
         }
 
-        public async Task TestWriteCacheBytesAsync(string cacheKey, byte[] bytes, CacheSerializerHints cacheSerializerHints = null)
+        public async Task TestWriteCacheBytesAsync(string cacheKey, byte[] bytes, CacheSerializerHints? cacheSerializerHints = null)
         {
             await WriteCacheBytesAsync(cacheKey, bytes, cacheSerializerHints).ConfigureAwait(false);
         }
 
-        public async Task<byte[]> TestReadCacheBytesAsync(string cacheKey)
+        public async Task<byte[]?> TestReadCacheBytesAsync(string cacheKey)
         {
             return await ReadCacheBytesAsync(cacheKey).ConfigureAwait(false);
         }

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/TestOptionsMonitor.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/TestOptionsMonitor.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
 
         public T CurrentValue { get; private set; }
 
-        public T Get(string name)
+        public T Get(string? name)
         {
             return CurrentValue;
         }
@@ -27,7 +27,9 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
         public void Set(T value)
         {
             CurrentValue = value;
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             _listener?.Invoke(value, null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         public IDisposable OnChange(Action<T, string> listener)

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Web.Test.Integration
     public class AcquireTokenForAppIntegrationTests
     {
         private TokenAcquisition _tokenAcquisition;
-        private ServiceProvider _provider;
+        private ServiceProvider? _provider;
         private MsalTestTokenCacheProvider _msalTestTokenCacheProvider;
         private IOptionsMonitor<MicrosoftIdentityOptions> _microsoftIdentityOptionsMonitor;
         private IOptionsMonitor<ConfidentialClientApplicationOptions> _applicationOptionsMonitor;
@@ -39,7 +39,11 @@ namespace Microsoft.Identity.Web.Test.Integration
         private readonly string _ccaSecret;
         private readonly ITestOutputHelper _output;
 
+        private ServiceProvider Provider { get => _provider!;  }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public AcquireTokenForAppIntegrationTests(ITestOutputHelper output) // test set-up
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             _output = output;
 
@@ -201,7 +205,7 @@ namespace Microsoft.Identity.Web.Test.Integration
 
             // Act & Assert
             async Task result() =>
-                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_userReadScope.FirstOrDefault()).ConfigureAwait(false);
+                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_userReadScope.First()).ConfigureAwait(false);
 
             ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(result).ConfigureAwait(false);
 
@@ -209,7 +213,7 @@ namespace Microsoft.Identity.Web.Test.Integration
 
             // Act & Assert
             async Task authResult() =>
-                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_userReadScope.FirstOrDefault()).ConfigureAwait(false);
+                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_userReadScope.First()).ConfigureAwait(false);
 
             ArgumentException ex2 = await Assert.ThrowsAsync<ArgumentException>(authResult).ConfigureAwait(false);
 
@@ -222,7 +226,7 @@ namespace Microsoft.Identity.Web.Test.Integration
         {
             var serviceCollection = new ServiceCollection();
             var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
+                .AddInMemoryCollection(new Dictionary<string, string?>
                 {
                     { "AzureAd:Instance", "https://login.microsoftonline.com/" },
                     { "AzureAd:TenantId", TestConstants.ConfidentialClientLabTenant },
@@ -247,25 +251,25 @@ namespace Microsoft.Identity.Web.Test.Integration
         private void InitializeTokenAcquisitionObjects()
         {
             _credentialsLoader = new DefaultCredentialsLoader();
-            MergedOptions mergedOptions = _provider.GetRequiredService<IMergedOptionsStore>().Get(OpenIdConnectDefaults.AuthenticationScheme);
+            MergedOptions mergedOptions = Provider.GetRequiredService<IMergedOptionsStore>().Get(OpenIdConnectDefaults.AuthenticationScheme);
 
             MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(_microsoftIdentityOptionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme), mergedOptions);
             MergedOptions.UpdateMergedOptionsFromConfidentialClientApplicationOptions(_applicationOptionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme), mergedOptions);
 
             _msalTestTokenCacheProvider = new MsalTestTokenCacheProvider(
-                 _provider.GetService<IMemoryCache>(),
-                 _provider.GetService<IOptions<MsalMemoryTokenCacheOptions>>());
+                 Provider.GetService<IMemoryCache>()!,
+                 Provider.GetService<IOptions<MsalMemoryTokenCacheOptions>>()!);
 
             var tokenAcquisitionAspnetCoreHost = new TokenAcquisitionAspnetCoreHost(
                 MockHttpContextAccessor.CreateMockHttpContextAccessor(),
-                _provider.GetService<IMergedOptionsStore>(),
-                _provider);
+                Provider.GetService<IMergedOptionsStore>()!,
+                Provider);
             _tokenAcquisition = new TokenAcquisitionAspNetCore(
                  _msalTestTokenCacheProvider,
-                 _provider.GetService<IHttpClientFactory>(),
-                 _provider.GetService<ILogger<TokenAcquisition>>(),
+                 Provider.GetService<IHttpClientFactory>()!,
+                 Provider.GetService<ILogger<TokenAcquisition>>()!,
                  tokenAcquisitionAspnetCoreHost,
-                 _provider,
+                 Provider,
                  _credentialsLoader);
             tokenAcquisitionAspnetCoreHost.GetOptions(OpenIdConnectDefaults.AuthenticationScheme, out _);
         }

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/Microsoft.Identity.Web.Test.LabInfrastructure.csproj
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/Microsoft.Identity.Web.Test.LabInfrastructure.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Identity.Web.Test/AccountExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AccountExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void ToClaimsPrincipal_NullAccount_ReturnsNull()
         {
-            IAccount account = null;
+            IAccount account = null!; // Forcing null to test the argument null exception
 
             Assert.Throws<ArgumentNullException>("account", () => account.ToClaimsPrincipal());
         }

--- a/tests/Microsoft.Identity.Web.Test/Base64UrlHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Base64UrlHelpersTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void Encode_NullByteArray_ReturnsNull()
         {
-            byte[] byteArrayToEncode = null;
+            byte[]? byteArrayToEncode = null;
             Assert.Null(Base64UrlHelpers.Encode(byteArrayToEncode));
         }
 
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void Encode_NullString_ReturnsNull()
         {
-            string stringToEncode = null;
+            string? stringToEncode = null;
             Assert.Null(Base64UrlHelpers.Encode(stringToEncode));
         }
 

--- a/tests/Microsoft.Identity.Web.Test/CacheEncryptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CacheEncryptionTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Identity.Client;
@@ -18,8 +20,12 @@ namespace Microsoft.Identity.Web.Test
 {
     public class CacheEncryptionTests
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        // These fields won't be null in tests, as tests call BuildTheRequiredServices()
         private TestMsalDistributedTokenCacheAdapter _testCacheAdapter;
         private IServiceProvider _provider;
+
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [Theory]
         [InlineData(true)]
@@ -29,7 +35,7 @@ namespace Microsoft.Identity.Web.Test
             // Arrange
             byte[] cache = new byte[] { 1, 2, 3, 4 };
             BuildTheRequiredServices(isEncrypted);
-            _testCacheAdapter = _provider.GetService<IMsalTokenCacheProvider>() as TestMsalDistributedTokenCacheAdapter;
+            _testCacheAdapter = (_provider.GetRequiredService<IMsalTokenCacheProvider>() as TestMsalDistributedTokenCacheAdapter)!;
             TestTokenCache tokenCache = new TestTokenCache();
             TokenCacheNotificationArgs args = InstantiateTokenCacheNotificationArgs(tokenCache);
             _testCacheAdapter.Initialize(tokenCache);
@@ -40,33 +46,34 @@ namespace Microsoft.Identity.Web.Test
             await tokenCache._afterAccess(args).ConfigureAwait(false);
 
             // Assert
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
-            Assert.NotEqual(cache.SequenceEqual(GetFirstCacheValue()), isEncrypted);
+            Assert.NotEqual(cache.SequenceEqual(GetFirstCacheValue(_testCacheAdapter._memoryCache)), isEncrypted);
         }
 
-        private byte[] GetFirstCacheValue()
+        private byte[] GetFirstCacheValue(MemoryCache memoryCache)
         {
+            IDictionary memoryCacheContent;
 #if NET7_0_OR_GREATER
-            dynamic content1 = _testCacheAdapter._memoryCache
+            dynamic content1 = memoryCache
                 .GetType()
-                .GetField("_coherentState", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-                .GetValue(_testCacheAdapter._memoryCache);
-            dynamic? content = content1?
+                .GetField("_coherentState", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(memoryCache)!;
+            memoryCacheContent = (content1?
                 .GetType()
                 .GetField("_entries", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-                .GetValue(content1);
+                .GetValue(content1) as IDictionary)!;
 #else
-            dynamic content = _testCacheAdapter._memoryCache
+            memoryCacheContent = (memoryCache
                 .GetType()
-                .GetField("_entries", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-                .GetValue(_testCacheAdapter._memoryCache);
+                .GetField("_entries", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(_testCacheAdapter._memoryCache) as IDictionary)!;
 #endif
-            System.Collections.IDictionary dictionary = content as System.Collections.IDictionary;
-            var firstEntry = dictionary.Values.OfType<object>().First();
+            var firstEntry = memoryCacheContent.Values.OfType<object>().First();
             var firstEntryValue = firstEntry.GetType()
-                .GetProperty("Value")
+                .GetProperty("Value")!
                 .GetValue(firstEntry);
-            return firstEntryValue as byte[];
+            return (firstEntryValue as byte[])!;
         }
 
         private void BuildTheRequiredServices(bool isEncrypted)
@@ -91,7 +98,7 @@ namespace Microsoft.Identity.Web.Test
         {
             ITokenCacheSerializer tokenCacheSerializer = tokenCache;
             string clientId = string.Empty;
-            IAccount account = null;
+            IAccount? account = null;
             bool hasStateChanged = true;
             bool isAppCache = false;
             bool hasTokens = true;
@@ -115,9 +122,11 @@ namespace Microsoft.Identity.Web.Test
 
     public class TestTokenCache : ITokenCache, ITokenCacheSerializer
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public byte[] cache;
         public Func<TokenCacheNotificationArgs, Task> _beforeAccess;
         public Func<TokenCacheNotificationArgs, Task> _afterAccess;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         public void Deserialize(byte[] msalV2State)
         {

--- a/tests/Microsoft.Identity.Web.Test/CacheExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CacheExtensionsTests.cs
@@ -14,7 +14,10 @@ namespace Microsoft.Identity.Web.Test
 {
     public class CacheExtensionsTests
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         private IConfidentialClientApplication _confidentialApp;
+        // Non nullable needed for the Argument null exception tests
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [Fact]
         public void InMemoryCacheExtensionsTests()
@@ -81,7 +84,7 @@ namespace Microsoft.Identity.Web.Test
         public void InMemoryCache_WithServices_NoService_ThrowsException_Tests()
         {
             CreateCca();
-            var ex = Assert.Throws<ArgumentNullException>(() => _confidentialApp.AddInMemoryTokenCache(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => _confidentialApp.AddInMemoryTokenCache(null!));
 
             Assert.Equal("initializeMemoryCache", ex.ParamName);
         }
@@ -114,7 +117,7 @@ namespace Microsoft.Identity.Web.Test
         public void DistributedCacheExtensions_NoService_ThrowsException_Tests()
         {
             CreateCca();
-            var ex = Assert.Throws<ArgumentNullException>(() => _confidentialApp.AddDistributedTokenCache(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => _confidentialApp.AddDistributedTokenCache(null!));
 
             Assert.Equal("initializeDistributedCache", ex.ParamName);
         }

--- a/tests/Microsoft.Identity.Web.Test/Certificates/DefaultCertificateLoaderTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/DefaultCertificateLoaderTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
                     certificateDescription.CertificateStorePath = container;
                     break;
                 default:
-                    certificateDescription = null;
+                    certificateDescription = new CertificateDescription();
                     break;
             }
 
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
                 container,
                 referenceOrValue);
 
-            X509Certificate2 certificate = DefaultCertificateLoader.LoadFirstCertificate(certDescriptions);
+            X509Certificate2? certificate = DefaultCertificateLoader.LoadFirstCertificate(certDescriptions);
 
             Assert.NotNull(certificate);
             Assert.Equal("CN=ACS2ClientCertificate", certificate.Issuer);
@@ -90,15 +90,17 @@ namespace Microsoft.Identity.Web.Test.Certificates
                 ReferenceOrValue = referenceOrValue,
             });
 
-            certDescriptions.Add(CertificateDescription.FromCertificate(null));
+            certDescriptions.Add(CertificateDescription.FromCertificate(null!));
 
-            IEnumerable<X509Certificate2> certificates = DefaultCertificateLoader.LoadAllCertificates(certDescriptions);
+            IEnumerable<X509Certificate2?> certificates = DefaultCertificateLoader.LoadAllCertificates(certDescriptions);
 
             Assert.NotNull(certificates);
             Assert.Equal(2, certificates.Count());
             Assert.Equal(3, certDescriptions.Count);
-            Assert.Equal("CN=ACS2ClientCertificate", certificates.First().Issuer);
-            Assert.Equal("CN=ACS2ClientCertificate", certificates.Last().Issuer);
+            Assert.NotNull(certificates.First());
+            Assert.Equal("CN=ACS2ClientCertificate", certificates.First()!.Issuer);
+            Assert.NotNull(certificates.Last());
+            Assert.Equal("CN=ACS2ClientCertificate", certificates.Last()!.Issuer);
             Assert.Null(certDescriptions.ElementAt(2).Certificate);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/ClaimsPrincipalFactoryTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClaimsPrincipalFactoryTests.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void FromHomeTenantIdAndHomeObjectId_NullParameters_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(TestConstants.Value, () => ClaimsPrincipalFactory.FromHomeTenantIdAndHomeObjectId(TestConstants.Utid, null));
-            Assert.Throws<ArgumentNullException>(TestConstants.Value, () => ClaimsPrincipalFactory.FromHomeTenantIdAndHomeObjectId(null, TestConstants.Uid));
+            Assert.Throws<ArgumentNullException>(TestConstants.Value, () => ClaimsPrincipalFactory.FromHomeTenantIdAndHomeObjectId(TestConstants.Utid, null!));
+            Assert.Throws<ArgumentNullException>(TestConstants.Value, () => ClaimsPrincipalFactory.FromHomeTenantIdAndHomeObjectId(null!, TestConstants.Uid));
         }
 
         [Fact]
@@ -31,8 +31,8 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void FromTenantIdAndObjectId_NullParameters_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(TestConstants.Value, () => ClaimsPrincipalFactory.FromTenantIdAndObjectId(TestConstants.ClaimNameTid, null));
-            Assert.Throws<ArgumentNullException>(TestConstants.Value, () => ClaimsPrincipalFactory.FromTenantIdAndObjectId(null, TestConstants.Oid));
+            Assert.Throws<ArgumentNullException>(TestConstants.Value, () => ClaimsPrincipalFactory.FromTenantIdAndObjectId(TestConstants.ClaimNameTid, null!));
+            Assert.Throws<ArgumentNullException>(TestConstants.Value, () => ClaimsPrincipalFactory.FromTenantIdAndObjectId(null!, TestConstants.Oid));
         }
 
         [Fact]

--- a/tests/Microsoft.Identity.Web.Test/ClientAssertionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClientAssertionTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Identity.Web.Test
             assertion = await clientAssertionDescription.GetSignedAssertion(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("1", assertion);
 
+            Assert.NotNull(clientAssertionDescription.Expiry);
             await Task.Delay(clientAssertionDescription.Expiry.Value - DateTimeOffset.Now + TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
             assertion = await clientAssertionDescription.GetSignedAssertion(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("2", assertion);

--- a/tests/Microsoft.Identity.Web.Test/ClientInfoTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClientInfoTests.cs
@@ -21,13 +21,13 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void CreateFromJson_ValidJson_ReturnsClientInfo()
         {
-            var clientInfoResult = ClientInfo.CreateFromJson(Base64UrlHelpers.Encode(_decodedJson));
+            var clientInfoResult = ClientInfo.CreateFromJson(Base64UrlHelpers.Encode(_decodedJson)!);
 
             Assert.NotNull(clientInfoResult);
             Assert.Equal(Uid, clientInfoResult.UniqueObjectIdentifier);
             Assert.Equal(Utid, clientInfoResult.UniqueTenantIdentifier);
 
-            clientInfoResult = ClientInfo.CreateFromJson(Base64UrlHelpers.Encode(_decodedEmptyJson));
+            clientInfoResult = ClientInfo.CreateFromJson(Base64UrlHelpers.Encode(_decodedEmptyJson)!);
             Assert.NotNull(clientInfoResult);
             Assert.Null(clientInfoResult.UniqueObjectIdentifier);
             Assert.Null(clientInfoResult.UniqueTenantIdentifier);
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void CreateFromJson_InvalidString_ThrowsException()
         {
-            Assert.Throws<JsonException>(() => ClientInfo.CreateFromJson(Base64UrlHelpers.Encode(_invalidJson)));
+            Assert.Throws<JsonException>(() => ClientInfo.CreateFromJson(Base64UrlHelpers.Encode(_invalidJson)!));
 
             Assert.Throws<ArgumentException>(() => ClientInfo.CreateFromJson(_invalidJson));
         }

--- a/tests/Microsoft.Identity.Web.Test/CookiePolicyOptionsExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CookiePolicyOptionsExtensionsTests.cs
@@ -40,10 +40,12 @@ namespace Microsoft.Identity.Web.Test
             _cookiePolicyOptions.HandleSameSiteCookieCompatibility();
 
             Assert.Equal(SameSiteMode.Unspecified, _cookiePolicyOptions.MinimumSameSitePolicy);
-
+            Assert.NotNull(_cookiePolicyOptions);
+            Assert.NotNull(_cookiePolicyOptions.OnAppendCookie);
             _cookiePolicyOptions.OnAppendCookie(appendCookieContext);
             Assert.Equal(expectedSameSiteMode, appendCookieOptions.SameSite);
 
+            Assert.NotNull(_cookiePolicyOptions.OnDeleteCookie);
             _cookiePolicyOptions.OnDeleteCookie(deleteCookieContext);
             Assert.Equal(expectedSameSiteMode, deleteCookieOptions.SameSite);
         }
@@ -70,6 +72,7 @@ namespace Microsoft.Identity.Web.Test
 
             Assert.Equal(SameSiteMode.Unspecified, _cookiePolicyOptions.MinimumSameSitePolicy);
 
+            Assert.NotNull(_cookiePolicyOptions.OnAppendCookie);
             _cookiePolicyOptions.OnAppendCookie(appendCookieContext);
             Assert.Equal(expectedSameSiteMode, appendCookieOptions.SameSite);
             Assert.Equal(expectedEventCalled, appendEventCalled);
@@ -80,6 +83,7 @@ namespace Microsoft.Identity.Web.Test
                 return CookiePolicyOptionsExtensions.DisallowsSameSiteNone(userAgent);
             });
 
+            Assert.NotNull(_cookiePolicyOptions.OnDeleteCookie);
             _cookiePolicyOptions.OnDeleteCookie(deleteCookieContext);
             Assert.Equal(expectedSameSiteMode, deleteCookieOptions.SameSite);
             Assert.Equal(expectedEventCalled, deleteEventCalled);

--- a/tests/Microsoft.Identity.Web.Test/ExceptionHandlingTest.cs
+++ b/tests/Microsoft.Identity.Web.Test/ExceptionHandlingTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Web.Test
         {
             MsalUiRequiredException msalUiRequiredException = new MsalUiRequiredException("code", "message");
 
-            MsalUiRequiredException result = AuthorizeForScopesAttribute.FindMsalUiRequiredExceptionIfAny(msalUiRequiredException);
+            MsalUiRequiredException? result = AuthorizeForScopesAttribute.FindMsalUiRequiredExceptionIfAny(msalUiRequiredException);
             Assert.Equal(result, msalUiRequiredException);
 
             Exception ex = new Exception("message", msalUiRequiredException);

--- a/tests/Microsoft.Identity.Web.Test/HttpClientBuilderExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/HttpClientBuilderExtensionsTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Web.Test
         {
             var builder = new ConfigurationBuilder();
             builder.AddInMemoryCollection(
-                new Dictionary<string, string>()
+                new Dictionary<string, string?>()
                 {
                     { $"{key}:Scopes", TestConstants.Scopes },
                     { $"{key}:Tenant", TestConstants.TenantIdAsGuid },
@@ -51,12 +51,12 @@ namespace Microsoft.Identity.Web.Test
             {
             }
 
-            public DelegatingHandler CreateAppHandler(string serviceName)
+            public DelegatingHandler CreateAppHandler(string? serviceName)
             {
                 return new CustomMicrosoftIdentityAuthenticationAppHandler();
             }
 
-            public DelegatingHandler CreateUserHandler(string serviceName)
+            public DelegatingHandler CreateUserHandler(string? serviceName)
             {
                 return new CustomMicrosoftIdentityAuthenticationUserHandler();
             }

--- a/tests/Microsoft.Identity.Web.Test/IncrementalConsentHelperTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/IncrementalConsentHelperTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Web.Test
         public void ReSignInOfUser_ReturnsBoolOnErrorTest(bool isUserNullError)
         {
             MsalUiRequiredException msalUiEx;
-            Assert.Throws<ArgumentNullException>(() => IncrementalConsentAndConditionalAccessHelper.CanBeSolvedByReSignInOfUser(null));
+            Assert.Throws<ArgumentNullException>(() => IncrementalConsentAndConditionalAccessHelper.CanBeSolvedByReSignInOfUser(null!));
             if (isUserNullError)
             {
                 msalUiEx = new(MsalError.UserNullError, MsalError.InvalidGrantError);
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void ReSignInOfUser_ThrowsOnNullMsalUiRequiredExceptionTest()
         {
-            Assert.Throws<ArgumentNullException>(() => IncrementalConsentAndConditionalAccessHelper.CanBeSolvedByReSignInOfUser(null));
+            Assert.Throws<ArgumentNullException>(() => IncrementalConsentAndConditionalAccessHelper.CanBeSolvedByReSignInOfUser(null!));
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Web.Test
         {
             Assert.Throws<ArgumentNullException>(() => IncrementalConsentAndConditionalAccessHelper.BuildAuthenticationProperties(
                 null,
-                null,
+                null!,
                 new ClaimsPrincipal(new ClaimsIdentity(null, "Basic")),
                 null));
         }

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheOptionsTests.cs
@@ -13,7 +13,10 @@ namespace Microsoft.Identity.Web.Test
 {
     public class L1L2CacheOptionsTests
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        // _provider is initialized by BuildTheRequiredServices() called in all tests.
         private ServiceProvider _provider;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [Theory]
         [InlineData(0)]
@@ -34,7 +37,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Throws<ArgumentOutOfRangeException>(() => new TestMsalDistributedTokenCacheAdapter(
                 new TestDistributedCache(),
                 msalDistributedTokenOptions,
-                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>()));
+                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>()!));
         }
 
         [Theory]
@@ -55,7 +58,7 @@ namespace Microsoft.Identity.Web.Test
             var testCache = new TestMsalDistributedTokenCacheAdapter(
                 new TestDistributedCache(),
                 msalDistributedTokenOptions,
-                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>());
+                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>()!);
 
             // Assert
             Assert.NotNull(testCache);
@@ -81,7 +84,7 @@ namespace Microsoft.Identity.Web.Test
             var testCache = new TestMsalDistributedTokenCacheAdapter(
                 new TestDistributedCache(),
                 msalDistributedTokenOptions,
-                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>());
+                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>()!);
 
             // Assert
             Assert.NotNull(testCache);

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -18,12 +18,13 @@ namespace Microsoft.Identity.Web.Test
     {
         private const string DefaultCacheKey = "default-key";
         private const string AnotherCacheKey = "another-key";
-        private ServiceProvider _provider;
+        private ServiceProvider? _provider;
+        private ServiceProvider Provider { get { return _provider!; } }
         private readonly TestMsalDistributedTokenCacheAdapter _testCacheAdapter;
 
         private TestDistributedCache L2Cache
         {
-            get { return _testCacheAdapter._distributedCache as TestDistributedCache; }
+            get { return (_testCacheAdapter._distributedCache as TestDistributedCache)!; }
         }
 
         public L1L2CacheTests()
@@ -31,8 +32,8 @@ namespace Microsoft.Identity.Web.Test
             BuildTheRequiredServices();
             _testCacheAdapter = new TestMsalDistributedTokenCacheAdapter(
                 MakeMockDistributedCache(),
-                _provider.GetService<IOptions<MsalDistributedTokenCacheAdapterOptions>>(),
-                _provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>());
+                Provider.GetService<IOptions<MsalDistributedTokenCacheAdapterOptions>>()!,
+                Provider.GetService<ILogger<MsalDistributedTokenCacheAdapter>>()!);
         }
 
         [Theory]
@@ -41,10 +42,10 @@ namespace Microsoft.Identity.Web.Test
         public async Task WriteCache_WritesInL1L2_TestAsync(bool enableAsyncL2Write)
         {
             // Arrange
-            _provider.GetService<IOptions<MsalDistributedTokenCacheAdapterOptions>>().Value.EnableAsyncL2Write = enableAsyncL2Write;
+            Provider.GetService<IOptions<MsalDistributedTokenCacheAdapterOptions>>()!.Value.EnableAsyncL2Write = enableAsyncL2Write;
             byte[] cache = new byte[3];
             AssertCacheValues(_testCacheAdapter);
-            Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
+            Assert.Equal(0, _testCacheAdapter._memoryCache!.Count);
             Assert.Empty(L2Cache._dict);
 
             // Act
@@ -64,6 +65,7 @@ namespace Microsoft.Identity.Web.Test
             await CreateL1L2TestWithSerializerHints(System.DateTimeOffset.Now - System.TimeSpan.FromHours(1), 0).ConfigureAwait(false);
 
             // Assert
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Null(_testCacheAdapter._memoryCache.Get(DefaultCacheKey));
 
             await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
@@ -77,8 +79,10 @@ namespace Microsoft.Identity.Web.Test
             await CreateL1L2TestWithSerializerHints(System.DateTimeOffset.Now - System.TimeSpan.FromHours(1), 0).ConfigureAwait(false);
 
             // Assert
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Null(_testCacheAdapter._memoryCache.Get(DefaultCacheKey));
-            var options = (_testCacheAdapter._distributedCache as TestDistributedCache).GetDistributedCacheEntryOptions(DefaultCacheKey);
+            var options = (_testCacheAdapter._distributedCache as TestDistributedCache)!.GetDistributedCacheEntryOptions(DefaultCacheKey);
+            Assert.NotNull(options);
             Assert.NotNull(options.AbsoluteExpiration);
             await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
@@ -93,8 +97,13 @@ namespace Microsoft.Identity.Web.Test
             await CreateL1L2TestWithSerializerHints(expiry, 1).ConfigureAwait(false);
 
             // Assert
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.NotNull(_testCacheAdapter._memoryCache.Get(DefaultCacheKey));
-            var options = (_testCacheAdapter._distributedCache as TestDistributedCache).GetDistributedCacheEntryOptions(DefaultCacheKey);
+            TestDistributedCache? testDistributedCache = _testCacheAdapter._distributedCache as TestDistributedCache;
+            Assert.NotNull(testDistributedCache);
+            var options = testDistributedCache.GetDistributedCacheEntryOptions(DefaultCacheKey);
+            Assert.NotNull(options);
+            Assert.NotNull(options.AbsoluteExpiration);
             Assert.Equal(expiry, options.AbsoluteExpiration.Value);
             await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
@@ -117,13 +126,18 @@ namespace Microsoft.Identity.Web.Test
             // Arrange & Act
             var timespan = System.TimeSpan.FromHours(1);
             var suggestedExpiry = System.DateTimeOffset.UtcNow + timespan;
-            var absoluteOptions = _provider.GetService<IOptions<MsalDistributedTokenCacheAdapterOptions>>();
+            var absoluteOptions = Provider.GetService<IOptions<MsalDistributedTokenCacheAdapterOptions>>();
+            Assert.NotNull(absoluteOptions);
             absoluteOptions.Value.AbsoluteExpiration = System.DateTimeOffset.Now + System.TimeSpan.FromHours(time);
             await CreateL1L2TestWithSerializerHints(suggestedExpiry, 1).ConfigureAwait(false);
 
             // Assert
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.NotNull(_testCacheAdapter._memoryCache.Get(DefaultCacheKey));
-            var options = (_testCacheAdapter._distributedCache as TestDistributedCache).GetDistributedCacheEntryOptions(DefaultCacheKey);
+            Assert.NotNull(_testCacheAdapter._distributedCache as TestDistributedCache);
+            var options = (_testCacheAdapter._distributedCache as TestDistributedCache)!.GetDistributedCacheEntryOptions(DefaultCacheKey);
+            Assert.NotNull(options);
+            Assert.NotNull(options.AbsoluteExpiration);
             if (time < 1)
             {
                 Assert.Equal(absoluteOptions.Value.AbsoluteExpiration, options.AbsoluteExpiration.Value);
@@ -145,6 +159,7 @@ namespace Microsoft.Identity.Web.Test
             // Arrange
             byte[] cache = new byte[3];
             AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             Assert.Empty(L2Cache._dict);
             CacheSerializerHints cacheSerializerHints = new CacheSerializerHints();
@@ -167,15 +182,17 @@ namespace Microsoft.Identity.Web.Test
             byte[] cache = new byte[3];
             cache[0] = 4;
             AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             _testCacheAdapter._memoryCache.Set(DefaultCacheKey, cache, new MemoryCacheEntryOptions { Size = cache.Length });
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
             Assert.Empty(L2Cache._dict);
 
             // Act
-            byte[] result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
 
             // Assert
+            Assert.NotNull(result);
             Assert.Equal(4, result[0]);
         }
 
@@ -188,12 +205,14 @@ namespace Microsoft.Identity.Web.Test
             AssertCacheValues(_testCacheAdapter);
             _testCacheAdapter._distributedCache.Set(DefaultCacheKey, cache);
             Assert.Single(L2Cache._dict);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
 
             // Act
-            byte[] result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
 
             // Assert
+            Assert.NotNull(result);
             Assert.Equal(4, result[0]);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
             Assert.Single(L2Cache._dict);
@@ -206,10 +225,11 @@ namespace Microsoft.Identity.Web.Test
             byte[] cache = new byte[3];
             cache[0] = 4;
             AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
 
             // Act
-            byte[] result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
 
             // Assert
             Assert.Null(result);
@@ -224,13 +244,14 @@ namespace Microsoft.Identity.Web.Test
             byte[] cache = new byte[3];
             cache[0] = 4;
             AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             Assert.Empty(L2Cache._dict);
             _testCacheAdapter._memoryCache.Set(AnotherCacheKey, cache, new MemoryCacheEntryOptions { Size = cache.Length });
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
 
             // Act
-            byte[] result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
 
             // Assert
             Assert.Null(result);
@@ -246,6 +267,7 @@ namespace Microsoft.Identity.Web.Test
             byte[] cacheL2 = new byte[2];
             cacheL2[0] = 9;
             AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             _testCacheAdapter._memoryCache.Set(AnotherCacheKey, cacheL1, new MemoryCacheEntryOptions { Size = cacheL1.Length });
             _testCacheAdapter._distributedCache.Set(DefaultCacheKey, cacheL2);
@@ -253,12 +275,14 @@ namespace Microsoft.Identity.Web.Test
             Assert.Single(L2Cache._dict);
 
             // Act & Assert
-            byte[] result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            Assert.NotNull(result);
             Assert.Equal(9, result[0]);
             Assert.Equal(2, _testCacheAdapter._memoryCache.Count);
             Assert.Single(L2Cache._dict);
 
-            byte[] result2 = await _testCacheAdapter.TestReadCacheBytesAsync(AnotherCacheKey).ConfigureAwait(false);
+            byte[]? result2 = await _testCacheAdapter.TestReadCacheBytesAsync(AnotherCacheKey).ConfigureAwait(false);
+            Assert.NotNull(result2);
             Assert.Equal(4, result2[0]);
             Assert.Equal(2, _testCacheAdapter._memoryCache.Count);
             Assert.Single(L2Cache._dict);
@@ -271,6 +295,7 @@ namespace Microsoft.Identity.Web.Test
             byte[] cacheL1 = new byte[3];
             cacheL1[0] = 4;
             AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             _testCacheAdapter._memoryCache.Set(DefaultCacheKey, cacheL1, new MemoryCacheEntryOptions { Size = cacheL1.Length });
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
@@ -289,6 +314,7 @@ namespace Microsoft.Identity.Web.Test
             byte[] cacheL2 = new byte[3];
             cacheL2[0] = 4;
             AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             _testCacheAdapter._distributedCache.Set(DefaultCacheKey, cacheL2);
             Assert.Single(L2Cache._dict);
@@ -308,6 +334,7 @@ namespace Microsoft.Identity.Web.Test
             byte[] cacheL1 = new byte[3];
             byte[] cacheL2 = new byte[2];
             AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             _testCacheAdapter._memoryCache.Set(AnotherCacheKey, cacheL1, new MemoryCacheEntryOptions { Size = cacheL1.Length });
             _testCacheAdapter._distributedCache.Set(DefaultCacheKey, cacheL2);

--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityAuthenticationMessageHandlerTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityAuthenticationMessageHandlerTests.cs
@@ -75,14 +75,14 @@ namespace Microsoft.Identity.Web.Test
 
             if (useApp)
             {
-                tokenAcquisition.GetAuthenticationResultForAppAsync(default, default, default, default)
+                tokenAcquisition.GetAuthenticationResultForAppAsync(default!, default, default, default)
                     .ReturnsForAnyArgs(_authenticationResult);
 
                 builder.AddHttpMessageHandler(() => new MicrosoftIdentityAppAuthenticationMessageHandler(tokenAcquisition, options));
             }
             else
             {
-                tokenAcquisition.GetAuthenticationResultForUserAsync(default, default, default, default, default, default)
+                tokenAcquisition.GetAuthenticationResultForUserAsync(default!, default, default, default, default, default)
                     .ReturnsForAnyArgs(_authenticationResult);
 
                 var identityOptions = Substitute.For<IOptionsMonitor<MicrosoftIdentityOptions>>();
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Web.Test
             if (useApp)
             {
                 await tokenAcquisition.Received().GetAuthenticationResultForAppAsync(
-                    _handlerOptions.Scopes,
+                    _handlerOptions.Scopes!,
                     _handlerOptions.AuthenticationScheme,
                     _handlerOptions.Tenant,
                     Arg.Any<TokenAcquisitionOptions>() /* options are cloned */)
@@ -142,14 +142,14 @@ namespace Microsoft.Identity.Web.Test
 
             if (useApp)
             {
-                tokenAcquisition.GetAuthenticationResultForAppAsync(default, default, default, default)
+                tokenAcquisition.GetAuthenticationResultForAppAsync(default!, default, default, default)
                     .ReturnsForAnyArgs(_authenticationResult);
 
                 builder.AddHttpMessageHandler(() => new MicrosoftIdentityAppAuthenticationMessageHandler(tokenAcquisition, options));
             }
             else
             {
-                tokenAcquisition.GetAuthenticationResultForUserAsync(default, default, default, default, default, default)
+                tokenAcquisition.GetAuthenticationResultForUserAsync(default!, default, default, default, default, default)
                     .ReturnsForAnyArgs(_authenticationResult);
 
                 var identityOptions = Substitute.For<IOptionsMonitor<MicrosoftIdentityOptions>>();
@@ -182,7 +182,7 @@ namespace Microsoft.Identity.Web.Test
 
             public IReadOnlyList<HttpRequestMessage> Requests => _requests;
 
-            public MockHttpMessageHandler(HttpStatusCode statusCode = HttpStatusCode.OK, HttpContent content = default, string reason = default)
+            public MockHttpMessageHandler(HttpStatusCode statusCode = HttpStatusCode.OK, HttpContent content = default!, string reason = default!)
             {
                 _statusCode = statusCode;
                 _reason = reason;

--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Identity.Web.Test
         private const string AzureAd = Constants.AzureAd;
         private const string AzureAdB2C = Constants.AzureAdB2C;
         private ServiceProvider? _provider;
-        private IOptionsMonitor<MicrosoftIdentityOptions>? _microsoftIdentityOptionsMonitor;
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private IOptionsMonitor<MicrosoftIdentityOptions> _microsoftIdentityOptionsMonitor;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [Fact]
         public void IsB2C_NotNullOrEmptyUserFlow_ReturnsTrue()
@@ -88,7 +90,7 @@ namespace Microsoft.Identity.Web.Test
             }
 
             BuildTheRequiredServices();
-            MergedOptions mergedOptions = _provider.GetRequiredService<IMergedOptionsStore>().Get(OpenIdConnectDefaults.AuthenticationScheme);
+            MergedOptions mergedOptions = _provider!.GetRequiredService<IMergedOptionsStore>().Get(OpenIdConnectDefaults.AuthenticationScheme);
 
             MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(_microsoftIdentityOptionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme), mergedOptions);
 
@@ -116,7 +118,7 @@ namespace Microsoft.Identity.Web.Test
             });
 
             BuildTheRequiredServices();
-            MergedOptions mergedOptions = _provider.GetRequiredService<IMergedOptionsStore>().Get(OpenIdConnectDefaults.AuthenticationScheme);
+            MergedOptions mergedOptions = _provider!.GetRequiredService<IMergedOptionsStore>().Get(OpenIdConnectDefaults.AuthenticationScheme);
 
             MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(_microsoftIdentityOptionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme), mergedOptions);
 
@@ -134,7 +136,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.IsType<UniqueJsonKeyClaimAction>(genderClaim);
 
             // Ensure gender has the value of sex
-            var jsonKeyClaim = genderClaim as UniqueJsonKeyClaimAction;
+            var jsonKeyClaim = (genderClaim as UniqueJsonKeyClaimAction)!;
             Assert.Equal("theGender", jsonKeyClaim.JsonKey);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/MsalTokenCacheProviderTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MsalTokenCacheProviderTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Identity.Web.Test
             return s_memoryCache;
         }
 
-        private static IMemoryCache s_memoryCache;
+        private static IMemoryCache? s_memoryCache;
 
         private static IMsalTokenCacheProvider CreateTokenCacheSerializer()
         {

--- a/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerMiddlewareDiagnosticsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerMiddlewareDiagnosticsTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         [Fact]
         public async void Subscribe_OnAuthenticationFailedDefault_CompletesSuccessfully()
         {
-            _jwtEvents = _jwtDiagnostics.Subscribe(null);
+            _jwtEvents = _jwtDiagnostics.Subscribe(null!);
             await _jwtEvents.AuthenticationFailed(new AuthenticationFailedContext(_httpContext, _authScheme, _jwtOptions)).ConfigureAwait(false);
 
             AssertSuccess(false);
@@ -124,7 +124,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         private void AssertSuccess(bool expectedCustomEventWasRaised = true)
         {
             Assert.Equal(expectedCustomEventWasRaised, _customEventWasRaised);
-            _logger.Received().Log(Arg.Any<LogLevel>(), Arg.Any<EventId>(), Arg.Any<object>(), Arg.Any<Exception>(), Arg.Any<Func<object, Exception, string>>());
+            _logger.Received().Log(Arg.Any<LogLevel>(), Arg.Any<EventId>(), Arg.Any<object>(), Arg.Any<Exception>(), Arg.Any<Func<object, Exception?, string>>());
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/Resource/MicrosoftIdentityIssuerValidatorTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/MicrosoftIdentityIssuerValidatorTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _httpClientFactory = new HttpClientFactoryTest();
             _issuerValidatorFactory = new MicrosoftIdentityIssuerValidatorFactory(
-                null,
+                null!,
                 _httpClientFactory);
         }
 
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             Assert.Throws<ArgumentNullException>(TestConstants.AadAuthority, () => _issuerValidatorFactory.GetAadIssuerValidator(string.Empty));
 
-            Assert.Throws<ArgumentNullException>(TestConstants.AadAuthority, () => _issuerValidatorFactory.GetAadIssuerValidator(null));
+            Assert.Throws<ArgumentNullException>(TestConstants.AadAuthority, () => _issuerValidatorFactory.GetAadIssuerValidator(null!));
         }
 
         [Fact]

--- a/tests/Microsoft.Identity.Web.Test/Resource/OpenIdConnectMiddlewareDiagnosticsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/OpenIdConnectMiddlewareDiagnosticsTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         private void AssertSuccess()
         {
             Assert.True(_customEventWasRaised);
-            _logger.Received().Log(Arg.Any<LogLevel>(), Arg.Any<EventId>(), Arg.Any<object>(), Arg.Any<Exception>(), Arg.Any<Func<object, Exception, string>>());
+            _logger.Received().Log(Arg.Any<LogLevel>(), Arg.Any<EventId>(), Arg.Any<object>(), Arg.Any<Exception>(), Arg.Any<Func<object, Exception?, string>>());
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/Resource/RegisterValidAudienceTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RegisterValidAudienceTests.cs
@@ -19,12 +19,14 @@ namespace Microsoft.Identity.Web.Test.Resource
         private const string V1 = "1.0";
         private const string V2 = "2.0";
         private const string V3 = "3.0";
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         private JwtSecurityToken _token;
         private RegisterValidAudience _registerValidAudience;
         private TokenValidationParameters _validationParams;
         private IEnumerable<string> _validAudiences;
         private MicrosoftIdentityOptions _options;
         private string _expectedAudience;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [Theory]
         [InlineData(false, V1)]
@@ -131,6 +133,8 @@ namespace Microsoft.Identity.Web.Test.Resource
 
         private void AssertAudienceProvidedInValidAudiences()
         {
+            Assert.NotNull(_options);
+            Assert.NotNull(_options.ClientId);
             _validationParams.ValidAudiences = new List<string>
                     {
                          $"api://{_options.ClientId}",

--- a/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopeOrAppPermissionPolicyTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopeOrAppPermissionPolicyTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Identity.Web.Test.Resource
     [RequiredScopeOrAppPermission(new string[] { "access_as_user" }, new string[] { "access_as_app" })]
     public class RequiredScopeOrAppPermissionPolicyTests
     {
-        private IServiceProvider _provider;
+        private IServiceProvider? _provider;
         private const string ConfigSectionName = "AzureAd";
         private const string MultipleAppPermissions = "access_as_app_read_only access_as_app";
         private const string AppPermission = "access_as_app";
@@ -153,11 +153,11 @@ namespace Microsoft.Identity.Web.Test.Resource
 
         private IAuthorizationService BuildAuthorizationService(
         string policy,
-        string appPermission,
-        string scope,
+        string? appPermission,
+        string? scope,
         bool withConfig = false)
         {
-            var configAsDictionary = new Dictionary<string, string>()
+            var configAsDictionary = new Dictionary<string, string?>()
             {
                 { ConfigSectionName, null },
                 { $"{ConfigSectionName}:Instance", TestConstants.AadInstance },
@@ -186,7 +186,9 @@ namespace Microsoft.Identity.Web.Test.Resource
                         }
                         else
                         {
-                            policyBuilder.RequireScopeOrAppPermission(scope?.Split(' '), appPermission?.Split(' '));
+                            // Considering that the scopes and app permissions are not null (!), in order to test
+                            // for the null argument exceptions
+                            policyBuilder.RequireScopeOrAppPermission(scope?.Split(' ')!, appPermission?.Split(' ')!);
                         }
                     });
                 });

--- a/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopePolicyTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopePolicyTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         string? scopes,
         bool withConfig = false)
         {
-            var configAsDictionary = new Dictionary<string, string>()
+            var configAsDictionary = new Dictionary<string, string?>()
             {
                 { ConfigSectionName, null },
                 { $"{ConfigSectionName}:Instance", TestConstants.AadInstance },
@@ -163,7 +163,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                         }
                         else
                         {
-                            policyBuilder.RequireScope(scopes?.Split(' '));
+                            policyBuilder.RequireScope(scopes?.Split(' ')!);
                         }
                     });
                 });

--- a/tests/Microsoft.Identity.Web.Test/Resource/RolesRequiredHttpContextExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RolesRequiredHttpContextExtensionsTests.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Identity.Web.Test.Resource
         [Fact]
         public void VerifyUserHasAnyAcceptedScope_NullParameters_ThrowsException()
         {
-            HttpContext httpContext = null;
+            HttpContext? httpContext = null;
 
-            Assert.Throws<ArgumentNullException>(() => httpContext.ValidateAppRole(string.Empty));
+            Assert.Throws<ArgumentNullException>(() => httpContext!.ValidateAppRole(string.Empty));
 
             httpContext = HttpContextUtilities.CreateHttpContext();
 
-            Assert.Throws<ArgumentNullException>("acceptedRoles", () => httpContext.ValidateAppRole(null));
+            Assert.Throws<ArgumentNullException>("acceptedRoles", () => httpContext.ValidateAppRole(null!));
         }
 
         [Fact]

--- a/tests/Microsoft.Identity.Web.Test/Resource/ScopesRequiredHttpContextExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/ScopesRequiredHttpContextExtensionsTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Identity.Web.Test.Resource
         [Fact]
         public void VerifyUserHasAnyAcceptedScope_NullParameters_ThrowsException()
         {
-            HttpContext httpContext = null;
-            Assert.Throws<ArgumentNullException>(() => httpContext.VerifyUserHasAnyAcceptedScope(string.Empty));
+            HttpContext? httpContext = null;
+            Assert.Throws<ArgumentNullException>(() => httpContext!.VerifyUserHasAnyAcceptedScope(string.Empty));
 
             httpContext = HttpContextUtilities.CreateHttpContext();
 
-            Assert.Throws<ArgumentNullException>("acceptedScopes", () => httpContext.VerifyUserHasAnyAcceptedScope(null));
+            Assert.Throws<ArgumentNullException>("acceptedScopes", () => httpContext.VerifyUserHasAnyAcceptedScope(null!));
         }
 
         [Fact]

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public void AddHttpContextAccessor_ThrowsWithoutServices()
         {
-            Assert.Throws<ArgumentNullException>("services", () => ServiceCollectionExtensions.AddTokenAcquisition(null));
+            Assert.Throws<ArgumentNullException>("services", () => ServiceCollectionExtensions.AddTokenAcquisition(null!));
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Web.Test
         internal readonly ConcurrentDictionary<string, Entry> _dict = new ConcurrentDictionary<string, Entry>();
         internal static ManualResetEventSlim ResetEvent { get; set; } = new ManualResetEventSlim(initialState: false);
 
-        public byte[] Get(string key)
+        public byte[]? Get(string key)
         {
             if (_dict.TryGetValue(key, out var value))
             {
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Web.Test
             return null;
         }
 
-        public DistributedCacheEntryOptions GetDistributedCacheEntryOptions(string key)
+        public DistributedCacheEntryOptions? GetDistributedCacheEntryOptions(string key)
         {
             if (_dict.TryGetValue(key, out var value))
             {
@@ -33,7 +33,7 @@ namespace Microsoft.Identity.Web.Test
             return null;
         }
 
-        public Task<byte[]> GetAsync(string key, CancellationToken token = default)
+        public Task<byte[]?> GetAsync(string key, CancellationToken token = default)
         {
             return Task.FromResult(Get(key));
         }

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -22,26 +22,28 @@ namespace Microsoft.Identity.Web.Test
 {
     public class TokenAcquisitionAuthorityTests
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         private TokenAcquisition _tokenAcquisition;
         private TokenAcquisitionAspnetCoreHost _tokenAcquisitionAspnetCoreHost;
         private ServiceProvider _provider;
         private IOptionsMonitor<ConfidentialClientApplicationOptions> _applicationOptionsMonitor;
         private IOptionsMonitor<MicrosoftIdentityOptions> _microsoftIdentityOptionsMonitor;
         private ICredentialsLoader _credentialsLoader;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         private void InitializeTokenAcquisitionObjects()
         {
             _credentialsLoader = new DefaultCredentialsLoader();
             _tokenAcquisitionAspnetCoreHost = new TokenAcquisitionAspnetCoreHost(
                 MockHttpContextAccessor.CreateMockHttpContextAccessor(),
-                _provider.GetService<IMergedOptionsStore>(),
+                _provider.GetService<IMergedOptionsStore>()!,
                 _provider);
             _tokenAcquisition = new TokenAcquisitionAspNetCore(
                 new MsalTestTokenCacheProvider(
-                _provider.GetService<IMemoryCache>(),
-                _provider.GetService<IOptions<MsalMemoryTokenCacheOptions>>()),
-                _provider.GetService<IHttpClientFactory>(),
-                _provider.GetService<ILogger<TokenAcquisition>>(),
+                _provider.GetService<IMemoryCache>()!,
+                _provider.GetService<IOptions<MsalMemoryTokenCacheOptions>>()!),
+                _provider.GetService<IHttpClientFactory>()!,
+                _provider.GetService<ILogger<TokenAcquisition>>()!,
                 _tokenAcquisitionAspnetCoreHost,
                 _provider,
                 _credentialsLoader);

--- a/tests/Microsoft.Identity.Web.Test/WebApiExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebApiExtensionsTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Identity.Web.Test
                     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                     PropertyNameCaseInsensitive = true,
                 }).Replace(":2", ": \"Base64Encoded\"", StringComparison.OrdinalIgnoreCase);
-            var configAsDictionary = new Dictionary<string, string>()
+            var configAsDictionary = new Dictionary<string, string?>()
             {
                 { configSectionName, null },
                 { $"{configSectionName}:Instance", TestConstants.AadInstance },

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -575,6 +575,7 @@ namespace Microsoft.Identity.Web.Test
             //};
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -630,6 +631,7 @@ namespace Microsoft.Identity.Web.Test
                 Assert.Null(downstreamWebApiOptions.Get(ConfigSectionName).Tenant);
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         [Theory]
         [InlineData(true)]
@@ -805,7 +807,7 @@ namespace Microsoft.Identity.Web.Test
                 ProtocolMessage = new OpenIdConnectMessage(
                     new Dictionary<string, string[]>()
                     {
-                        { ClaimConstants.ClientInfo, new string[] { Base64UrlHelpers.Encode($"{{\"uid\":\"{TestConstants.Uid}\",\"utid\":\"{TestConstants.Utid}\"}}") } },
+                        { ClaimConstants.ClientInfo, new string[] { Base64UrlHelpers.Encode($"{{\"uid\":\"{TestConstants.Uid}\",\"utid\":\"{TestConstants.Utid}\"}}")! } },
                     }),
             };
 
@@ -845,7 +847,7 @@ namespace Microsoft.Identity.Web.Test
 
         private IConfigurationSection GetConfigSection(string configSectionName, bool includeB2cConfig = false)
         {
-            var configAsDictionary = new Dictionary<string, string>()
+            var configAsDictionary = new Dictionary<string, string?>()
             {
                 { configSectionName, null },
                 { $"{configSectionName}:Instance", TestConstants.AadInstance },

--- a/tests/PerformanceTests/Microsoft.Identity.Web.Perf.Benchmark/TokenAcquisitionTests.cs
+++ b/tests/PerformanceTests/Microsoft.Identity.Web.Perf.Benchmark/TokenAcquisitionTests.cs
@@ -21,10 +21,13 @@ namespace Microsoft.Identity.Web.Perf.Benchmark
         private readonly WebApplicationFactory<Startup> _factory;
         private HttpClient _client;
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. 
+        // The GlobalSetup ensures that the _client is not null.
         public TokenAcquisitionTests()
         {
             _factory = new WebApplicationFactory<Startup>();
         }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [GlobalSetup]
         public void GlobalSetup()

--- a/tests/PerformanceTests/Microsoft.Identity.Web.Perf.Client/Microsoft.Identity.Web.Perf.Client.csproj
+++ b/tests/PerformanceTests/Microsoft.Identity.Web.Perf.Client/Microsoft.Identity.Web.Perf.Client.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net6.0; net7.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\..\..\.sonarlint\azuread_microsoft-identity-webcsharp.ruleset</CodeAnalysisRuleSet>
     <AssemblyOriginatorKeyFile>../../../build/MSAL.snk</AssemblyOriginatorKeyFile>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/PerformanceTests/PerformanceTestService/EventSource/BenchmarkMsalDistributedTokenCacheAdapter.cs
+++ b/tests/PerformanceTests/PerformanceTestService/EventSource/BenchmarkMsalDistributedTokenCacheAdapter.cs
@@ -70,7 +70,7 @@ namespace PerformanceTestService.EventSource
         /// <param name="cacheKey">Key of the cache item to retrieve.</param>
         /// <returns>Read blob representing a token cache for the cache key
         /// (account or app).</returns>
-        protected override async Task<byte[]> ReadCacheBytesAsync(string cacheKey)
+        protected override async Task<byte[]?> ReadCacheBytesAsync(string cacheKey)
         {
             var stopwatch = Stopwatch.StartNew();
             var bytes = await _distributedCache.GetAsync(cacheKey).ConfigureAwait(false);

--- a/tests/PerformanceTests/PerformanceTestService/EventSource/BenchmarkMsalMemoryTokenCacheProvider.cs
+++ b/tests/PerformanceTests/PerformanceTestService/EventSource/BenchmarkMsalMemoryTokenCacheProvider.cs
@@ -54,7 +54,7 @@ namespace PerformanceTestService
         /// <returns>A <see cref="Task"/> that completes when key removal has completed.</returns>
         protected override Task RemoveKeyAsync(string cacheKey)
         {
-            byte[] tokenCacheBytes = (byte[])_memoryCache.Get(cacheKey);
+            byte[]? tokenCacheBytes = (byte[]?)_memoryCache.Get(cacheKey);
             _memoryCache.Remove(cacheKey);
 
             MemoryCacheEventSource.Log.IncrementRemoveCount();
@@ -71,10 +71,10 @@ namespace PerformanceTestService
         /// </summary>
         /// <param name="cacheKey">Token cache key.</param>
         /// <returns>Read Bytes.</returns>
-        protected override Task<byte[]> ReadCacheBytesAsync(string cacheKey)
+        protected override Task<byte[]?> ReadCacheBytesAsync(string cacheKey)
         {
             var stopwatch = Stopwatch.StartNew();
-            byte[] tokenCacheBytes = (byte[])_memoryCache.Get(cacheKey);
+            byte[]? tokenCacheBytes = (byte[]?)_memoryCache.Get(cacheKey);
             stopwatch.Stop();
 
             MemoryCacheEventSource.Log.IncrementReadCount();

--- a/tests/PerformanceTests/PerformanceTestService/EventSource/MemoryCacheEventSource.cs
+++ b/tests/PerformanceTests/PerformanceTestService/EventSource/MemoryCacheEventSource.cs
@@ -47,7 +47,9 @@ namespace PerformanceTestService
         {
         }
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         internal MemoryCacheEventSource(string eventSourceName)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
             : base(eventSourceName)
         {
         }

--- a/tests/PerformanceTests/PerformanceTestService/EventSource/ServiceExtensions.cs
+++ b/tests/PerformanceTests/PerformanceTestService/EventSource/ServiceExtensions.cs
@@ -27,7 +27,7 @@ namespace PerformanceTestService.EventSource
 
         private static void RemoveExistingMemoryCache(IServiceCollection services)
         {
-            ServiceDescriptor msalMemoryCacheService = services.FirstOrDefault(s => s.ServiceType == typeof(IMsalTokenCacheProvider));
+            ServiceDescriptor msalMemoryCacheService = services.First(s => s.ServiceType == typeof(IMsalTokenCacheProvider));
 
             if (msalMemoryCacheService != null)
             {

--- a/tests/PerformanceTests/PerformanceTestService/PerformanceTestService.csproj
+++ b/tests/PerformanceTests/PerformanceTestService/PerformanceTestService.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.DownstreamRestApi\Microsoft.Identity.Web.DownstreamRestApi.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.MicrosoftGraph\Microsoft.Identity.Web.MicrosoftGraph.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />
     <ProjectReference Include="..\..\Microsoft.Identity.Web.Test.Common\Microsoft.Identity.Web.Test.Common.csproj" />

--- a/tests/PerformanceTests/PerformanceTestService/Startup.cs
+++ b/tests/PerformanceTests/PerformanceTestService/Startup.cs
@@ -31,7 +31,7 @@ namespace PerformanceTestService
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                       .AddMicrosoftIdentityWebApi(Configuration)
                       .EnableTokenAcquisitionToCallDownstreamApi()
-                            .AddDownstreamWebApi(
+                            .AddDownstreamRestApi(
                                 TestConstants.SectionNameCalledApi,
                                 Configuration.GetSection(TestConstants.SectionNameCalledApi))
                             .AddMicrosoftGraph(Configuration.GetSection("GraphBeta"));


### PR DESCRIPTION
Remove all TSA warnings
Adds EditorBrowsable(Never) attributes for the methods that were obsoleted Auth code flow redemption now also provides the access token (#1771)