### PR TITLE
Fix App service authentication regressions in 2.x

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -11,7 +11,7 @@ on:
       - reopened
       - ready_for_review
     branches:
-      - "master"
+      - master
     paths:
       - ".github/workflows/dotnetcore.yml"
 

--- a/src/Microsoft.Identity.Web.Diagnostics/Diagnostics/CallerArgumentExpressionAttribute.cs
+++ b/src/Microsoft.Identity.Web.Diagnostics/Diagnostics/CallerArgumentExpressionAttribute.cs
@@ -1,10 +1,8 @@
 ﻿#if !NETCOREAPP3_1_OR_GREATER
-#pragma warning disable IDE0073 // The file header does not match the required text
-                               // Licensed to the .NET Foundation under one or more agreements.
-                               // The .NET Foundation licenses this file to you under the MIT license.
+                                // Licensed to the .NET Foundation under one or more agreements.
+                                // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Runtime.CompilerServices
-#pragma warning restore IDE0073 // The file header does not match the required text
 {
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     internal sealed class CallerArgumentExpressionAttribute : Attribute

--- a/src/Microsoft.Identity.Web.Diagnostics/GlobalSuppressions.cs
+++ b/src/Microsoft.Identity.Web.Diagnostics/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0073:The file header is missing or not located at the top of the file", Justification = "<Pending>")]

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -1,4 +1,5 @@
-﻿// Licensed under the MIT License.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisition-AspnetCore.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisition-AspnetCore.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -20,7 +19,7 @@ using Microsoft.Identity.Web.TokenCacheProviders;
 
 namespace Microsoft.Identity.Web
 {
-    internal class TokenAcquisitionAspNetCore : TokenAcquisition, ITokenAcquisitionInternal, ITokenAcquirerFactory
+    internal class TokenAcquisitionAspNetCore : TokenAcquisition, ITokenAcquisitionInternal
     {
         /// <summary>
         /// Constructor of the TokenAcquisition service. This requires the Azure AD Options to
@@ -160,30 +159,6 @@ namespace Microsoft.Identity.Web
                 userFlow,
                 context!.ProtocolMessage.DomainHint)).ConfigureAwait(false);
             context.HandleCodeRedemption(result.AccessToken!, result.IdToken!);
-        }
-
-        TokenAcquirerFactory_GetTokenAcquirers? _implementation;
-
-        /// <inheritdoc/>
-        public ITokenAcquirer GetTokenAcquirer(string authority, string clientId, IEnumerable<CredentialDescription> clientCredentials, string? region)
-        {
-            _implementation ??= new TokenAcquirerFactory_GetTokenAcquirers(_serviceProvider);
-            return _implementation.GetTokenAcquirer(authority, clientId, clientCredentials, region);
-        }
-
-        /// <inheritdoc/>
-        public ITokenAcquirer GetTokenAcquirer(IdentityApplicationOptions applicationIdentityOptions)
-        {
-            _implementation ??= new TokenAcquirerFactory_GetTokenAcquirers(_serviceProvider);
-            return _implementation.GetTokenAcquirer(applicationIdentityOptions);
-        }
-
-        /// <inheritdoc/>
-        public ITokenAcquirer GetTokenAcquirer(string optionName = "")
-        {
-            _implementation ??= new TokenAcquirerFactory_GetTokenAcquirers(_serviceProvider);
-            string effectiveAuthenticationScheme = GetEffectiveAuthenticationScheme(optionName);
-            return _implementation.GetTokenAcquirer(effectiveAuthenticationScheme);
         }
 
         private void CheckParameters(

--- a/src/Microsoft.Identity.Web.TokenAcquisition/DefaultTokenAcquirerFactoryImplementation.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/DefaultTokenAcquirerFactoryImplementation.cs
@@ -9,9 +9,9 @@ using Microsoft.Identity.Abstractions;
 
 namespace Microsoft.Identity.Web
 {
-    internal sealed class DefaultTokenAcquirerFactoryImplentation : ITokenAcquirerFactory
+    internal sealed class DefaultTokenAcquirerFactoryImplementation : ITokenAcquirerFactory
     {
-        public DefaultTokenAcquirerFactoryImplentation(IServiceProvider serviceProvider)
+        public DefaultTokenAcquirerFactoryImplementation(IServiceProvider serviceProvider)
         {
             ServiceProvider = serviceProvider;
         }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/DefaultTokenAcquirerFactoryImplentation.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/DefaultTokenAcquirerFactoryImplentation.cs
@@ -9,9 +9,9 @@ using Microsoft.Identity.Abstractions;
 
 namespace Microsoft.Identity.Web
 {
-    internal sealed class TokenAcquirerFactory_GetTokenAcquirers
+    internal sealed class DefaultTokenAcquirerFactoryImplentation : ITokenAcquirerFactory
     {
-        public TokenAcquirerFactory_GetTokenAcquirers(IServiceProvider serviceProvider)
+        public DefaultTokenAcquirerFactoryImplentation(IServiceProvider serviceProvider)
         {
             ServiceProvider = serviceProvider;
         }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Web
                 // ASP.NET Core
                 services.AddHttpContextAccessor();
                 services.AddSingleton<ITokenAcquisition, TokenAcquisitionAspNetCore>();
-                services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplentation>();
+                services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplementation>();
 
                 services.AddSingleton<ITokenAcquisitionHost, TokenAcquisitionAspnetCoreHost>();
 
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Web
                 services.AddHttpContextAccessor();
 
                 services.AddScoped<ITokenAcquisition, TokenAcquisitionAspNetCore>();
-                services.AddScoped<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplentation>();
+                services.AddScoped<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplementation>();
 
                 services.AddScoped<ITokenAcquisitionHost, TokenAcquisitionAspnetCoreHost>();
 #else

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Web
                 // ASP.NET Core
                 services.AddHttpContextAccessor();
                 services.AddSingleton<ITokenAcquisition, TokenAcquisitionAspNetCore>();
-                services.AddSingleton(s => (ITokenAcquirerFactory)s.GetRequiredService<ITokenAcquisition>());
+                services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplentation>();
 
                 services.AddSingleton<ITokenAcquisitionHost, TokenAcquisitionAspnetCoreHost>();
 
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Web
                 services.AddHttpContextAccessor();
 
                 services.AddScoped<ITokenAcquisition, TokenAcquisitionAspNetCore>();
-                services.AddScoped(s => (ITokenAcquirerFactory)s.GetRequiredService<ITokenAcquisition>());
+                services.AddScoped<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplentation>();
 
                 services.AddScoped<ITokenAcquisitionHost, TokenAcquisitionAspnetCoreHost>();
 #else

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Identity.Web
                 instance.Services.AddTokenAcquisition();
                 instance.Services.AddHttpClient();
                 instance.Services.Configure<MicrosoftIdentityApplicationOptions>(option => instance.Configuration.GetSection(configSection).Bind(option));
-                instance.Services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplentation>();
+                instance.Services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplementation>();
                 instance.Services.AddSingleton(defaultInstance.Configuration);
             }
             return (defaultInstance as T)!;
@@ -113,7 +113,7 @@ namespace Microsoft.Identity.Web
                 instance.Services.AddTokenAcquisition();
                 instance.Services.AddHttpClient();
                 instance.Services.AddOptions<MicrosoftIdentityApplicationOptions>(string.Empty);
-                instance.Services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplentation>();
+                instance.Services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplementation>();
                 instance.Services.AddSingleton(defaultInstance.Configuration);
             }
             return defaultInstance!;

--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
@@ -247,7 +247,8 @@ namespace Microsoft.Identity.Web
             string? tenant = null,
             TokenAcquisitionOptions? tokenAcquisitionOptions = null)
         {
-            throw new NotSupportedException();
+            return this.GetAuthenticationResultForUserAsync(new string[] {scope}, authenticationScheme, tenant,
+                tokenAcquisitionOptions: tokenAcquisitionOptions);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Identity.Web
             {
                 services.AddScoped<ITokenAcquisition, AppServicesAuthenticationTokenAcquisition>();
                 services.AddScoped<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
-                services.AddScoped<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplentation>();
+                services.AddScoped<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplementation>();
             }
             else
             {

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
@@ -97,6 +98,8 @@ namespace Microsoft.Identity.Web
             if (AppServicesAuthenticationInformation.IsAppServicesAadAuthenticationEnabled)
             {
                 services.AddScoped<ITokenAcquisition, AppServicesAuthenticationTokenAcquisition>();
+                services.AddScoped<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
+                services.AddScoped<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplentation>();
             }
             else
             {

--- a/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
@@ -58,7 +58,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -74,7 +74,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.WsFederation" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -82,23 +82,23 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.48.1.0" newVersion="4.48.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.51.0.0" newVersion="4.51.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
@@ -176,6 +176,7 @@
 				<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
 			</dependentAssembly>
+			
    
     </assemblyBinding>
   </runtime>

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
@@ -59,7 +59,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -75,7 +75,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.WsFederation" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -83,23 +83,23 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.25.1.0" newVersion="6.25.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.27.0.0" newVersion="6.27.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.48.1.0" newVersion="4.48.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.51.0.0" newVersion="4.51.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
             defaultcertloader.LoadCredentialsIfNeededAsync(credentialDescription).GetAwaiter().GetResult();
             if (credentialDescription.Certificate == null)
             {
-                Assert.Fail($"Did you install the lab certificate '{credentialDescription.CertificateThumbprint}' in the `Local Machine/Personal` credential store?");
+                throw new ArgumentException ($"Lab cert not found. Did you install the lab certificate '{credentialDescription.CertificateThumbprint}' in the `Local Machine/Personal` credential store?");
             }
             else
             {

--- a/tests/Microsoft.Identity.Web.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
+++ b/tests/Microsoft.Identity.Web.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
@@ -7,6 +7,7 @@ using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Web.Test.Common;
+using Xunit;
 
 namespace Microsoft.Identity.Web.Test.LabInfrastructure
 {
@@ -23,7 +24,14 @@ namespace Microsoft.Identity.Web.Test.LabInfrastructure
 
             };
             defaultcertloader.LoadCredentialsIfNeededAsync(credentialDescription).GetAwaiter().GetResult();
-            Certificate = credentialDescription.Certificate;
+            if (credentialDescription.Certificate == null)
+            {
+                Assert.Fail($"Did you install the lab certificate '{credentialDescription.CertificateThumbprint}' in the `Local Machine/Personal` credential store?");
+            }
+            else
+            {
+                Certificate = credentialDescription.Certificate;
+            }
         }
 
         public X509Certificate2 Certificate  { get; set; }

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -75,9 +75,9 @@ namespace Microsoft.Identity.Web.Test
                 {
                     Assert.Equal(ServiceLifetime.Scoped, actual.Lifetime);
                     Assert.Equal(typeof(ITokenAcquirerFactory), actual.ServiceType);
-                    Assert.Null(actual.ImplementationType);
+                    Assert.Equal(typeof(DefaultTokenAcquirerFactoryImplentation), actual.ImplementationType);
                     Assert.Null(actual.ImplementationInstance);
-                    Assert.NotNull(actual.ImplementationFactory);
+                    Assert.Null(actual.ImplementationFactory);
                 },
                 actual =>
                 {

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Web.Test
                 {
                     Assert.Equal(ServiceLifetime.Scoped, actual.Lifetime);
                     Assert.Equal(typeof(ITokenAcquirerFactory), actual.ServiceType);
-                    Assert.Equal(typeof(DefaultTokenAcquirerFactoryImplentation), actual.ImplementationType);
+                    Assert.Equal(typeof(DefaultTokenAcquirerFactoryImplementation), actual.ImplementationType);
                     Assert.Null(actual.ImplementationInstance);
                     Assert.Null(actual.ImplementationFactory);
                 },


### PR DESCRIPTION
Fix App service authentication:
- Add support for app tokens (if the app services authentication provided the right scopes)
- Fix the app services authentication regression in 2.x by registering IAuthorizationHeaderProvider and ITokenAcquirerFactory
- Remove a few warnings (Diagnostics, DownstreamApi)
- Refactors the implementation of ITokenAcquirerFactory to be a new class DefaultTokenAcquirerFactory (And no longer the TokenAquisitionAspNetCore class in ASP.NET Core)
  - fix the ServiceCollectionExtensions accordingly
  - fix the tests accordingly
- Adds a more explicit test failtures when the lab certificate is missing.
- Update the App.Config from the OWIN web app and web API
