### PR TITLE
Enable developpers to support the authority in the configuration inst…

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/CiamAuthorityHelper.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/CiamAuthorityHelper.cs
@@ -7,6 +7,8 @@ using Microsoft.Identity.Abstractions;
 
 namespace Microsoft.Identity.Web
 {
+
+    // This class is temporary. Will be removed when the authority supports the right pattern.
     internal class CiamAuthorityHelper
     {
         internal static void BuildCiamAuthorityIfNeeded(MicrosoftIdentityApplicationOptions options)

--- a/src/Microsoft.Identity.Web.TokenAcquisition/CiamAuthorityHelper.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/CiamAuthorityHelper.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Microsoft.Identity.Abstractions;
+
+namespace Microsoft.Identity.Web
+{
+    internal class CiamAuthorityHelper
+    {
+        internal static void BuildCiamAuthorityIfNeeded(MicrosoftIdentityApplicationOptions options)
+        {
+            const string ciamAuthority = ".ciamlogin.com";
+            string? authority = options.Authority;
+
+            // Case where the instance is given with tenant.ciamlogin.com, and not tenant Id
+            // We trim the v2.0
+            if (authority != null)
+            {
+                if (authority.EndsWith("//v2.0", StringComparison.OrdinalIgnoreCase))
+                {
+                    authority = authority.Substring(0, authority.Length - 5);
+                }
+                else if (authority.EndsWith("/v2.0", StringComparison.OrdinalIgnoreCase))
+                {
+                    authority = authority.Substring(0, authority.Length - 4);
+                }
+            }
+
+            if (authority != null
+#if NET462 || NET472 || NETSTANDARD2_0
+                && authority.Contains(ciamAuthority))
+#else
+                && authority.Contains(ciamAuthority, StringComparison.OrdinalIgnoreCase))
+#endif
+            {
+                Uri baseUri = new Uri(authority);
+                string host = baseUri.Host;
+                if (host.EndsWith(ciamAuthority, StringComparison.OrdinalIgnoreCase)
+                    && baseUri.AbsolutePath == "/")
+                {
+                    string tenantId = host.Substring(0, host.IndexOf(ciamAuthority, StringComparison.OrdinalIgnoreCase)) + ".onmicrosoft.com";
+                    options.Authority = new Uri(baseUri, $"{baseUri.PathAndQuery}{tenantId}/v2.0").ToString();
+                    options.Instance = new Uri(baseUri, $"{baseUri.PathAndQuery}").ToString();
+                    options.TenantId = tenantId;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web.TokenAcquisition/Constants.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/Constants.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Identity.Web
         internal const string True = "True";
         internal const string InvalidClient = "invalid_client";
         internal const string InvalidKeyError = "AADSTS700027";
+        internal const string CiamAuthoritySuffix = ".ciamlogin.com";
 
         // Blazor challenge URI
         internal const string BlazorChallengeUri = "MicrosoftIdentity/Account/Challenge?redirectUri=";

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
@@ -83,7 +83,13 @@ namespace Microsoft.Identity.Web
                 defaultInstance = instance;
                 instance.Services.AddTokenAcquisition();
                 instance.Services.AddHttpClient();
-                instance.Services.Configure<MicrosoftIdentityApplicationOptions>(option => instance.Configuration.GetSection(configSection).Bind(option));
+                instance.Services.Configure<MicrosoftIdentityApplicationOptions>(option =>
+                {
+                    instance.Configuration.GetSection(configSection).Bind(option);
+
+                    // This is temporary and will be removed eventually.
+                    CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(option);
+                });
                 instance.Services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplementation>();
                 instance.Services.AddSingleton(defaultInstance.Configuration);
             }
@@ -112,7 +118,13 @@ namespace Microsoft.Identity.Web
                 defaultInstance = instance;
                 instance.Services.AddTokenAcquisition();
                 instance.Services.AddHttpClient();
-                instance.Services.AddOptions<MicrosoftIdentityApplicationOptions>(string.Empty);
+                instance.Services.Configure<MicrosoftIdentityApplicationOptions>(option =>
+                {
+                    instance.Configuration.GetSection(configSection).Bind(option);
+
+                    // This is temporary and will be removed eventually.
+                    CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(option);
+                });
                 instance.Services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplementation>();
                 instance.Services.AddSingleton(defaultInstance.Configuration);
             }

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -33,5 +33,22 @@ namespace Microsoft.Identity.Web
 
             return authority;
         }
+
+        internal static string? BuildCiamAuthorityIfNeeded(string? authority)
+        {
+            const string ciamAuthority = ".ciamlogin.com";
+            if (authority != null && authority.Contains(ciamAuthority, StringComparison.OrdinalIgnoreCase))
+            {
+                Uri baseUri = new Uri(authority);
+                string host = baseUri.Host;
+                if (host.EndsWith(ciamAuthority, StringComparison.OrdinalIgnoreCase)
+                    && baseUri.AbsolutePath == "/")
+                {
+                    string tenantId = host.Substring(0, host.IndexOf(ciamAuthority, StringComparison.OrdinalIgnoreCase)) + ".onmicrosoft.com";
+                    return new Uri(baseUri, new PathString($"{baseUri.PathAndQuery}{tenantId}/v2.0")).ToString();
+                }
+            }
+            return authority;
+        }
     }
 }

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Web
                     && baseUri.AbsolutePath == "/")
                 {
                     string tenantId = host.Substring(0, host.IndexOf(ciamAuthority, StringComparison.OrdinalIgnoreCase)) + ".onmicrosoft.com";
-                    return new Uri(baseUri, new PathString($"{baseUri.PathAndQuery}{tenantId}/v2.0")).ToString();
+                    return new Uri(baseUri, new PathString($"{baseUri.PathAndQuery}{tenantId}")).ToString();
                 }
             }
             return authority;

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -36,15 +36,14 @@ namespace Microsoft.Identity.Web
 
         internal static string? BuildCiamAuthorityIfNeeded(string? authority)
         {
-            const string ciamAuthority = ".ciamlogin.com";
-            if (authority != null && authority.Contains(ciamAuthority, StringComparison.OrdinalIgnoreCase))
+            if (authority != null && authority.Contains(Constants.CiamAuthoritySuffix, StringComparison.OrdinalIgnoreCase))
             {
                 Uri baseUri = new Uri(authority);
                 string host = baseUri.Host;
-                if (host.EndsWith(ciamAuthority, StringComparison.OrdinalIgnoreCase)
+                if (host.EndsWith(Constants.CiamAuthoritySuffix, StringComparison.OrdinalIgnoreCase)
                     && baseUri.AbsolutePath == "/")
                 {
-                    string tenantId = host.Substring(0, host.IndexOf(ciamAuthority, StringComparison.OrdinalIgnoreCase)) + ".onmicrosoft.com";
+                    string tenantId = host.Substring(0, host.IndexOf(Constants.CiamAuthoritySuffix, StringComparison.OrdinalIgnoreCase)) + ".onmicrosoft.com";
                     return new Uri(baseUri, new PathString($"{baseUri.PathAndQuery}{tenantId}")).ToString();
                 }
             }

--- a/src/Microsoft.Identity.Web/MergedOptionsValidation.cs
+++ b/src/Microsoft.Identity.Web/MergedOptionsValidation.cs
@@ -15,23 +15,26 @@ namespace Microsoft.Identity.Web
                 throw new ArgumentNullException(options.ClientId, string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.ClientId)));
             }
 
-            if (string.IsNullOrEmpty(options.Authority) && string.IsNullOrEmpty(options.Instance))
+            if (string.IsNullOrEmpty(options.Authority))
             {
-                throw new ArgumentNullException(options.Instance, string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.Instance)));
-            }
-
-            if (options.IsB2C)
-            {
-                if (string.IsNullOrEmpty(options.Domain))
+                if (string.IsNullOrEmpty(options.Instance))
                 {
-                    throw new ArgumentNullException(options.Domain, string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.Domain)));
+                    throw new ArgumentNullException(options.Instance, string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.Instance)));
                 }
-            }
-            else
-            {
-                if (string.IsNullOrEmpty(options.TenantId))
+
+                if (options.IsB2C)
                 {
-                    throw new ArgumentNullException(options.TenantId, string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.TenantId)));
+                    if (string.IsNullOrEmpty(options.Domain))
+                    {
+                        throw new ArgumentNullException(options.Domain, string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.Domain)));
+                    }
+                }
+                else
+                {
+                    if (string.IsNullOrEmpty(options.TenantId))
+                    {
+                        throw new ArgumentNullException(options.TenantId, string.Format(CultureInfo.InvariantCulture, IDWebErrorMessage.ConfigurationOptionRequired, nameof(options.TenantId)));
+                    }
                 }
             }
         }

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -164,6 +164,7 @@ namespace Microsoft.Identity.Web
                     MicrosoftIdentityBaseAuthenticationBuilder.SetIdentityModelLogger(serviceProvider);
                     msIdOptionsMonitor.Get(jwtBearerScheme); // needed for firing the PostConfigure.
                     MergedOptions mergedOptions = mergedOptionsMonitor.Get(jwtBearerScheme);
+                    mergedOptions.Authority = AuthorityHelpers.BuildCiamAuthorityIfNeeded(mergedOptions.Authority);
 
                     MergedOptionsValidation.Validate(mergedOptions);
 

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -164,7 +164,11 @@ namespace Microsoft.Identity.Web
                     MicrosoftIdentityBaseAuthenticationBuilder.SetIdentityModelLogger(serviceProvider);
                     msIdOptionsMonitor.Get(jwtBearerScheme); // needed for firing the PostConfigure.
                     MergedOptions mergedOptions = mergedOptionsMonitor.Get(jwtBearerScheme);
-                    mergedOptions.Authority = AuthorityHelpers.BuildCiamAuthorityIfNeeded(mergedOptions.Authority);
+
+                    if (mergedOptions.Authority != null)
+                    {
+                        mergedOptions.Authority = AuthorityHelpers.BuildCiamAuthorityIfNeeded(mergedOptions.Authority);
+                    }
 
                     MergedOptionsValidation.Validate(mergedOptions);
 

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -289,7 +289,12 @@ namespace Microsoft.Identity.Web
                     MergedOptions mergedOptions = mergedOptionsMonitor.Get(openIdConnectScheme);
 
                     MergedOptionsValidation.Validate(mergedOptions);
-                    mergedOptions.Authority = AuthorityHelpers.BuildCiamAuthorityIfNeeded(mergedOptions.Authority);
+
+                    if (mergedOptions.Authority != null)
+                    {
+                        mergedOptions.Authority = AuthorityHelpers.BuildCiamAuthorityIfNeeded(mergedOptions.Authority);
+                    }
+
                     PopulateOpenIdOptionsFromMergedOptions(options, mergedOptions);
 
                     var b2cOidcHandlers = new AzureADB2COpenIDConnectEventHandlers(

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -289,6 +289,7 @@ namespace Microsoft.Identity.Web
                     MergedOptions mergedOptions = mergedOptionsMonitor.Get(openIdConnectScheme);
 
                     MergedOptionsValidation.Validate(mergedOptions);
+                    mergedOptions.Authority = AuthorityHelpers.BuildCiamAuthorityIfNeeded(mergedOptions.Authority);
                     PopulateOpenIdOptionsFromMergedOptions(options, mergedOptions);
 
                     var b2cOidcHandlers = new AzureADB2COpenIDConnectEventHandlers(

--- a/tests/DevApps/B2CWebAppCallsWebApi/Client/Controllers/HomeController.cs
+++ b/tests/DevApps/B2CWebAppCallsWebApi/Client/Controllers/HomeController.cs
@@ -20,17 +20,15 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
             _tokenAcquisition = tokenAcquisition;
         }
 
-        [HttpPut]
-        [ValidateAntiForgeryToken]
+        [HttpGet]
         public IActionResult Index()
         {
             return View();
         }
 
         
-        [HttpPost]
+        [HttpGet]
         [AllowAnonymous]
-        [ValidateAntiForgeryToken]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
         {

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Controllers/HomeController.cs
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Controllers/HomeController.cs
@@ -30,16 +30,14 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
             _downstreamApi = downstreamApi;
         }
 
-        [HttpPut]
-        [ValidateAntiForgeryToken]
+        [HttpGet]
         public IActionResult Index()
         {
             return View();
         }
 
-        [HttpPost]
+        [HttpGet]
         [AllowAnonymous]
-        [ValidateAntiForgeryToken]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
         {

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Controllers/TodoListController.cs
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Controllers/TodoListController.cs
@@ -46,8 +46,7 @@ namespace TodoListClient.Controllers
         }
 
         // Create and present to the user (no service call)
-        [HttpPost]
-        [ValidateAntiForgeryToken]
+        [HttpGet]
         public ActionResult Create()
         {
             Todo todo = new Todo() { Owner = HttpContext.User.Identity.Name };

--- a/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.Test.Common;
 using Xunit;
 
@@ -61,6 +62,36 @@ namespace Microsoft.Identity.Web.Test
             string expectedResult = $"{TestConstants.AadInstance}/{options.TenantId}/v2.0";
 
             string result = AuthorityHelpers.BuildAuthority(options);
+
+            Assert.NotNull(result);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void BuildAuthority_CiamAuthority_ReturnsValidAadAuthority()
+        {
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                Authority = "https://tenant.ciamlogin.com/"
+            };
+            string expectedResult = options.Authority + "tenant.onmicrosoft.com/v2.0";
+
+            string? result = AuthorityHelpers.BuildCiamAuthorityIfNeeded(options.Authority);
+
+            Assert.NotNull(result);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void BuildAuthority_CiamAuthorityWithTenant_ReturnsValidAadAuthority()
+        {
+            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
+            {
+                Authority = "https://tenant.ciamlogin.com/anything"
+            };
+            string expectedResult = options.Authority ;
+
+            string? result = AuthorityHelpers.BuildCiamAuthorityIfNeeded(options.Authority);
 
             Assert.NotNull(result);
             Assert.Equal(expectedResult, result);

--- a/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
@@ -72,9 +72,9 @@ namespace Microsoft.Identity.Web.Test
         {
             MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
             {
-                Authority = "https://tenant.ciamlogin.com/"
+                Authority = $"https://contoso{Constants.CiamAuthoritySuffix}/"
             };
-            string expectedResult = options.Authority + "tenant.onmicrosoft.com";
+            string expectedResult = options.Authority + TestConstants.Domain;
 
             string? result = AuthorityHelpers.BuildCiamAuthorityIfNeeded(options.Authority);
 
@@ -87,7 +87,7 @@ namespace Microsoft.Identity.Web.Test
         {
             MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
             {
-                Authority = "https://tenant.ciamlogin.com/anything"
+                Authority = $"https://contoso{Constants.CiamAuthoritySuffix}/{TestConstants.TenantIdAsGuid}/"
             };
             string expectedResult = options.Authority ;
 

--- a/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.Web.Test
             {
                 Authority = "https://tenant.ciamlogin.com/"
             };
-            string expectedResult = options.Authority + "tenant.onmicrosoft.com/v2.0";
+            string expectedResult = options.Authority + "tenant.onmicrosoft.com";
 
             string? result = AuthorityHelpers.BuildCiamAuthorityIfNeeded(options.Authority);
 

--- a/tests/Microsoft.Identity.Web.Test/CiamAuthorityHelperTest.cs
+++ b/tests/Microsoft.Identity.Web.Test/CiamAuthorityHelperTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Web.Test
     public class CiamAuthorityHelperTest
     {
         [Fact]
-        public void NotCiam()
+        public void CiamHelperWithNonCiamAuthority()
         {
             MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
             {
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
-        public void CiamTenantSpecified()
+        public void CiamHelperWithCiamTenantSpecified()
         {
             MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
             {
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
-        public void CiamTenantInferredFromAuthority()
+        public void CiamHelperWithCiamTenantInferredFromAuthority()
         {
             MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
-        public void CiamTenantInferredFromInstance()
+        public void CiamHelperWithCiamTenantInferredFromInstance()
         {
             MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
             {

--- a/tests/Microsoft.Identity.Web.Test/CiamAuthorityHelperTest.cs
+++ b/tests/Microsoft.Identity.Web.Test/CiamAuthorityHelperTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Web.Test.Common;
 using Xunit;
 
 namespace Microsoft.Identity.Web.Test
@@ -13,13 +14,13 @@ namespace Microsoft.Identity.Web.Test
         {
             MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
             {
-                Instance = "https://login.microsoftonline.com/",
-                TenantId = "common"
+                Instance = TestConstants.AadInstance +"/",
+                TenantId = TestConstants.Organizations
             };
 
             CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(options);
-            Assert.Equal("https://login.microsoftonline.com/common/v2.0", options.Authority);
-            Assert.Equal("common", options.TenantId);
+            Assert.Equal(TestConstants.AuthorityOrganizationsWithV2, options.Authority);
+            Assert.Equal(TestConstants.Organizations, options.TenantId);
         }
 
         [Fact]
@@ -27,14 +28,14 @@ namespace Microsoft.Identity.Web.Test
         {
             MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
             {
-                Instance = "https://tenant.ciamlogin.com/",
-                TenantId = "aDomain"
+                Instance = $"https://tenant{Constants.CiamAuthoritySuffix}/",
+                TenantId = TestConstants.B2CCustomDomainTenant
             };
 
             CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(options);
-            Assert.Equal("https://tenant.ciamlogin.com/aDomain/v2.0", options.Authority);
-            Assert.Equal("aDomain", options.TenantId);
-            Assert.Equal("https://tenant.ciamlogin.com/", options.Instance);
+            Assert.Equal($"https://tenant{Constants.CiamAuthoritySuffix}/{TestConstants.B2CCustomDomainTenant}/v2.0", options.Authority);
+            Assert.Equal(TestConstants.B2CCustomDomainTenant, options.TenantId);
+            Assert.Equal($"https://tenant{Constants.CiamAuthoritySuffix}/", options.Instance);
         }
 
         [Fact]
@@ -42,13 +43,13 @@ namespace Microsoft.Identity.Web.Test
         {
             MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
             {
-                Instance = "https://tenant.ciamlogin.com/",
+                Instance = $"https://cpimtestpartners{Constants.CiamAuthoritySuffix}/",
             };
 
             CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(options);
-            Assert.Equal("https://tenant.ciamlogin.com/tenant.onmicrosoft.com/v2.0", options.Authority);
-            Assert.Equal("tenant.onmicrosoft.com", options.TenantId);
-            Assert.Equal("https://tenant.ciamlogin.com/", options.Instance);
+            Assert.Equal($"https://cpimtestpartners{Constants.CiamAuthoritySuffix}/{TestConstants.B2CCustomDomainTenant}/v2.0", options.Authority);
+            Assert.Equal(TestConstants.B2CCustomDomainTenant, options.TenantId);
+            Assert.Equal($"https://cpimtestpartners{Constants.CiamAuthoritySuffix}/", options.Instance);
         }
 
         [Fact]
@@ -56,13 +57,13 @@ namespace Microsoft.Identity.Web.Test
         {
             MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
             {
-                Authority = "https://tenant.ciamlogin.com/",
+                Authority = $"https://cpimtestpartners{Constants.CiamAuthoritySuffix}/",
             };
 
             CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(options);
-            Assert.Equal("https://tenant.ciamlogin.com/tenant.onmicrosoft.com/v2.0", options.Authority);
-            Assert.Equal("tenant.onmicrosoft.com", options.TenantId);
-            Assert.Equal("https://tenant.ciamlogin.com/", options.Instance);
+            Assert.Equal($"https://cpimtestpartners{Constants.CiamAuthoritySuffix}/{TestConstants.B2CCustomDomainTenant}/v2.0", options.Authority);
+            Assert.Equal(TestConstants.B2CCustomDomainTenant, options.TenantId);
+            Assert.Equal($"https://cpimtestpartners{Constants.CiamAuthoritySuffix}/", options.Instance);
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/CiamAuthorityHelperTest.cs
+++ b/tests/Microsoft.Identity.Web.Test/CiamAuthorityHelperTest.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Abstractions;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    public class CiamAuthorityHelperTest
+    {
+        [Fact]
+        public void NotCiam()
+        {
+            MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
+            {
+                Instance = "https://login.microsoftonline.com/",
+                TenantId = "common"
+            };
+
+            CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(options);
+            Assert.Equal("https://login.microsoftonline.com/common/v2.0", options.Authority);
+            Assert.Equal("common", options.TenantId);
+        }
+
+        [Fact]
+        public void CiamTenantSpecified()
+        {
+            MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
+            {
+                Instance = "https://tenant.ciamlogin.com/",
+                TenantId = "aDomain"
+            };
+
+            CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(options);
+            Assert.Equal("https://tenant.ciamlogin.com/aDomain/v2.0", options.Authority);
+            Assert.Equal("aDomain", options.TenantId);
+            Assert.Equal("https://tenant.ciamlogin.com/", options.Instance);
+        }
+
+        [Fact]
+        public void CiamTenantInferredFromAuthority()
+        {
+            MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
+            {
+                Instance = "https://tenant.ciamlogin.com/",
+            };
+
+            CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(options);
+            Assert.Equal("https://tenant.ciamlogin.com/tenant.onmicrosoft.com/v2.0", options.Authority);
+            Assert.Equal("tenant.onmicrosoft.com", options.TenantId);
+            Assert.Equal("https://tenant.ciamlogin.com/", options.Instance);
+        }
+
+        [Fact]
+        public void CiamTenantInferredFromInstance()
+        {
+            MicrosoftIdentityApplicationOptions options = new MicrosoftIdentityApplicationOptions
+            {
+                Authority = "https://tenant.ciamlogin.com/",
+            };
+
+            CiamAuthorityHelper.BuildCiamAuthorityIfNeeded(options);
+            Assert.Equal("https://tenant.ciamlogin.com/tenant.onmicrosoft.com/v2.0", options.Authority);
+            Assert.Equal("tenant.onmicrosoft.com", options.TenantId);
+            Assert.Equal("https://tenant.ciamlogin.com/", options.Instance);
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
+++ b/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Abstractions" Version="$(MicrosoftIdentityAbstractions)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityOptionsTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Web.Test
         [InlineData(TestConstants.ClientId, TestConstants.B2CInstance, null, null, TestConstants.B2CSignUpSignInUserFlow, TestConstants.B2CTenant, AzureAdB2C)]
         [InlineData(TestConstants.ClientId, TestConstants.B2CInstance, null, null, TestConstants.B2CSignUpSignInUserFlow, null, AzureAdB2C, MissingParam.Domain)]
         [InlineData(TestConstants.ClientId, TestConstants.B2CInstance, null, null, TestConstants.B2CSignUpSignInUserFlow, "", AzureAdB2C, MissingParam.Domain)]
-        [InlineData(TestConstants.ClientId, null, null, TestConstants.AuthorityWithTenantSpecified, null, null, AzureAd, MissingParam.TenantId)]
+        [InlineData(TestConstants.ClientId, null, null, TestConstants.AuthorityWithTenantSpecified, null, null, AzureAd)]
         [InlineData(null, null, null, TestConstants.AuthorityWithTenantSpecified, null, null, AzureAd, MissingParam.ClientId)]
         public void ValidateRequiredMicrosoftIdentityOptions(
            string clientId,


### PR DESCRIPTION
Enable developpers to support the authority in the configuration instead of the instance+tenantId, or instance+Domain

```diff
    "AzureAd": {
-       "Instance": "https://login.microsoftonline.com/",
+      "Authority": "https://login.microsoftonline.com/7f58f645-c190-4ce5-9de4-e2b7acd2a6ab",
-       "Domain": "msidentitytesting.onmicrosofonline.com",
-        "TenantId": "7f58f645-c190-4ce5-9de4-e2b7acd2a6ab",
```

Tested with:
- WebApp calls Graph
- WebApp calls own web API calls Graph 
- B2C WebApp calls web API 