### PR TITLE
OWIN: Remove Microsoft.AspNet.WebApi.HelpPage dependency

### DIFF
--- a/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj
+++ b/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.HelpPage" Version="5.2.7" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="5.5.0" />
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.2" />
     <PackageReference Include="Microsoft.Owin.Security.ActiveDirectory" Version="4.2.2" />


### PR DESCRIPTION
OWIN: Remove Microsoft.AspNet.WebApi.HelpPage dependency

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

OWIN: Remove Microsoft.AspNet.WebApi.HelpPage dependency
The package auto copies a lot of unnecessary files to the target project, and the dependency cannot be removed while Microsoft.Identity.Web .OWIN is installed.

## Description

By installing Microsoft.Identity.Web.Owin it auto adds all these files to my project through its (seemingly) unused dependency to Microsoft.AspNet.WebApi.HelpPage:
![image](https://github.com/AzureAD/microsoft-identity-web/assets/3185998/658c74c6-c00c-4b9c-bed7-0f484dd1f23a)

This PR removes the dependency.

Fixes #2417 (in this specific format)
