### PR TITLE
Fix build on .NET FW after #2480

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">net6.0; net7.0; net8.0; net462; net472; netstandard2.0; netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">net6.0; net7.0; net462; net472; netstandard2.0; netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">net462; net472; netstandard2.0; netcoreapp3.1; net6.0; net7.0; net8.0;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">net462; net472; netstandard2.0; netcoreapp3.1; net6.0; net7.0;</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj
@@ -18,7 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
+  </ItemGroup>
+  
+    <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="$(IdentityModelVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.LoggingExtensions" Version="$(IdentityModelVersion)" />


### PR DESCRIPTION
# Fix build and warnings

Fix build on .NET FW after #2480 and remove the "The referenced project is targeted to a different framework family" warnings

#2480 
