### PR TITLE
[OWIN] Avoid null reference in SecurityTokenValidated with B2C

### DIFF
--- a/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
+++ b/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
@@ -177,8 +177,14 @@ namespace Microsoft.Identity.Web
                             httpContext.Session.Remove(ClaimConstants.ClientInfo);
                         }
 
-                        string name = context.AuthenticationTicket.Identity.FindFirst("preferred_username").Value;
-                        context.AuthenticationTicket.Identity.AddClaim(new Claim(ClaimTypes.Name, name, string.Empty));
+                        Claim nameClaim = context.AuthenticationTicket.Identity.FindFirst("preferred_username")
+                                          ?? context.AuthenticationTicket.Identity.FindFirst("name");
+
+                        if (!string.IsNullOrEmpty(nameClaim?.Value))
+                        {
+                            context.AuthenticationTicket.Identity.AddClaim(new Claim(ClaimTypes.Name, nameClaim.Value, string.Empty));
+                        }
+                        
                         return Task.CompletedTask;
                     },
                 }


### PR DESCRIPTION
# Avoid null reference in SecurityTokenValidated with B2C
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

When using B2C, returned claims do not have `preferred_username` and therefore the `.Value` property throws an exception in the SecurityTokenValidated handler. This change fallbacks to just `name` claim if the original is not found and checks for empty value before adding new claim to the identity.
