### PR TITLE
Addition of environment variables as config source in TokenAcquirerFactory

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
@@ -197,11 +197,12 @@ namespace Microsoft.Identity.Web
         {
             if (Configuration == null)
             {
-                // Read the configuration from a file
+                // Read the configuration from a file and augment/replace from environment variable
                 var builder = new ConfigurationBuilder();
                 string basePath = DefineConfiguration(builder);
                 builder.SetBasePath(basePath)
-                       .AddJsonFile("appsettings.json", optional: true);
+                       .AddJsonFile("appsettings.json", optional: true)
+                       .AddEnvironmentVariables();
                 Configuration = builder.Build();
             }
             return Configuration;


### PR DESCRIPTION
# Addition of environment variables as config source

- [ X] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ X] You've included inline docs for your change, where applicable.
- [ X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

Addition of environment variables as a source for configuration values. Placed after appsettings.config so that they can be used to override variables. Especially useful in containers.


Fixes #2480
