### PR TITLE
Introduces a lock while loading credentials from Credential Source

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -80,7 +80,7 @@
     <MicrosoftGraphVersion>4.34.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.50.0-preview</MicrosoftGraphBetaVersion>
     <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
-    <MicrosoftIdentityAbstractions>4.0.0</MicrosoftIdentityAbstractions>
+    <MicrosoftIdentityAbstractions>4.1.0</MicrosoftIdentityAbstractions>
     <!--CVE-2021-24112-->
     <SystemDrawingCommon>4.7.2</SystemDrawingCommon>
   </PropertyGroup>

--- a/src/Microsoft.Identity.Web.Certificate/DefaultCredentialsLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/DefaultCredentialsLoader.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Web
                 string key = GenerateKey(credentialDescription);
 
                 // Get or create a semaphore for this key
-                SemaphoreSlim semaphore;
+                SemaphoreSlim? semaphore;
                 lock (_semaphoreLock)
                 {
                     if (!_loadingSemaphores.TryGetValue(key, out semaphore))

--- a/src/Microsoft.Identity.Web.Certificate/DefaultCredentialsLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/DefaultCredentialsLoader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
@@ -79,12 +78,6 @@ namespace Microsoft.Identity.Web
                     semaphore.Release();
                 }
             }
-        }
-
-        private string GenerateKey(CredentialDescription credentialDescription)
-        {
-            // Generate a unique key for the credentialDescription
-            return $"{credentialDescription.SourceType}_{credentialDescription.ReferenceOrValue}";
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Identity.Web.Certificate/DefaultCredentialsLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/DefaultCredentialsLoader.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Web
             if (credentialDescription.CachedValue == null)
             {
                 // Get or create a semaphore for this credentialDescription
-                var semaphore = _loadingSemaphores.GetOrAdd(credentialDescription.Id, new SemaphoreSlim(1));
+                var semaphore = _loadingSemaphores.GetOrAdd(credentialDescription.Id, (v) => new SemaphoreSlim(1));
 
                 // Wait to acquire the semaphore
                 await semaphore.WaitAsync();

--- a/tests/IntegrationTests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/IntegrationTests/TokenAcquirerTests/TokenAcquirer.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
# Introduces a lock while loading credentials from Credential Source

Summary of the changes
Ensure multiple requests don't attempt to load the same credentialDescription concurrently.

## Description
When a customer configures the source of a token decryption certificate in the inbound policy, SAL attempts to load the certificate from the specified source or retrieves the cached certificate if it has been loaded previously. SAL then creates an X509SecurityKey from the certificate and adds it to InboundPolicy.TokenValidationParameters.TokenDecryptionKeys if the key was not already added. This logic is executed for every incoming token validation request, and SAL utilizes ID.Web's implementation of ICredentialLoader to retrieve the certificate.

Until the certificate is cached by ID.Web (i.e., when credentialDescription.CachedValue is set), multiple parallel requests (potentially exceeding 100 incoming requests, as indicated by Keegan) may attempt to load the same certificate from the source. This raises performance concerns, particularly when fetching the certificate involves making an HTTP request (e.g., fetching from KeyVault).

Open Questions:
1. How does ID.Web detect when a certificate has been rotated?
2. Is the ResetCredentials API invoked when a certificate rotation occurs?

Note: Unit tests will be added once the design is approved