### PR TITLE
Fix #2456

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">net462; net472; netstandard2.0; netcoreapp3.1; net6.0; net7.0; net8.0;</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">net462; net472; netstandard2.0; netcoreapp3.1; net6.0; net7.0;</TargetFrameworks>
+    <!-- For files to appear in the Visual Studio Solution explorer given we have conditional inclusion in some projects (IdWeb for instance)
+         we need to have the higher framework, even if this produces a warning in the IDE -->
+    <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">net7.0; net462; net472; netstandard2.0; netcoreapp3.1; net6.0; net8.0;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">net7.0; net462; net472; netstandard2.0; netcoreapp3.1; net6.0;</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">net6.0; net7.0; net8.0; net462; net472; netstandard2.0; netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">net6.0; net7.0; net462; net472; netstandard2.0; netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">net462; net472; netstandard2.0; netcoreapp3.1; net6.0; net7.0; net8.0;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">net462; net472; netstandard2.0; netcoreapp3.1; net6.0; net7.0;</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj
@@ -18,7 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
+  </ItemGroup>
+  
+    <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="$(IdentityModelVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.LoggingExtensions" Version="$(IdentityModelVersion)" />

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -79,7 +80,7 @@ namespace Microsoft.Identity.Web
             WebAppCallsWebApiImplementation(
                 Services,
                 initialScopes,
-                ConfigureMicrosoftIdentityOptions,
+                null,
                 OpenIdConnectScheme,
                 configureConfidentialClientApplicationOptions);
             return new MicrosoftIdentityAppCallsWebApiAuthenticationBuilder(
@@ -93,14 +94,18 @@ namespace Microsoft.Identity.Web
         internal static void WebAppCallsWebApiImplementation(
             IServiceCollection services,
             IEnumerable<string>? initialScopes,
-            Action<MicrosoftIdentityOptions> configureMicrosoftIdentityOptions,
+            Action<MicrosoftIdentityOptions>? configureMicrosoftIdentityOptions,
             string openIdConnectScheme,
             Action<ConfidentialClientApplicationOptions>? configureConfidentialClientApplicationOptions)
         {
             // Ensure that configuration options for MSAL.NET, HttpContext accessor and the Token acquisition service
             // (encapsulating MSAL.NET) are available through dependency injection
-            services.Configure(openIdConnectScheme, configureMicrosoftIdentityOptions);
-
+            if (configureMicrosoftIdentityOptions != null)
+            {
+                // Won't be null in the case where the caller is MISE. Will be null when called
+                // from IdWeb
+                services.Configure(openIdConnectScheme, configureMicrosoftIdentityOptions);
+            }
             if (configureConfidentialClientApplicationOptions != null)
             {
                 services.Configure(openIdConnectScheme, configureConfidentialClientApplicationOptions);
@@ -157,8 +162,7 @@ namespace Microsoft.Identity.Web
                        };
 
                        // Handling the token validated to get the client_info for cases where tenantId is not present (example: B2C)
-                       var onTokenValidatedHandler = options.Events.OnTokenValidated;
-                       options.Events.OnTokenValidated = async context =>
+                       options.Events.OnTokenValidated += async context =>
                        {
                            string? clientInfo = context!.ProtocolMessage?.GetParameter(ClaimConstants.ClientInfo);
 
@@ -172,8 +176,7 @@ namespace Microsoft.Identity.Web
                                    context!.Principal!.Identities.FirstOrDefault()?.AddClaim(new Claim(ClaimConstants.UniqueObjectIdentifier, clientInfoFromServer.UniqueObjectIdentifier));
                                }
                            }
-
-                           await onTokenValidatedHandler(context).ConfigureAwait(false);
+                           await Task.CompletedTask;
                        };
 
                        // Handling the sign-out: removing the account from MSAL.NET cache

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Web
             WebAppCallsWebApiImplementation(
                 Services,
                 initialScopes,
-                null,
+                null, /* to avoid calling the delegate twice */
                 OpenIdConnectScheme,
                 configureConfidentialClientApplicationOptions);
             return new MicrosoftIdentityAppCallsWebApiAuthenticationBuilder(
@@ -98,12 +98,15 @@ namespace Microsoft.Identity.Web
             string openIdConnectScheme,
             Action<ConfidentialClientApplicationOptions>? configureConfidentialClientApplicationOptions)
         {
-            // Ensure that configuration options for MSAL.NET, HttpContext accessor and the Token acquisition service
-            // (encapsulating MSAL.NET) are available through dependency injection
+            // When called from MISE, ensure that configuration options for MSAL.NET, HttpContext accessor
+            // and the Token acquisition service (encapsulating MSAL.NET) are available through dependency injection.
+            // When called from AddMicrosoftIdentityWebApp(delegate), should not be re-configured otherwise
+            // the delegate would be called twice.
             if (configureMicrosoftIdentityOptions != null)
             {
-                // Won't be null in the case where the caller is MISE. Will be null when called
-                // from IdWeb
+                // Won't be null in the case where the caller is MISE (to ensure that the configuration for MSAL.NET
+                // is available through DI).
+                // Will be null when called from AddMicrosoftIdentityWebApp(delegate) to avoid calling the delegate twice.
                 services.Configure(openIdConnectScheme, configureMicrosoftIdentityOptions);
             }
             if (configureConfidentialClientApplicationOptions != null)


### PR DESCRIPTION
# Fixes delegate called twice in AddMicrosoftIdentityWebApp (and hence TokenValidated event called twice)

In a web app using the initialization with delegates (not by configuration), and using EnableTokenAcquisitionToCallDownstreamApi, the delegate was called twice. This is because the configuration of the MicrosoftIdentityOptions was needed in the MISE EnableTokenAcquisitionToCallDownstreamApi method, whereas IdWeb AddMicrosoftIdentityWebApp had called it already.

## Description

- Fixes the issue
- Adds a regression test in the WebAppCallGraph devapp
- Re add a net7.0 target framework as the first framework, as Visual Studio does no longer display the files in the solution explorer :-(

Fixes  #2456
