### PR TITLE
Lozensky/fix perf issue CallDownstreamApi

### DIFF
--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Web
         {
             _ = Throws.IfNull(configurationSection);
             _ = Throws.IfNull(builder);
-
+            
             AddMicrosoftIdentityWebApiImplementation(
                 builder,
                 options => configurationSection.Bind(options),
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Web
 
             return new MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration(
                 builder.Services,
-                jwtBearerScheme,
+                jwtBearerScheme,// first sends here
                 options => configurationSection.Bind(options),
                 options => configurationSection.Bind(options),
                 configurationSection);
@@ -142,7 +142,6 @@ namespace Microsoft.Identity.Web
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents)
         {
             builder.AddJwtBearer(jwtBearerScheme, configureJwtBearerOptions);
-            builder.Services.Configure(jwtBearerScheme, configureMicrosoftIdentityOptions);
             builder.Services.AddSingleton<IMergedOptionsStore, MergedOptionsStore>();
 
             builder.Services.AddHttpContextAccessor();
@@ -166,7 +165,7 @@ namespace Microsoft.Identity.Web
 
             // Change the authentication configuration to accommodate the Microsoft identity platform endpoint (v2.0).
             builder.Services.AddOptions<JwtBearerOptions>(jwtBearerScheme)
-                .Configure<IServiceProvider, IMergedOptionsStore, IOptionsMonitor<MicrosoftIdentityOptions>>((
+                .Configure<IServiceProvider, IMergedOptionsStore, IOptionsMonitor<MicrosoftIdentityOptions>>(( //here
                 options,
                 serviceProvider,
                 mergedOptionsMonitor,

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -83,7 +83,6 @@ namespace Microsoft.Identity.Web
             AddMicrosoftIdentityWebApiImplementation(
                 builder,
                 options => configurationSection.Bind(options),
-                options => configurationSection.Bind(options),
                 jwtBearerScheme,
                 subscribeToJwtBearerMiddlewareDiagnosticsEvents);
 
@@ -122,7 +121,6 @@ namespace Microsoft.Identity.Web
             AddMicrosoftIdentityWebApiImplementation(
                 builder,
                 configureJwtBearerOptions,
-                configureMicrosoftIdentityOptions,
                 jwtBearerScheme,
                 subscribeToJwtBearerMiddlewareDiagnosticsEvents);
 
@@ -137,7 +135,6 @@ namespace Microsoft.Identity.Web
         private static void AddMicrosoftIdentityWebApiImplementation(
             AuthenticationBuilder builder,
             Action<JwtBearerOptions> configureJwtBearerOptions,
-            Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions,
             string jwtBearerScheme,
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents)
         {

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Web
 
             return new MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration(
                 builder.Services,
-                jwtBearerScheme,// first sends here
+                jwtBearerScheme,
                 options => configurationSection.Bind(options),
                 options => configurationSection.Bind(options),
                 configurationSection);
@@ -165,7 +165,7 @@ namespace Microsoft.Identity.Web
 
             // Change the authentication configuration to accommodate the Microsoft identity platform endpoint (v2.0).
             builder.Services.AddOptions<JwtBearerOptions>(jwtBearerScheme)
-                .Configure<IServiceProvider, IMergedOptionsStore, IOptionsMonitor<MicrosoftIdentityOptions>>(( //here
+                .Configure<IServiceProvider, IMergedOptionsStore, IOptionsMonitor<MicrosoftIdentityOptions>>((
                 options,
                 serviceProvider,
                 mergedOptionsMonitor,


### PR DESCRIPTION
# fix perf issue CallDownstreamApi

Summary of the changes (Less than 80 chars)

The Services.Configure line deleted also occurs in [WebApiAuthenticationBuilder](https://github.com/AzureAD/microsoft-identity-web/blob/48e4a5e9af22439ac9e633707860073bd5d4c91e/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilder.cs#L45C1-L45C98)

## Description
The line deleted in MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs calls builder.Services.Configure which is also happening in the builder constructor itself (MicrosoftIdentityWebApiAuthenticationBuilder) with the same arguments which duplicated the configuration every time a builder was run using the CallDownstreamApi.

Testing:
- Unit tests all pass
- Succeeded running the DaemonConsoleCallingDownstreamApi sample against the MinimalWebApi sample.

Fixes #{bug number} (in this specific format)
#2083
#2355 