### PR TITLE
fix: rename SimulateGetttingHeaderFromDebugEnvironmentVariable to SimulateGettingHeaderFromDebugEnvironmentVariable

### DIFF
--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Get headers from environment to help debugging App Services authentication.
         /// </summary>
-        internal static string? SimulateGetttingHeaderFromDebugEnvironmentVariable(string header)
+        internal static string? SimulateGettingHeaderFromDebugEnvironmentVariable(string header)
         {
             string? headerPlusValue = Environment.GetEnvironmentVariable(AppServicesAuthDebugHeadersEnvironmentVariable)
                 ?.Split(';')
@@ -145,7 +145,7 @@ namespace Microsoft.Identity.Web
 #if DEBUG
             if (string.IsNullOrEmpty(idToken))
             {
-                idToken = SimulateGetttingHeaderFromDebugEnvironmentVariable(AppServicesAuthIdTokenHeader);
+                idToken = SimulateGettingHeaderFromDebugEnvironmentVariable(AppServicesAuthIdTokenHeader);
             }
 #endif
             return idToken;
@@ -164,7 +164,7 @@ namespace Microsoft.Identity.Web
 #if DEBUG
             if (string.IsNullOrEmpty(idp))
             {
-                idp = SimulateGetttingHeaderFromDebugEnvironmentVariable(AppServicesAuthIdpTokenHeader);
+                idp = SimulateGettingHeaderFromDebugEnvironmentVariable(AppServicesAuthIdpTokenHeader);
             }
 #endif
             return idp;

--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Identity.Web
 #if DEBUG
             if (string.IsNullOrEmpty(accessToken))
             {
-                accessToken = AppServicesAuthenticationInformation.SimulateGetttingHeaderFromDebugEnvironmentVariable(AppServicesAuthAccessTokenHeader);
+                accessToken = AppServicesAuthenticationInformation.SimulateGettingHeaderFromDebugEnvironmentVariable(AppServicesAuthAccessTokenHeader);
             }
 #endif
             if (!string.IsNullOrEmpty(accessToken))

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -87,7 +87,7 @@
             Issuer of the App Services Auth web site.
             </summary>
         </member>
-        <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationInformation.SimulateGetttingHeaderFromDebugEnvironmentVariable(System.String)">
+        <member name="M:Microsoft.Identity.Web.AppServicesAuthenticationInformation.SimulateGettingHeaderFromDebugEnvironmentVariable(System.String)">
             <summary>
             Get headers from environment to help debugging App Services authentication.
             </summary>

--- a/tests/Microsoft.Identity.Web.Test/AppServicesAuthenticationInformationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AppServicesAuthenticationInformationTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Web.Test
     public class AppServicesAuthenticationInformationTests
     {
         [Fact]
-        public void SimulateGetttingHeaderFromDebugEnvironmentVariable()
+        public void SimulateGettingHeaderFromDebugEnvironmentVariable()
         {
             try
             {


### PR DESCRIPTION
# fix: rename SimulateGetttingHeaderFromDebugEnvironmentVariable to SimulateGettingHeaderFromDebugEnvironmentVariable
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This PR corrects a typo in a method name from `SimulateGetttingHeaderFromDebugEnvironmentVariable` to `SimulateGettingHeaderFromDebugEnvironmentVariable`

## Description

There isn't more detail than that really - it's just fixing a typo; nothing more and nothing less.
