### PR TITLE
Fix for #2371

### DIFF
--- a/src/Microsoft.Identity.Web.OWIN/OwinTokenAcquisitionHost.cs
+++ b/src/Microsoft.Identity.Web.OWIN/OwinTokenAcquisitionHost.cs
@@ -8,7 +8,6 @@ using System.Web;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
-using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Identity.Web.Hosts
@@ -68,14 +67,7 @@ namespace Microsoft.Identity.Web.Hosts
 
         public SecurityToken? GetTokenUsedToCallWebAPI()
         {
-            object? o = (HttpContext.Current.User.Identity as ClaimsIdentity)?.BootstrapContext;
-
-            if (o != null)
-            {
-                // TODO: do better as this won't do for JWE and wastes time. The token was already decrypted.
-                return new JsonWebToken(o as string);
-            }
-            return null;
+            return HttpContext.Current.User.GetBootstrapToken();
         }
 
         public ClaimsPrincipal? GetUserFromRequest()

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisitionAspnetCoreHost.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisitionAspnetCoreHost.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PrincipalExtensionsForSecurityTokens.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PrincipalExtensionsForSecurityTokens.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Web
             {
                 return new JsonWebToken(s);
             }
-            return null;
+            return (o != null) ? new JsonWebToken(o.ToString()) : null;
         }
     }
 }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PrincipalExtensionsForSecurityTokens.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PrincipalExtensionsForSecurityTokens.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using System.Security.Principal;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Extensions to retrive a <see cref="SecurityToken"/> from <see cref="ClaimsPrincipal"/>.
+    /// </summary>
+    public static class PrincipalExtensionsForSecurityTokens
+    {
+        /// <summary>
+        /// Get the <see cref="SecurityToken"/> used to call a protected web API.
+        /// </summary>
+        /// <param name="claimsPrincipal"></param>
+        /// <returns></returns>
+        public static SecurityToken? GetBootstrapToken(this IPrincipal claimsPrincipal)
+        {
+            object? o = (claimsPrincipal?.Identity as ClaimsIdentity)?.BootstrapContext;
+            if (o is SecurityToken securityToken)
+            {
+                return securityToken;
+            }
+            if (o is string s)
+            {
+                return new JsonWebToken(s);
+            }
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Web
             // Token acquisition service
             if (isTokenAcquisitionSingleton)
             {
-#if !NETSTANDARD2_0 && !NET462 && !NET472
+#if NETCOREAPP3_1_OR_GREATER
                 // ASP.NET Core
                 services.AddHttpContextAccessor();
                 if (forceSdk)
@@ -114,7 +114,7 @@ namespace Microsoft.Identity.Web
             }
             else
             {
-#if !NETSTANDARD2_0 && !NET462 && !NET472
+#if NETCOREAPP3_1_OR_GREATER
                 // ASP.NET Core
                 services.AddHttpContextAccessor();
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -9,11 +9,9 @@ using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
@@ -245,7 +243,8 @@ namespace Microsoft.Identity.Web
                     tenantId,
                     scopes,
                     tokenAcquisitionOptions,
-                    mergedOptions).ConfigureAwait(false);
+                    mergedOptions,
+                    user).ConfigureAwait(false);
 
                 if (authenticationResult != null)
                 {
@@ -658,12 +657,13 @@ namespace Microsoft.Identity.Web
            string? tenantId,
            IEnumerable<string> scopes,
            TokenAcquisitionOptions? tokenAcquisitionOptions,
-           MergedOptions mergedOptions)
+           MergedOptions mergedOptions,
+           ClaimsPrincipal? userHint)
         {
             try
             {
                 // In web API, validatedToken will not be null
-                SecurityToken? validatedToken = _tokenAcquisitionHost.GetTokenUsedToCallWebAPI();
+                SecurityToken? validatedToken = userHint?.GetBootstrapToken() ?? _tokenAcquisitionHost.GetTokenUsedToCallWebAPI();
 
                 // In the case the token is a JWE (encrypted token), we use the decrypted token.
                 string? tokenUsedToCallTheWebApi = GetActualToken(validatedToken);
@@ -889,7 +889,7 @@ namespace Microsoft.Identity.Web
 
                 if (dict != null)
                 {
-                        builder.WithExtraQueryParameters(dict);
+                    builder.WithExtraQueryParameters(dict);
                 }
                 if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
                 {
@@ -937,16 +937,16 @@ namespace Microsoft.Identity.Web
             {
                 var mergedDict = new Dictionary<string, string>(tokenAcquisitionOptions.ExtraQueryParameters);
                 if (mergedOptions.ExtraQueryParameters != null)
-                {                    
+                {
                     foreach (var pair in mergedOptions!.ExtraQueryParameters)
                     {
                         if (!mergedDict!.ContainsKey(pair.Key))
                             mergedDict.Add(pair.Key, pair.Value);
-                    }                   
+                    }
                 }
                 return mergedDict;
             }
-            
+
             return (Dictionary<string, string>?)mergedOptions.ExtraQueryParameters;
         }
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Identity.Web
 
             MergedOptions mergedOptions = _tokenAcquisitionHost.GetOptions(authenticationScheme, out _);
 
-            user = await _tokenAcquisitionHost.GetAuthenticatedUserAsync(user).ConfigureAwait(false);
+            user ??= await _tokenAcquisitionHost.GetAuthenticatedUserAsync(user).ConfigureAwait(false);
 
             var application = GetOrBuildConfidentialClientApplication(mergedOptions);
 

--- a/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
@@ -98,7 +98,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.54.1.0" newVersion="4.54.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.55.0.0" newVersion="4.55.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
@@ -99,7 +99,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.54.1.0" newVersion="4.54.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.55.0.0" newVersion="4.55.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>

--- a/tests/DevApps/daemon-app/Daemon-app/Daemon-app.csproj
+++ b/tests/DevApps/daemon-app/Daemon-app/Daemon-app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <RootNamespace>Daemon_app</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/DevApps/daemon-app/Daemon-app/Program.cs
+++ b/tests/DevApps/daemon-app/Daemon-app/Program.cs
@@ -38,7 +38,14 @@ namespace daemon_console
             var users = await graphServiceClient.Users
                 // Change the protocol if you wish .WithAuthenticationOptions(options => options.ProtocolScheme = "Bearer")
                 .GetAsync(r => r.Options.WithAppOnly());
-            Console.WriteLine($"{users.Value.Count} users");
+            if (users != null && users.Value!=null)
+            {
+                Console.WriteLine($"{users.Value.Count} users");
+            }
+            else
+            {
+                Console.WriteLine("No user");
+            }
 #else
             // Call downstream web API
             var downstreamApi = serviceProvider.GetRequiredService<IDownstreamApi>();

--- a/tests/DevApps/daemon-app/daemon-console-calling-msgraph/Properties/launchSettings.json
+++ b/tests/DevApps/daemon-app/daemon-console-calling-msgraph/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "WSL": {
+      "commandName": "WSL2",
+      "distributionName": ""
+    }
+  }
+}

--- a/tests/IntegrationTests/GraphServiceClientTests/GraphServiceClientTests.cs
+++ b/tests/IntegrationTests/GraphServiceClientTests/GraphServiceClientTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Identity.Web.Test.Integration
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 #pragma warning disable CS0649 // Field 'GraphServiceClientTests._authorizationHeaderProvider' is never assigned to, and will always have its default value null
         readonly IAuthorizationHeaderProvider _authorizationHeaderProvider;
-        readonly GraphServiceClientOptions _defaultAuthenticationOptions;
 #pragma warning restore CS0649 // Field 'GraphServiceClientTests._authorizationHeaderProvider' is never assigned to, and will always have its default value null
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 

--- a/tests/IntegrationTests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/IntegrationTests/TokenAcquirerTests/TokenAcquirer.cs
@@ -33,6 +33,16 @@ namespace TokenAcquirerTests
             TokenAcquirerFactory.ResetDefaultInstance(); // Test only
         }
 
+        [Fact]
+        public void TokenAcquirerFactoryDoesNotUseAspNetCoreHost()
+        {
+            TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
+            var serviceProvider = tokenAcquirerFactory.Build();
+            var service = serviceProvider.GetService<ITokenAcquisitionHost>();
+            Assert.NotNull(service);
+            Assert.Equal("Microsoft.Identity.Web.Hosts.DefaultTokenAcquisitionHost", service.GetType().FullName);
+        }
+
         [IgnoreOnAzureDevopsFact]
         //[Theory]
         //[InlineData(false)]
@@ -42,7 +52,6 @@ namespace TokenAcquirerTests
             bool withClientCredentials = false; //add as param above
             TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
             IServiceCollection services = tokenAcquirerFactory.Services;
-
 
             services.Configure<MicrosoftIdentityOptions>(s_optionName, option =>
             {

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -24,6 +24,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Microsoft.Identity.Client.Platforms.Features.DesktopOs.Kerberos;
 using System.Threading;
+using Microsoft.AspNetCore.Builder;
 
 namespace Microsoft.Identity.Web.Test.Integration
 {
@@ -225,7 +226,8 @@ namespace Microsoft.Identity.Web.Test.Integration
         [Fact]
         public async Task GetAccessTokenForApp_WithAnonymousController_Async()
         {
-            var serviceCollection = new ServiceCollection();
+            // ASP.NET Core builder.
+            var serviceCollection = WebApplication.CreateBuilder().Services;
             var configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>
                 {
@@ -243,6 +245,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             var services = serviceCollection.BuildServiceProvider();
 
             var tokenAcquisition = services.GetRequiredService<ITokenAcquisition>();
+            var tokenAcquisitionHost = services.GetRequiredService<ITokenAcquisitionHost>();
 
             var token = await tokenAcquisition.GetAccessTokenForAppAsync("https://graph.microsoft.com/.default").ConfigureAwait(false);
 

--- a/tests/Microsoft.Identity.Web.Test/PrincipalExtensionsForSecurityTokensTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/PrincipalExtensionsForSecurityTokensTests.cs
@@ -1,5 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Principal;
@@ -13,10 +15,10 @@ namespace Microsoft.Identity.Web.Tests
         public void GetBootstrapToken_Returns_Null_When_ClaimsPrincipal_Is_Null()
         {
             // Arrange
-            IPrincipal claimsPrincipal = null;
+            IPrincipal? claimsPrincipal = null;
 
             // Act
-            var result = claimsPrincipal.GetBootstrapToken();
+            var result = claimsPrincipal?.GetBootstrapToken();
 
             // Assert
             Assert.Null(result);

--- a/tests/Microsoft.Identity.Web.Test/PrincipalExtensionsForSecurityTokensTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/PrincipalExtensionsForSecurityTokensTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Principal;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Tests
+{
+    public class PrincipalExtensionsForSecurityTokensTests
+    {
+        [Fact]
+        public void GetBootstrapToken_Returns_Null_When_ClaimsPrincipal_Is_Null()
+        {
+            // Arrange
+            IPrincipal claimsPrincipal = null;
+
+            // Act
+            var result = claimsPrincipal.GetBootstrapToken();
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetBootstrapToken_Returns_Null_When_BootstrapContext_Is_Null()
+        {
+            // Arrange
+            IPrincipal claimsPrincipal = new GenericPrincipal(new GenericIdentity(""), null);
+
+            // Act
+            var result = claimsPrincipal.GetBootstrapToken();
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetBootstrapToken_Returns_SecurityToken_When_BootstrapContext_Is_SecurityToken()
+        {
+            // Arrange
+            var securityToken = new JwtSecurityToken();
+            IPrincipal claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "TestUser") })
+            {
+                BootstrapContext = securityToken
+            });
+
+            // Act
+            var result = claimsPrincipal.GetBootstrapToken();
+
+            // Assert
+            Assert.Equal(securityToken, result);
+        }
+
+        [Fact]
+        public void GetBootstrapToken_Returns_JsonWebToken_When_BootstrapContext_Is_String()
+        {
+            // Arrange
+            const string jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+            IPrincipal claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "TestUser") })
+            {
+                BootstrapContext = jwtString
+            });
+
+            // Act
+            var result = claimsPrincipal.GetBootstrapToken() as JsonWebToken;
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(jwtString, result.EncodedToken);
+        }
+    }
+}


### PR DESCRIPTION


# Fix for #2371 

## Description

In .NET 5+, we now use the DefaultTokenAcquisitionHost (the host for SDK apps) instead of the Asp.NET core one, when the service collection was not initialized by ASP.NET Core (that is the `IWebHostEnvironment` is not present in the collection.

If developers want the ASP.NET Core host, they would need to use the WebApplication.CreateBuilder().Services instead of instanciating a simple service collection.

Fixes #2371
