### PR TITLE
Add support for CIAM to the app registration tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/tools/app-provisioning-tool/testwebapp

--- a/tools/app-provisioning-tool/Directory.Build.props
+++ b/tools/app-provisioning-tool/Directory.Build.props
@@ -1,0 +1,14 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+  <PropertyGroup>
+     <TargetFrameworks>net7.0</TargetFrameworks>
+     <SignAssembly>True</SignAssembly>
+     <AssemblyOriginatorKeyFile>../../../build/MSAL.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+
+ <ItemGroup>
+    <None Remove="..\..\LICENSE"/>
+ </ItemGroup>
+
+</Project>

--- a/tools/app-provisioning-tool/README.md
+++ b/tools/app-provisioning-tool/README.md
@@ -40,7 +40,7 @@ You can install the tool as an external tool in Visual Studio for this:
    5. Check **Use output window** and **Prompt for arguments**
  6. Select OK 
 
-![image](https://user-images.githubusercontent.com/13203188/113719161-9e2b8580-96ed-11eb-8ad8-7b02eedbd4ed.png)
+   ![image](https://user-images.githubusercontent.com/13203188/113719161-9e2b8580-96ed-11eb-8ad8-7b02eedbd4ed.png)
 
 `msidentity-app-sync` now appears in the **Tools** menu, and when you select an ASP.NET Core project, you can run it on that project.
 

--- a/tools/app-provisioning-tool/app-provisioning-lib/AuthenticationParameters/ApplicationParameters.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/AuthenticationParameters/ApplicationParameters.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.App.AuthenticationParameters
         {
             get
             {
-                return Domain?.Replace(".onmicrosoft.com", string.Empty);
+                return Domain?.Replace(".onmicrosoft.com", string.Empty, StringComparison.OrdinalIgnoreCase);
             }
         }
 

--- a/tools/app-provisioning-tool/app-provisioning-lib/AuthenticationParameters/ApplicationParameters.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/AuthenticationParameters/ApplicationParameters.cs
@@ -82,6 +82,10 @@ namespace Microsoft.Identity.App.AuthenticationParameters
         /// </summary>
         public bool IsB2C { get; set; }
 
+        /// <summary>
+        /// Is the tenant a CIAM tenant?
+        /// </summary>
+        public bool IsCiam { get; set; }
 
         // TODO: propose a fix for the blazorwasm project template
         

--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                 IEnumerable<string> httpsProfileLaunchUrls = projectAuthenticationSettings.Replacements
                     .Where(r => r.ReplaceBy == "profilesApplicationUrls")
                     .SelectMany(r => r.ReplaceFrom.Split(';'))
-                    .Where(u => u.StartsWith("https://"));
+                    .Where(u => u.StartsWith("https://", StringComparison.OrdinalIgnoreCase));
                 launchUrls.AddRange(httpsProfileLaunchUrls);
 
                 // Set the web redirect URIs
@@ -132,7 +132,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                 }
                 if (!string.IsNullOrEmpty(signoutPath))
                 {
-                    if (signoutPath.StartsWith("/"))
+                    if (signoutPath.StartsWith("/", StringComparison.OrdinalIgnoreCase))
                     {
                         if (launchUrls.Any())
                         {
@@ -158,12 +158,12 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                 JsonElement jsonContent = default;
                 XmlDocument? xmlDocument = null;
 
-                if (filePath.EndsWith(".json"))
+                if (filePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
                 {
                     jsonContent = JsonSerializer.Deserialize<JsonElement>(fileContent,
                                                                           s_serializerOptionsWithComments);
                 }
-                else if (filePath.EndsWith(".csproj"))
+                else if (filePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
                 {
                     xmlDocument = new XmlDocument();
                     xmlDocument.Load(filePath);
@@ -177,7 +177,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     {
                         string[] path = property.Split(':');
 
-                        if (filePath.EndsWith(".json"))
+                        if (filePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
                         {
                             IEnumerable<KeyValuePair<JsonElement, int>> elements = FindMatchingElements(jsonContent, path, 0);
                             foreach (var pair in elements)
@@ -213,7 +213,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                         }
                         else
                         {
-                            int index = fileContent.IndexOf(property);
+                            int index = fileContent.IndexOf(property, StringComparison.OrdinalIgnoreCase);
                             if (index != -1)
                             {
                                 UpdatePropertyRepresents(
@@ -227,7 +227,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     }
 
                     if (!string.IsNullOrEmpty(propertyMapping.Sets) && (found
-                            || (propertyMapping.MatchAny != null && propertyMapping.MatchAny.Any(m => fileContent.Contains(m)))))
+                            || (propertyMapping.MatchAny != null && propertyMapping.MatchAny.Any(m => fileContent.Contains(m, StringComparison.OrdinalIgnoreCase)))))
                     {
                         projectAuthenticationSettings.ApplicationParameters.Sets(propertyMapping.Sets);
                     }

--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
@@ -258,7 +258,8 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     index,
                     length,
                     replaceFrom,
-                    propertyMapping.Represents);
+                    propertyMapping.Represents,
+                    propertyMapping.Property!);
             }
         }
 
@@ -331,9 +332,9 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     projectAuthenticationSettings.ApplicationParameters.EffectiveTenantId = (value != defaultValue) ? value : null;
                     break;
                 case "Application.Authority":
-                    // Case of Blazorwasm where the authority is not separated :(
+                    // Case of Blazorwasm and CIAM where the authority is not separated :(
                     projectAuthenticationSettings.ApplicationParameters.Authority = value;
-                    if (!string.IsNullOrEmpty(value))
+                    if (!string.IsNullOrEmpty(value) && !projectAuthenticationSettings.ApplicationParameters.IsCiam)
                     {
                         // TODO: something more generic
                         Uri authority = new Uri(value);
@@ -388,9 +389,10 @@ namespace Microsoft.Identity.App.CodeReaderWriter
             int index,
             int length,
             string replaceFrom,
-            string replaceBy)
+            string replaceBy,
+            string property)
         {
-            projectAuthenticationSettings.Replacements.Add(new Replacement(filePath, index, length, replaceFrom, replaceBy));
+            projectAuthenticationSettings.Replacements.Add(new Replacement(filePath, index, length, replaceFrom, replaceBy, property));
         }
 
     }

--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeReader.cs
@@ -338,13 +338,25 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     {
                         // TODO: something more generic
                         Uri authority = new Uri(value);
-                        string? tenantOrDomain = authority.LocalPath.Split('/', StringSplitOptions.RemoveEmptyEntries)[0];
-                        if (tenantOrDomain == "qualified.domain.name")
+                        string[] segments = authority.LocalPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                        if (segments.Length > 0)
                         {
-                            tenantOrDomain = null;
+                            string? tenantOrDomain = segments[0];
+
+                            if (tenantOrDomain == "qualified.domain.name")
+                            {
+                                tenantOrDomain = null;
+                            }
+                            projectAuthenticationSettings.ApplicationParameters.Domain = tenantOrDomain;
+                            projectAuthenticationSettings.ApplicationParameters.TenantId = tenantOrDomain;
                         }
-                        projectAuthenticationSettings.ApplicationParameters.Domain = tenantOrDomain;
-                        projectAuthenticationSettings.ApplicationParameters.TenantId = tenantOrDomain;
+                        else
+                        {
+                            if (value.Contains(".ciamlogin.com", StringComparison.OrdinalIgnoreCase))
+                            {
+                                projectAuthenticationSettings.ApplicationParameters.IsCiam = true;
+                            }
+                        }
                     }
                     break;
                 case "Directory.Domain":

--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeWriter.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeWriter.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                 string? replaceBy = ComputeReplacement(r.ReplaceBy, reconcialedApplicationParameters);
                 if (replaceBy != null && replaceBy != r.ReplaceFrom)
                 {
-                    int index = fileContent.IndexOf(r.ReplaceFrom /*, r.Index*/);
+                    int index = fileContent.IndexOf(r.ReplaceFrom /*, r.Index*/, StringComparison.OrdinalIgnoreCase);
                     if (index != -1)
                     {
                         fileContent = fileContent.Substring(0, index)
@@ -192,7 +192,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                 case "Application.Authority":
                     replacement = reconciledApplicationParameters.Authority;
                     // Blazor b2C
-                    replacement = replacement?.Replace("onmicrosoft.com.b2clogin.com", "b2clogin.com");
+                    replacement = replacement?.Replace("onmicrosoft.com.b2clogin.com", "b2clogin.com", StringComparison.OrdinalIgnoreCase);
                     break;
                 case "MsalAuthenticationOptions":
                     // Todo generalize with a directive: Ensure line after line, or ensure line
@@ -207,8 +207,8 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     break;
                 case "Application.CalledApiScopes":
                     replacement = reconciledApplicationParameters.CalledApiScopes
-                        ?.Replace("openid", string.Empty)
-                        ?.Replace("offline_access", string.Empty)
+                        ?.Replace("openid", string.Empty, StringComparison.OrdinalIgnoreCase)
+                        ?.Replace("offline_access", string.Empty, StringComparison.OrdinalIgnoreCase)
                         ?.Trim();
                     break;
 
@@ -223,10 +223,10 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                         if (reconciledApplicationParameters.Instance == "https://login.microsoftonline.com/tfp/"
                         && reconciledApplicationParameters.IsB2C
                         && !string.IsNullOrEmpty(reconciledApplicationParameters.Domain)
-                        && reconciledApplicationParameters.Domain.EndsWith(".onmicrosoft.com"))
+                        && reconciledApplicationParameters.Domain.EndsWith(".onmicrosoft.com", StringComparison.OrdinalIgnoreCase))
                         {
-                            replacement = "https://" + reconciledApplicationParameters.Domain.Replace(".onmicrosoft.com", ".b2clogin.com")
-                                .Replace("aadB2CInstance", reconciledApplicationParameters.Domain1);
+                            replacement = "https://" + reconciledApplicationParameters.Domain.Replace(".onmicrosoft.com", ".b2clogin.com", StringComparison.OrdinalIgnoreCase)
+                                .Replace("aadB2CInstance", reconciledApplicationParameters.Domain1, StringComparison.OrdinalIgnoreCase);
                         }
                         else
                         {

--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeWriter.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeWriter.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     replacement = reconciledApplicationParameters.IsCiam ? "*Remove*" : reconciledApplicationParameters.TenantId;
                     break;
                 case "Directory.Domain":
-                    replacement = reconciledApplicationParameters.Domain;
+                    replacement = reconciledApplicationParameters.IsCiam ? "*Remove*" : reconciledApplicationParameters.Domain;
                     break;
                 case "Application.SusiPolicy":
                     replacement = reconciledApplicationParameters.SusiPolicy;

--- a/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeWriter.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/CodeReaderWriter/CodeWriter.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Identity.App.CodeReaderWriter
 {
@@ -20,21 +22,14 @@ namespace Microsoft.Identity.App.CodeReaderWriter
 
                 string fileContent = File.ReadAllText(filePath);
                 bool updated = false;
-                foreach (Replacement r in replacementsInFile.OrderByDescending(r => r.Index))
+
+                if (filePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
                 {
-                    string? replaceBy = ComputeReplacement(r.ReplaceBy, reconcialedApplicationParameters);
-                    if (replaceBy != null && replaceBy!=r.ReplaceFrom)
-                    {
-                        int index = fileContent.IndexOf(r.ReplaceFrom /*, r.Index*/);
-                        if (index != -1)
-                        {
-                            fileContent = fileContent.Substring(0, index)
-                                + replaceBy
-                                + fileContent.Substring(index + r.Length);
-                            updated = true;
-                            summary.changes.Add(new Change($"{filePath}: updating {r.ReplaceBy}"));
-                        }
-                    }
+                    updated = ReplaceInJSonFile(reconcialedApplicationParameters, replacementsInFile, ref fileContent);
+                }
+                else
+                {
+                    updated = ReplaceInTextFile(summary, reconcialedApplicationParameters, replacementsInFile, filePath, ref fileContent);
                 }
 
                 if (updated)
@@ -49,10 +44,93 @@ namespace Microsoft.Identity.App.CodeReaderWriter
             }
         }
 
+        private bool ReplaceInTextFile(Summary summary, ApplicationParameters reconcialedApplicationParameters, IGrouping<string, Replacement> replacementsInFile, string filePath, ref string fileContent)
+        {
+            bool updated = false;
+
+            foreach (Replacement r in replacementsInFile.OrderByDescending(r => r.Index))
+            {
+                string? replaceBy = ComputeReplacement(r.ReplaceBy, reconcialedApplicationParameters);
+                if (replaceBy != null && replaceBy != r.ReplaceFrom)
+                {
+                    int index = fileContent.IndexOf(r.ReplaceFrom /*, r.Index*/);
+                    if (index != -1)
+                    {
+                        fileContent = fileContent.Substring(0, index)
+                            + replaceBy
+                            + fileContent.Substring(index + r.Length);
+                        updated = true;
+                        summary.changes.Add(new Change($"{filePath}: updating {r.ReplaceBy}"));
+                    }
+                }
+            }
+            return updated;
+        }
+
+        private bool ReplaceInJSonFile(ApplicationParameters reconcialedApplicationParameters, IGrouping<string, Replacement> replacementsInFile, ref string fileContent)
+        {
+            bool updated = false;
+            JsonNode jsonNode = JsonNode.Parse(fileContent, new JsonNodeOptions() { }, new JsonDocumentOptions() { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip })!;
+            foreach (var replacement in replacementsInFile.Where(r => r.ReplaceBy != null))
+            {
+                string? newValue = ComputeReplacement(replacement.ReplaceBy, reconcialedApplicationParameters);
+                if (newValue == null)
+                {
+                    continue;
+                }
+
+                IEnumerable<string> pathToParent = replacement.Property.Split(":");
+                string propertyName = pathToParent.Last();
+                pathToParent = pathToParent.Take(pathToParent.Count() - 1);
+
+                JsonNode? parent = jsonNode;
+                foreach (string nodeName in pathToParent)
+                {
+                    if (parent != null)
+                    {
+                        parent = parent[nodeName];
+                    }
+                }
+
+                if (parent == null)
+                {
+                    continue;
+                }
+
+                JsonValue? propertyNode = parent[propertyName] as JsonValue;
+
+                if (propertyNode == null)
+                {
+                    parent.AsObject().Add(propertyName, newValue);
+                    updated = true;
+                }
+                else if (newValue == "*Remove*")
+                {
+                    JsonObject parentAsObject = parent.AsObject();
+                    parentAsObject.Remove(propertyName);
+                    updated = true;
+                }
+                else
+                {
+                    if (propertyNode.TryGetValue(out string? value))
+                    {
+                        if (value != newValue)
+                        {
+                            parent[propertyName] = newValue;
+                            updated = true;
+                        }
+                    }
+                }
+            }
+
+            fileContent = jsonNode.ToJsonString(new JsonSerializerOptions() { WriteIndented = true });
+            return updated;
+        }
+
         private string? ComputeReplacement(string replaceBy, ApplicationParameters reconciledApplicationParameters)
         {
             string? replacement = replaceBy;
-            switch(replaceBy)
+            switch (replaceBy)
             {
                 case "Application.ClientSecret":
                     string? password = reconciledApplicationParameters.PasswordCredentials.LastOrDefault();
@@ -89,7 +167,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     replacement = reconciledApplicationParameters.ClientId;
                     break;
                 case "Directory.TenantId":
-                    replacement = reconciledApplicationParameters.TenantId;
+                    replacement = reconciledApplicationParameters.IsCiam ? "*Remove*" : reconciledApplicationParameters.TenantId;
                     break;
                 case "Directory.Domain":
                     replacement = reconciledApplicationParameters.Domain;
@@ -115,7 +193,6 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     replacement = reconciledApplicationParameters.Authority;
                     // Blazor b2C
                     replacement = replacement?.Replace("onmicrosoft.com.b2clogin.com", "b2clogin.com");
-
                     break;
                 case "MsalAuthenticationOptions":
                     // Todo generalize with a directive: Ensure line after line, or ensure line
@@ -126,7 +203,7 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                         replacement +=
                             "\n                options.ProviderOptions.DefaultAccessTokenScopes.Add(\"User.Read\");";
 
-                    }                    
+                    }
                     break;
                 case "Application.CalledApiScopes":
                     replacement = reconciledApplicationParameters.CalledApiScopes
@@ -136,17 +213,25 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                     break;
 
                 case "Application.Instance":
-                    if (reconciledApplicationParameters.Instance == "https://login.microsoftonline.com/tfp/"
-                        && reconciledApplicationParameters.IsB2C
-                        && !string.IsNullOrEmpty(reconciledApplicationParameters.Domain)
-                        && reconciledApplicationParameters.Domain.EndsWith(".onmicrosoft.com"))
+                    if (reconciledApplicationParameters.IsCiam)
                     {
-                        replacement = "https://"+reconciledApplicationParameters.Domain.Replace(".onmicrosoft.com", ".b2clogin.com")
-                            .Replace("aadB2CInstance", reconciledApplicationParameters.Domain1);
+                        replacement = "*Remove*";
                     }
                     else
                     {
-                        replacement = reconciledApplicationParameters.Instance;
+
+                        if (reconciledApplicationParameters.Instance == "https://login.microsoftonline.com/tfp/"
+                        && reconciledApplicationParameters.IsB2C
+                        && !string.IsNullOrEmpty(reconciledApplicationParameters.Domain)
+                        && reconciledApplicationParameters.Domain.EndsWith(".onmicrosoft.com"))
+                        {
+                            replacement = "https://" + reconciledApplicationParameters.Domain.Replace(".onmicrosoft.com", ".b2clogin.com")
+                                .Replace("aadB2CInstance", reconciledApplicationParameters.Domain1);
+                        }
+                        else
+                        {
+                            replacement = reconciledApplicationParameters.Instance;
+                        }
                     }
                     break;
                 case "Application.ConfigurationSection":
@@ -155,6 +240,10 @@ namespace Microsoft.Identity.App.CodeReaderWriter
                 case "Application.AppIdUri":
                     replacement = reconciledApplicationParameters.AppIdUri;
                     break;
+                case "Application.ExtraQueryParameters":
+                    replacement = null;
+                    break;
+
 
                 default:
                     Console.WriteLine($"{replaceBy} not known");

--- a/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/DeveloperCredentials/MsalTokenCredential.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Identity.App.DeveloperCredentials
             }
             catch (MsalServiceException ex)
             {
-                if (ex.Message.Contains("AADSTS70002")) // "The client does not exist or is not enabled for consumers"
+                if (ex.Message.Contains("AADSTS70002", StringComparison.OrdinalIgnoreCase)) // "The client does not exist or is not enabled for consumers"
                 {
                     Console.WriteLine("An Azure AD tenant, and a user in that tenant, " +
                         "needs to be created for this account before an application can be created. See https://aka.ms/ms-identity-app/create-a-tenant. ");

--- a/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/MicrosoftIdentityPlatformApplicationManager.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/MicrosoftIdentityPlatformApplicationManager.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
                 }
                 else
                 {
-                    if (ex.Message.Contains("User was not found") || ex.Message.Contains("not found in tenant"))
+                    if (ex.Message.Contains("User was not found", StringComparison.OrdinalIgnoreCase) || ex.Message.Contains("not found in tenant", StringComparison.OrdinalIgnoreCase))
                     {
                         Console.WriteLine("User was not found.\nUse both --tenant-id <tenant> --username <username@tenant>.\nAnd re-run the tool.");
                     }
@@ -352,7 +352,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
             if (!string.IsNullOrEmpty(calledApiScopes))
             {
                 string[] scopes = calledApiScopes.Split(' ', '\t', StringSplitOptions.RemoveEmptyEntries);
-                scopesPerResource = scopes.Select(s => (!s.Contains('/'))
+                scopesPerResource = scopes.Select(s => (!s.Contains('/', StringComparison.OrdinalIgnoreCase))
                 // Microsoft Graph shortcut scopes (for instance "User.Read")
                 ? new ResourceAndScope("https://graph.microsoft.com", s)
                 // Proper AppIdUri/scope
@@ -421,11 +421,11 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
                 {
                     applicationParameters.CalledApiScopes = string.Empty;
                 }
-                if (!applicationParameters.CalledApiScopes.Contains("openid"))
+                if (!applicationParameters.CalledApiScopes.Contains("openid", StringComparison.OrdinalIgnoreCase))
                 {
                     applicationParameters.CalledApiScopes += " openid";
                 }
-                if (!applicationParameters.CalledApiScopes.Contains("offline_access"))
+                if (!applicationParameters.CalledApiScopes.Contains("offline_access", StringComparison.OrdinalIgnoreCase))
                 {
                     applicationParameters.CalledApiScopes += " offline_access";
                 }

--- a/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/MicrosoftIdentityPlatformApplicationManager.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/MicrosoftIdentityPlatformApplicationManager.cs
@@ -578,7 +578,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
             Application application,
             ApplicationParameters originalApplicationParameters)
         {
-            bool isB2C = (tenant.TenantType == "AAD B2C");
+            bool isB2C = (tenant.TenantType == "AAD B2C") && !originalApplicationParameters.IsCiam;
             var effectiveApplicationParameters = new ApplicationParameters
             {
                 ApplicationDisplayName = application.DisplayName,
@@ -586,6 +586,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
                 EffectiveClientId = application.AppId,
                 IsAAD = !isB2C,
                 IsB2C = isB2C,
+                IsCiam = originalApplicationParameters.IsCiam,
                 HasAuthentication = true,
                 IsWebApi = application.Api != null
                         && (application.Api.Oauth2PermissionScopes != null && application.Api.Oauth2PermissionScopes.Any())
@@ -617,9 +618,11 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
             // TODO: introduce the Instance?
             effectiveApplicationParameters.Authority = isB2C
                  ? $"https://{effectiveApplicationParameters.Domain1}.b2clogin.com/{effectiveApplicationParameters.Domain}/{effectiveApplicationParameters.SusiPolicy}/"
+                 : originalApplicationParameters.IsCiam ? $"https://{effectiveApplicationParameters.Domain1}.ciamlogin.com/"
                  : $"https://login.microsoftonline.com/{effectiveApplicationParameters.TenantId ?? effectiveApplicationParameters.Domain}/";
             effectiveApplicationParameters.Instance = isB2C
                 ? $"https://{effectiveApplicationParameters.Domain1}.b2clogin.com/"
+                : originalApplicationParameters.IsCiam ? $"https://{effectiveApplicationParameters.Domain1}.ciamlogin.com/"
                 : originalApplicationParameters.Instance;
 
             effectiveApplicationParameters.PasswordCredentials.AddRange(application.PasswordCredentials.Select(p => p.Hint + "******************"));

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/ConfigurationProperties.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/ConfigurationProperties.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -11,7 +12,7 @@ namespace Microsoft.Identity.App.Project
     {
         public string? FileRelativePath 
         {
-            get { return _fileRelativePath?.Replace("\\", Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture)); }
+            get { return _fileRelativePath?.Replace("\\", Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase); }
             set { _fileRelativePath = value; } 
         }
         private string? _fileRelativePath;

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/MatchesForProjectType.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/MatchesForProjectType.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -11,7 +12,7 @@ namespace Microsoft.Identity.App.Project
     {
         public string? FileRelativePath
         {
-            get { return _fileRelativePath?.Replace("\\", Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture)); }
+            get { return _fileRelativePath?.Replace("\\", Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase); }
             set { _fileRelativePath = value; }
         }
         private string? _fileRelativePath;

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/ProjectDescriptionReader.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/ProjectDescriptionReader.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.App.Project
                                     string fileContent = File.ReadAllText(filePath);
                                     foreach (string match in matchesForProjectType.MatchAny!) // Valid project => 
                                     {
-                                        if (fileContent.Contains(match))
+                                        if (fileContent.Contains(match, StringComparison.OrdinalIgnoreCase))
                                         {
                                             return projectDescription.Identifier!;
                                         }

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/Replacement.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescription/Replacement.cs
@@ -10,25 +10,28 @@ namespace Microsoft.Identity.App.Project
             FilePath = string.Empty;
             ReplaceFrom = string.Empty;
             ReplaceBy = string.Empty;
+            Property = string.Empty;
         }
 
-        public Replacement(string filePath, int index, int length, string replaceFrom, string replaceBy)
+        public Replacement(string filePath, int index, int length, string replaceFrom, string replaceBy, string property)
         {
             FilePath = filePath;
             Index = index;
             Length = length;
             ReplaceFrom = replaceFrom;
             ReplaceBy = replaceBy;
+            Property = property;
         }
         public string FilePath { get; set; }
         public int Index { get; set; }
         public int Length { get; set; }
         public string ReplaceFrom { get; set; }
         public string ReplaceBy { get; set; }
+        public string Property { get; set; }
 
         public override string ToString()
         {
-            return $"Replace '{ReplaceFrom}' by '{ReplaceBy}'";
+            return $"Replace '{Property}' from '{ReplaceFrom}' by '{ReplaceBy}'";
         }
     }
 }

--- a/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescriptions/dotnet-web.json
+++ b/tools/app-provisioning-tool/app-provisioning-lib/ProjectDescriptions/dotnet-web.json
@@ -13,6 +13,17 @@
                 "Default": "11111111-1111-1111-11111111111111111"
             },
             {
+                "Property": "AzureAd:Instance",
+                "Represents": "Application.Instance",
+                "Sets": "IsAAD",
+                "Default": "https://login.microsoftonline.com/"
+            },
+            {
+                "Property": "AzureAd:Authority",
+                "Represents": "Application.Authority",
+                "Sets": "IsCiam"
+            },
+            {
                 "Property": "AzureAd:Domain",
                 "Represents": "Directory.Domain",
                 "Sets": "IsAAD",

--- a/tools/app-provisioning-tool/app-provisioning-lib/Properties/Resources.Designer.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.App.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/tools/app-provisioning-tool/app-provisioning-lib/Tool/AppProvisioningTool.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/Tool/AppProvisioningTool.cs
@@ -151,10 +151,7 @@ namespace Microsoft.Identity.App
             ProcessStartInfo processStartInfo = new ProcessStartInfo("dotnet", $"add package {package}")
             {
                 UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
             };
-            processStartInfo.UseShellExecute = false;
             Process? process = Process.Start(processStartInfo);
             process?.WaitForExit();
         }

--- a/tools/app-provisioning-tool/app-provisioning-lib/Tool/AppProvisioningTool.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/Tool/AppProvisioningTool.cs
@@ -154,13 +154,13 @@ namespace Microsoft.Identity.App
             foreach (string filePath in filesWithReplacementsForB2C)
             {
                 string fileContent = File.ReadAllText(filePath);
-                string updatedContent = fileContent.Replace("AzureAd", "AzureAdB2C");
+                string updatedContent = fileContent.Replace("AzureAd", "AzureAdB2C", StringComparison.OrdinalIgnoreCase);
 
                 // Add the policies to the appsettings.json
-                if (filePath.EndsWith("appsettings.json"))
+                if (filePath.EndsWith("appsettings.json", StringComparison.OrdinalIgnoreCase))
                 {
                     // Insert the policies
-                    int indexCallbackPath = updatedContent.IndexOf("\"CallbackPath\"");
+                    int indexCallbackPath = updatedContent.IndexOf("\"CallbackPath\"", StringComparison.OrdinalIgnoreCase);
                     if (indexCallbackPath > 0)
                     {
                         updatedContent = updatedContent.Substring(0, indexCallbackPath)

--- a/tools/app-provisioning-tool/app-provisioning-lib/Tool/AppProvisioningTool.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/Tool/AppProvisioningTool.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Core;
+using Microsoft.Graph;
 using Microsoft.Identity.App.AuthenticationParameters;
 using Microsoft.Identity.App.CodeReaderWriter;
 using Microsoft.Identity.App.DeveloperCredentials;
@@ -9,10 +10,12 @@ using Microsoft.Identity.App.MicrosoftIdentityPlatformApplication;
 using Microsoft.Identity.App.Project;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using File = System.IO.File;
+using Process = System.Diagnostics.Process;
 
 namespace Microsoft.Identity.App
 {
@@ -135,7 +138,25 @@ namespace Microsoft.Identity.App
 
             // Summarizes what happened
             WriteSummary(summary);
+
+            Console.WriteLine("Updating NuGet packages\n");
+            EnsurePackage("Microsoft.Identity.Web");
+            EnsurePackage("Microsoft.Identity.Web.UI");
+
             return effectiveApplicationParameters;
+        }
+
+        private static void EnsurePackage(string package)
+        {
+            ProcessStartInfo processStartInfo = new ProcessStartInfo("dotnet", $"add package {package}")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            processStartInfo.UseShellExecute = false;
+            Process? process = Process.Start(processStartInfo);
+            process?.WaitForExit();
         }
 
         /// <summary>

--- a/tools/app-provisioning-tool/app-provisioning-lib/app-provisioning-lib.csproj
+++ b/tools/app-provisioning-tool/app-provisioning-lib/app-provisioning-lib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Identity.App</RootNamespace>
     <OutputType>Library</OutputType>
@@ -16,14 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Graph" Version="3.25.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.0" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Azure.Identity" Version="1.8.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Graph" Version="4.54.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.29.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,6 +42,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/tools/app-provisioning-tool/app-provisioning-tool/Program.cs
+++ b/tools/app-provisioning-tool/app-provisioning-tool/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.App
@@ -86,7 +87,7 @@ namespace Microsoft.Identity.App
             {
                 foreach (string projectFolder in System.IO.Directory.GetDirectories(subFolder))
                 {
-                    System.Console.WriteLine($"[InlineData(@\"{System.IO.Path.GetFileName(subFolder)}\\{System.IO.Path.GetFileName(projectFolder)}\", {projectFolder.Contains("b2c")}, \"dotnet-WebApp\")]");
+                    System.Console.WriteLine($"[InlineData(@\"{System.IO.Path.GetFileName(subFolder)}\\{System.IO.Path.GetFileName(projectFolder)}\", {projectFolder.Contains("b2c", StringComparison.OrdinalIgnoreCase)}, \"dotnet-WebApp\")]");
                 }
             }
         }

--- a/tools/app-provisioning-tool/app-provisioning-tool/msidentity-app-sync.csproj
+++ b/tools/app-provisioning-tool/app-provisioning-tool/msidentity-app-sync.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Version>1.0.1</Version>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <Version>1.1.0</Version>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Identity.App</RootNamespace>
 

--- a/tools/app-provisioning-tool/app-provisioning-tool/msidentity-app-sync.csproj
+++ b/tools/app-provisioning-tool/app-provisioning-tool/msidentity-app-sync.csproj
@@ -12,8 +12,6 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../../build/MSAL.snk</AssemblyOriginatorKeyFile>
-
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <!-- Copyright needs to be in the form of © not (c) to be compliant -->
     <Title>Microsoft identity platform auto-sync app registration tool</Title>
     <Authors>Microsoft</Authors>
@@ -27,20 +25,12 @@
       For details see https://aka.ms/ms-identity-app-registration.
     </Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/AzureAD/microsoft-identity-web/blob/master/tools/app-provisioning-tool/README.md</PackageProjectUrl>
     <RepositoryUrl>https://github.com/AzureAD/microsoft-identity-web</RepositoryUrl>
     <PackageReleaseNotes>The release notes are available at https://github.com/AzureAD/microsoft-identity-web/releases and the roadmap at https://github.com/AzureAD/microsoft-identity-web/wiki#roadmap </PackageReleaseNotes>
     <PackageTags>Microsoft Identity Web;Microsoft identity platform;Microsoft.Identity.Web;.NET;ASP.NET Core;Web App;Web API;B2C;Azure Active Directory;AAD;Identity;Authentication;Authorization;Application registration;app registration</PackageTags>
 
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="nupkg\**" />
@@ -52,6 +42,11 @@
     <None Remove="nupkg\**" />
     <None Remove="ProjectDescriptions\**" />
     <None Remove="TestResults\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="..\..\LICENSE" />
+    <None Include="..\..\..\LICENSE" Link="LICENSE" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/app-provisioning-tool/app-provisioning-tool/msidentity-app-sync.csproj
+++ b/tools/app-provisioning-tool/app-provisioning-tool/msidentity-app-sync.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <None Remove="..\..\LICENSE" />
-    <None Include="..\..\..\LICENSE" Link="LICENSE" />
+    <None Include="..\..\..\..\LICENSE" Link="LICENSE" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/app-provisioning-tool/tests/ProjectDescriptionReaderTests.cs
+++ b/tools/app-provisioning-tool/tests/ProjectDescriptionReaderTests.cs
@@ -51,15 +51,15 @@ namespace Tests
             var projectDescription = _projectDescriptionReader.GetProjectDescription(string.Empty, createdProjectFolder);
 
             Assert.NotNull(projectDescription);
-            Assert.Equal(expectedProjectType, projectDescription.Identifier);
+            Assert.Equal(expectedProjectType, projectDescription!.Identifier);
 
             var authenticationSettings = _codeReader.ReadFromFiles(
                 createdProjectFolder,
                 projectDescription,
                 _projectDescriptionReader.projectDescriptions);
 
-            bool callsGraph = folderPath.Contains(TestConstants.CallsGraph);
-            bool callsWebApi = folderPath.Contains(TestConstants.CallsWebApi) || callsGraph;
+            bool callsGraph = folderPath.Contains(TestConstants.CallsGraph, StringComparison.OrdinalIgnoreCase);
+            bool callsWebApi = folderPath.Contains(TestConstants.CallsWebApi, StringComparison.OrdinalIgnoreCase) || callsGraph;
 
             if (isB2C)
             {
@@ -95,7 +95,7 @@ namespace Tests
             var projectDescription = _projectDescriptionReader.GetProjectDescription(string.Empty, createdProjectFolder);
 
             Assert.NotNull(projectDescription);
-            Assert.Equal(expectedProjectType, projectDescription.Identifier);
+            Assert.Equal(expectedProjectType, projectDescription!.Identifier);
 
             var authenticationSettings = _codeReader.ReadFromFiles(
                 createdProjectFolder,
@@ -130,7 +130,7 @@ namespace Tests
             var projectDescription = _projectDescriptionReader.GetProjectDescription(string.Empty, createdProjectFolder);
 
             Assert.NotNull(projectDescription);
-            Assert.Equal(expectedProjectType, projectDescription.Identifier);
+            Assert.Equal(expectedProjectType, projectDescription!.Identifier);
 
             var authenticationSettings = _codeReader.ReadFromFiles(
                 createdProjectFolder,
@@ -155,7 +155,7 @@ namespace Tests
 
             var projectDescription = _projectDescriptionReader.GetProjectDescription(string.Empty, createdProjectFolder);
             Assert.NotNull(projectDescription);
-            Assert.Equal(expectedProjectType, projectDescription.Identifier);
+            Assert.Equal(expectedProjectType, projectDescription!.Identifier);
 
             var authenticationSettings = _codeReader.ReadFromFiles(
                 createdProjectFolder,
@@ -217,7 +217,7 @@ namespace Tests
             string parentFolder = Path.Combine(tempFolder, "Provisioning", testName);
             string createdProjectFolder = Path.Combine(
                 parentFolder, 
-                projectFolderName.Replace("\\", Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture)));
+                projectFolderName.Replace("\\", Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase));
 
             if (!Directory.Exists(createdProjectFolder))
             {
@@ -226,7 +226,7 @@ namespace Tests
                 TestUtilities.RunProcess(_testOutput, command, createdProjectFolder, " --force");
 
                 // Add the capability of holding user secrets aside of appsettings.json if needed
-                if (command.Contains("--calls"))
+                if (command.Contains("--calls", StringComparison.OrdinalIgnoreCase))
                 {
                     try
                     {

--- a/tools/app-provisioning-tool/tests/TestUtilities.cs
+++ b/tools/app-provisioning-tool/tests/TestUtilities.cs
@@ -21,19 +21,22 @@ namespace Tests
         public static void RunProcess(ITestOutputHelper testOutput, string command, string folder, string postFix = "")
         {
             Directory.CreateDirectory(folder);
-            ProcessStartInfo processStartInfo = new ProcessStartInfo("dotnet", command.Replace("dotnet ", string.Empty) + postFix);
+            ProcessStartInfo processStartInfo = new ProcessStartInfo("dotnet", command.Replace("dotnet ", string.Empty, StringComparison.OrdinalIgnoreCase) + postFix);
             processStartInfo.UseShellExecute = false;
             processStartInfo.RedirectStandardOutput = true;
             processStartInfo.RedirectStandardError = true;
             Environment.GetEnvironmentVariables();
             processStartInfo.WorkingDirectory = folder;
-            Process process = Process.Start(processStartInfo);
-            process.WaitForExit();
-            string output = process.StandardOutput.ReadToEnd();
-            testOutput.WriteLine(output);
-            string errors = process.StandardError.ReadToEnd();
-            testOutput.WriteLine(errors);
-            Assert.Equal(string.Empty, errors);
+            Process? process = Process.Start(processStartInfo);
+            if (process != null)
+            {
+                process.WaitForExit();
+                string output = process.StandardOutput.ReadToEnd();
+                testOutput.WriteLine(output);
+                string errors = process.StandardError.ReadToEnd();
+                testOutput.WriteLine(errors);
+                Assert.Equal(string.Empty, errors);
+            }
         }
     }
 }

--- a/tools/app-provisioning-tool/tests/Tests.csproj
+++ b/tools/app-provisioning-tool/tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tools/app-provisioning-tool/tests/Tests.csproj
+++ b/tools/app-provisioning-tool/tests/Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
+
+    <GenerateDocumentationFile>False</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update to .NET 7, and latest NuGet packages
- Add support for CIAM
- The json files can now be entirely modified (adding and removing nodes)

```sh
dotnet new web app --auth SingleOrg
dotnet add package Microsoft.Identity.Web
dotnet add package Microsoft.Identity.Web.UI
msidentity-app-sync --tenant-id mytenant.ciamlogin.com
```

For the moment, until the Graph API tenant-type returns the right value, the tenant-id needs to contain ciamlogin.com.