### PR TITLE
[OWIN] Avoid null reference when session is disabled

### DIFF
--- a/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
+++ b/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
@@ -165,7 +165,23 @@ namespace Microsoft.Identity.Web
                     {
                         HttpContextBase httpContext = context.OwinContext.Get<HttpContextBase>(typeof(HttpContextBase).FullName);
 
-                        if (httpContext.Session[ClaimConstants.ClientInfo] is string clientInfo && !string.IsNullOrEmpty(clientInfo))
+                        if (httpContext.Session is null)
+                        {
+                            var clientInfo = context.OwinContext.Get<string>(ClaimConstants.ClientInfo);
+
+                            if (!string.IsNullOrEmpty(clientInfo))
+                            {
+                                ClientInfo? clientInfoFromServer = ClientInfo.CreateFromJson(clientInfo);
+
+                                if (clientInfoFromServer != null && clientInfoFromServer.UniqueTenantIdentifier != null && clientInfoFromServer.UniqueObjectIdentifier != null)
+                                {
+                                    context.AuthenticationTicket.Identity.AddClaim(new Claim(ClaimConstants.UniqueTenantIdentifier, clientInfoFromServer.UniqueTenantIdentifier));
+                                    context.AuthenticationTicket.Identity.AddClaim(new Claim(ClaimConstants.UniqueObjectIdentifier, clientInfoFromServer.UniqueObjectIdentifier));
+                                }
+                                context.OwinContext.Environment.Remove(ClaimConstants.ClientInfo);
+                            }
+                        }
+                        else if (httpContext.Session[ClaimConstants.ClientInfo] is string clientInfo && !string.IsNullOrEmpty(clientInfo))
                         {
                             ClientInfo? clientInfoFromServer = ClientInfo.CreateFromJson(clientInfo);
 
@@ -201,7 +217,14 @@ namespace Microsoft.Identity.Web
                     msIdentityOptions?.Value.DefaultUserFlow,
                     context.ProtocolMessage.DomainHint))).ConfigureAwait(false);
                 HttpContextBase httpContext = context.OwinContext.Get<HttpContextBase>(typeof(HttpContextBase).FullName);
-                httpContext.Session.Add(ClaimConstants.ClientInfo, context.ProtocolMessage.GetParameter(ClaimConstants.ClientInfo));
+                if (httpContext.Session is null)
+                {
+                    context.OwinContext.Set(ClaimConstants.ClientInfo, context.ProtocolMessage.GetParameter(ClaimConstants.ClientInfo));
+                }
+                else
+                {
+                    httpContext.Session.Add(ClaimConstants.ClientInfo, context.ProtocolMessage.GetParameter(ClaimConstants.ClientInfo));
+                }
                 context.HandleCodeRedemption(result.AccessToken, result.IdToken);
             };
 


### PR DESCRIPTION
# Avoid null reference when session is disabled
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

When sessions are disabled in Web.config, Session property is null and the AuthorizationCodeReceived handler throws exception. This change fallbacks to OwinContext.Environment dictionary, because the only use of session is to hand over Client Info from one handler to another in a single request.