### PR TITLE
api: Check all responses for success

### DIFF
--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.HttpMethods.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.HttpMethods.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
             }
             catch(Exception ex) when (
                 ex is InvalidOperationException
@@ -243,6 +244,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
             }
             catch(Exception ex) when (
                 ex is InvalidOperationException
@@ -316,6 +318,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
             }
             catch(Exception ex) when (
                 ex is InvalidOperationException
@@ -389,6 +392,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
             }
             catch(Exception ex) when (
                 ex is InvalidOperationException
@@ -464,6 +468,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
             }
             catch(Exception ex) when (
                 ex is InvalidOperationException
@@ -537,6 +542,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
             }
             catch(Exception ex) when (
                 ex is InvalidOperationException
@@ -612,6 +618,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
             }
             catch(Exception ex) when (
                 ex is InvalidOperationException
@@ -685,6 +692,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
             }
             catch(Exception ex) when (
                 ex is InvalidOperationException

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.HttpMethods.tt
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.HttpMethods.tt
@@ -87,6 +87,7 @@ namespace Microsoft.Identity.Web
                 {
                     effectiveInput?.Dispose();
                 }
+                response.EnsureSuccessStatusCode();
 <# }
    if (hasOutput)
    { #>


### PR DESCRIPTION
Check all HttpResponses for success before returning to the caller.

Check all API Responses for success

## Description

Update HttpMethods to check the response for success before returning to the user.
Currently only calls that try to de-serialize were getting checked.

Fixes #{bug number} (in this specific format)
Issue #2426 
