### PR TITLE
Fix L2 logging. Fix L2 empty read.

### DIFF
--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -267,7 +267,8 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                                 // the parent class 
                         distributedCacheEntryOptions,
                         cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
-                    cacheKey).Measure().ConfigureAwait(false);
+                    cacheKey,
+                    bytes!).Measure().ConfigureAwait(false);
             }
             else
             {
@@ -279,7 +280,8 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                      bytes!,
                      distributedCacheEntryOptions,
                      cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
-                 cacheKey).Measure().ConfigureAwait(false));
+                 cacheKey,
+                 bytes!).Measure().ConfigureAwait(false));
             }
         }
 

--- a/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.DataProtection;
@@ -109,10 +108,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
             if (!string.IsNullOrEmpty(GetSuggestedCacheKey(args)))
             {
                 byte[]? tokenCacheBytes = await ReadCacheBytesAsync(GetSuggestedCacheKey(args), CreateHintsFromArgs(args)).ConfigureAwait(false);
-                if (tokenCacheBytes == null)
-                {
-                    return;
-                }
 
                 try
                 {
@@ -139,7 +134,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
             }
         }
 
-        private byte[] UnprotectBytes(byte[]? msalBytes)
+        private byte[]? UnprotectBytes(byte[]? msalBytes)
         {
             if (msalBytes != null && _protector != null)
             {
@@ -154,7 +149,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
                 }
             }
 
-            return msalBytes!;
+            return msalBytes;
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
@@ -111,6 +111,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
 
                 try
                 {
+                    // Must call Deserialize, even if the L2 read operation returned nothing.
+                    // Deserialize with null value will ensure that the cache in MSAL is properly initialized.
+                    // This will also ensure that the cache in MSAL is cleared if the cache entry in L2 was empty.
                     args.TokenCache.DeserializeMsalV3(UnprotectBytes(tokenCacheBytes), shouldClearExistingCache: true);
                 }
                 catch (MsalClientException exception)
@@ -134,6 +137,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
             }
         }
 
+        // Tries to unprotect the bytes if protection is enabled and the cache is encrypted.
+        // If the cache is unencrypted, returns the same bytes.
+        // Returns null, if the bytes are null.
         private byte[]? UnprotectBytes(byte[]? msalBytes)
         {
             if (msalBytes != null && _protector != null)

--- a/tests/Microsoft.Identity.Web.Test/CacheExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CacheExtensionsTests.cs
@@ -124,6 +124,11 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public async Task SingletonMsal_ResultsInCorrectCacheEntries_Test()
         {
+            var tenantId1 = "tenant1";
+            var tenantId2 = "tenant2";
+            var cacheKey1 = $"{TestConstants.ClientId}_{tenantId1}_AppTokenCache";
+            var cacheKey2 = $"{TestConstants.ClientId}_{tenantId2}_AppTokenCache";
+
             using MockHttpClientFactory mockHttpClient = new MockHttpClientFactory();
             using (mockHttpClient.AddMockHandler(MockHttpCreator.CreateClientCredentialTokenHandler()))
             using (mockHttpClient.AddMockHandler(MockHttpCreator.CreateClientCredentialTokenHandler()))
@@ -144,16 +149,16 @@ namespace Microsoft.Identity.Web.Test
 
                 // Different tenants used to created different cache entries
                 var result1 = await confidentialApp.AcquireTokenForClient(new[] { TestConstants.s_scopeForApp })
-                    .WithTenantId("tenant1")
+                    .WithTenantId(tenantId1)
                     .ExecuteAsync().ConfigureAwait(false);
                 var result2 = await confidentialApp.AcquireTokenForClient(new[] { TestConstants.s_scopeForApp })
-                    .WithTenantId("tenant2")
+                    .WithTenantId(tenantId2)
                     .ExecuteAsync().ConfigureAwait(false);
 
                 Assert.Equal(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource);
                 Assert.Equal(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource);
                 Assert.Equal(2, distributedCache._dict.Count);
-                Assert.Equal(distributedCache.Get($"{TestConstants.ClientId}_tenant1_AppTokenCache")!.Length, distributedCache.Get($"{TestConstants.ClientId}_tenant2_AppTokenCache")!.Length);
+                Assert.Equal(distributedCache.Get(cacheKey1)!.Length, distributedCache.Get(cacheKey2)!.Length);
             }
         }
 

--- a/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
+++ b/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Certificates\DefaultCertificateLoaderTests.cs" />
     <Compile Include="CacheExtensionsTests.cs" />
     <Compile Include="CacheEncryptionTests.cs" />
+    <Compile Include="TestDistributedCache.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

- Updates `MsalAbstractTokenCacheProvider.OnBeforeAccessAsync` to call Msal.Deseralize even if the read operation returned nothing.
- Fixes distributed cache logger to print correct cache entry size.

Fixes #2348, fixes #2349
