### PR TITLE
app services roles

### DIFF
--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.JsonWebTokens;
-using static Microsoft.Identity.Web.AppServicesAuthenticationTokenAcquisition;
 
 namespace Microsoft.Identity.Web
 {
@@ -190,7 +189,7 @@ namespace Microsoft.Identity.Web
                     jsonWebToken.Claims,
                     idp,
                     isAadV1Token ? Constants.NameClaim : Constants.PreferredUserName,
-                    ClaimsIdentity.DefaultRoleClaimType));
+                    "roles"));
             }
             else
             {

--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Identity.Web
                     jsonWebToken.Claims,
                     idp,
                     isAadV1Token ? Constants.NameClaim : Constants.PreferredUserName,
-                    "roles"));
+                    ClaimConstants.Roles));
             }
             else
             {


### PR DESCRIPTION
Fix the roles claims type in apps services
the issuer is v2.0, and it does not go through
Wilson's claimsTypeMapping, so the claims type
will always be "roles"

See also; https://github.com/AzureAD/microsoft-identity-web/pull/2027