### PR TITLE
Set EnableCacheSynchronization to false by default.

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Identity.Web
         public bool IsDefaultPlatformLoggingEnabled { get; set; }
         public LogLevel LogLevel { get; set; }
         public string? RedirectUri { get; set; }
-        public bool EnableCacheSynchronization { get; set; }
         internal bool MergedWithCca { get; set; }
 
         internal static void UpdateMergedOptionsFromMicrosoftIdentityOptions(MicrosoftIdentityOptions microsoftIdentityOptions, MergedOptions mergedOptions)
@@ -282,6 +281,8 @@ namespace Microsoft.Identity.Web
             }
 
             mergedOptions.LegacyCacheCompatibilityEnabled |= microsoftIdentityOptions.LegacyCacheCompatibilityEnabled;
+            
+            mergedOptions.EnableCacheSynchronization |= microsoftIdentityOptions.EnableCacheSynchronization;
 
             if (string.IsNullOrEmpty(mergedOptions.SignUpSignInPolicyId) && !string.IsNullOrEmpty(microsoftIdentityOptions.SignUpSignInPolicyId))
             {
@@ -343,8 +344,8 @@ namespace Microsoft.Identity.Web
             }
 
             mergedOptions.IsDefaultPlatformLoggingEnabled |= confidentialClientApplicationOptions.IsDefaultPlatformLoggingEnabled;
-            // mergedOptions.LegacyCacheCompatibilityEnabled |= confidentialClientApplicationOptions.LegacyCacheCompatibilityEnabled; // must be set through id web options
-            mergedOptions.EnableCacheSynchronization |= confidentialClientApplicationOptions.EnableCacheSynchronization;
+            // mergedOptions.LegacyCacheCompatibilityEnabled |= confidentialClientApplicationOptions.LegacyCacheCompatibilityEnabled; // must be set through MicrosoftIdentityOptions because MSAL has different default
+            // mergedOptions.EnableCacheSynchronization |= confidentialClientApplicationOptions.EnableCacheSynchronization; // must be set through MicrosoftIdentityOptions because MSAL has different default
             mergedOptions.LogLevel = confidentialClientApplicationOptions.LogLevel;
             if (string.IsNullOrEmpty(mergedOptions.RedirectUri) && !string.IsNullOrEmpty(confidentialClientApplicationOptions.RedirectUri))
             {

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityOptions.cs
@@ -93,8 +93,22 @@ namespace Microsoft.Identity.Web
         /// Performance improvements when working with MSAL only apps.
         /// Set to true if you have a shared cache with ADAL apps.
         /// </summary>
-        /// The default is <c>false.</c>
+        /// <remarks>
+        /// The default is <c>false</c>.
+        /// </remarks>
         public bool LegacyCacheCompatibilityEnabled { get; set; }
+
+        /// <summary>
+        /// When set to <c>true</c>, MSAL will lock cache access at the ConfidentialClientApplication level, i.e.
+        /// the block of code between BeforeAccessAsync and AfterAccessAsync callbacks will be synchronized. 
+        /// Apps can set this flag to <c>false</c> to enable an optimistic cache locking strategy, which may result in better performance
+        /// at the cost of cache consistency. 
+        /// Setting this flag to <c>false</c> is only recommended for apps which create a new ConfidentialClientApplication per request.
+        /// </summary>
+        /// <remarks>
+        /// The default is <c>false</c>.
+        /// </remarks>
+        public bool EnableCacheSynchronization { get; set; }
 
         /// <summary>
         /// Is considered B2C if the attribute SignUpSignInPolicyId is defined.
@@ -165,14 +179,18 @@ namespace Microsoft.Identity.Web
         /// This saves the application admin from the need to explicitly manage the certificate rollover
         /// (either via portal or PowerShell/CLI operation). For details see https://aka.ms/msal-net-sni.
         /// </summary>
-        /// The default is <c>false.</c>
+        /// <remarks>
+        /// The default is <c>false</c>.
+        /// </remarks>
         public bool SendX5C { get; set; }
 
         /// <summary>
         /// Requests an auth code for the frontend (SPA using MSAL.js for instance). 
         /// See https://aka.ms/msal-net/spa-auth-code for details.
         /// </summary>
-        /// The default is <c>false.</c>
+        /// <remarks>
+        /// The default is <c>false</c>.
+        /// </remarks>
         public bool WithSpaAuthCode { get; set; }
 
         /// <summary>
@@ -181,7 +199,9 @@ namespace Microsoft.Identity.Web
         /// Microsoft Identity Web will not throw if roles or scopes are not in the Claims.
         /// For details see https://aka.ms/ms-identity-web/daemon-ACL.
         /// </summary>
-        /// The default is <c>false.</c>
+        /// <remarks>
+        /// The default is <c>false</c>.
+        /// </remarks>
         public bool AllowWebApiToBeAuthorizedByACL { get; set; }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Web.Test/MergedOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MergedOptionsTests.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Identity.Web.Test
             microsoftIdentityOptions.DisableTelemetry = true;
             microsoftIdentityOptions.Domain = _msIdentityDomain;
             microsoftIdentityOptions.EditProfilePolicyId = _msIdentityEditProfile;
+            microsoftIdentityOptions.EnableCacheSynchronization = true;
             microsoftIdentityOptions.ForwardAuthenticate = _msIdentityForwardAuth;
             microsoftIdentityOptions.ForwardChallenge = _msIdentityForwardChallenge;
             microsoftIdentityOptions.ForwardDefault = _msIdentityForwardDefault;
@@ -227,6 +228,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(_msIdentityTokenDecryptCertificates!.First(), mergedOptions.TokenDecryptionCredentials!.First());
             Assert.True(mergedOptions.AllowWebApiToBeAuthorizedByACL);
             Assert.True(mergedOptions.DisableTelemetry);
+            Assert.True(mergedOptions.EnableCacheSynchronization);
             Assert.True(mergedOptions.GetClaimsFromUserInfoEndpoint);
             Assert.True(mergedOptions.LegacyCacheCompatibilityEnabled);
             Assert.True(mergedOptions.MapInboundClaims);


### PR DESCRIPTION
## Description
In the next version MSAL will set `EnableCacheSynchronization` flag to true by default. These changes will keep the flag false by default here to not affect the users. This is similar to the `LegacyCacheCompatibilityEnabled` (#1266).

Fixes #2413
