### PR TITLE
Test fix for AccountID being in x.y format

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/AccountExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AccountExtensionsTests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Identity.Web.Test
 
             IAccount account = Substitute.For<IAccount>();
             account.Username.Returns(username);
-            account.HomeAccountId.Returns(new AccountId("identifier", oid, tid));
+            // AccountId is in the x.y format, MSAL has some DEBUG only checks on that format
+            account.HomeAccountId.Returns(new AccountId($"{oid}.{tid}", oid, tid)); 
 
             var claimsIdentityResult = account.ToClaimsPrincipal().Identity as ClaimsIdentity;
 


### PR DESCRIPTION
The ID.Web test in question fails when presented with a DEBUG version of MSAL because it uses an incorrect id.