### PR TITLE
Fixes #2410, #2410

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Web
             _ = Throws.IfNull(services);
 
 #if !NETSTANDARD2_0 && !NET462 && !NET472
-            bool forceSdk = !services.Any(s => s.ServiceType == typeof(AspNetCore.Hosting.IWebHostEnvironment));
+            bool forceSdk = !services.Any(s => s.ServiceType.FullName == "Microsoft.AspNetCore.Authentication.IAuthenticationService");
 #endif
 
             if (services.FirstOrDefault(s => s.ImplementationType == typeof(ICredentialsLoader)) == null)

--- a/tests/Microsoft.Identity.Web.Test/TestTokenAcquisitionHost.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestTokenAcquisitionHost.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    public class TestTokenAcquisitionHost
+    {
+        [Fact]
+        public void TestTokenAcquisitionHostNotAspNetCore()
+        {
+            // When not adding Services.AddAuthentication, the host should be 
+            TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
+            var host = tokenAcquirerFactory.Services.First(s => s.ServiceType.Name == "Microsoft.Identity.Web.ITokenAcquisitionHost");
+            Assert.True(host.ImplementationType!.FullName == "Microsoft.Identity.Web.Hosts.DefaultTokenAcquisitionHost");
+        }
+
+        [Fact]
+        public void TestTokenAcquisitionAspNetCoreBuilderNoAuth()
+        {
+            // When not adding Services.AddAuthentication, the host should be 
+            var builder = WebApplication.CreateBuilder();
+            builder.Services.AddTokenAcquisition();
+            var host = builder.Services.First(s => s.ServiceType.Name == "ITokenAcquisitionHost");
+            Assert.True(host.ImplementationType!.FullName == "Microsoft.Identity.Web.Hosts.DefaultTokenAcquisitionHost");
+        }
+
+
+        [Fact]
+        public void TestTokenAcquisitionAspNetCoreBuilderAuth()
+        {
+            // When not adding Services.AddAuthentication, the host should be 
+            var builder = WebApplication.CreateBuilder();
+            builder.Services.AddAuthentication()
+                .AddMicrosoftIdentityWebApi(builder.Configuration)
+                 .EnableTokenAcquisitionToCallDownstreamApi();
+
+            var host = builder.Services.First(s => s.ServiceType.Name == "ITokenAcquisitionHost");
+            Assert.True(host.ImplementationType!.FullName == "Microsoft.Identity.Web.TokenAcquisitionAspnetCoreHost");
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/TestTokenAcquisitionHost.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestTokenAcquisitionHost.cs
@@ -1,14 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Microsoft.Identity.Web.Test
@@ -20,7 +15,7 @@ namespace Microsoft.Identity.Web.Test
         {
             // When not adding Services.AddAuthentication, the host should be 
             TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
-            var host = tokenAcquirerFactory.Services.First(s => s.ServiceType.Name == "Microsoft.Identity.Web.ITokenAcquisitionHost");
+            var host = tokenAcquirerFactory.Services.First(s => s.ServiceType.FullName == "Microsoft.Identity.Web.ITokenAcquisitionHost");
             Assert.True(host.ImplementationType!.FullName == "Microsoft.Identity.Web.Hosts.DefaultTokenAcquisitionHost");
         }
 
@@ -30,7 +25,7 @@ namespace Microsoft.Identity.Web.Test
             // When not adding Services.AddAuthentication, the host should be 
             var builder = WebApplication.CreateBuilder();
             builder.Services.AddTokenAcquisition();
-            var host = builder.Services.First(s => s.ServiceType.Name == "ITokenAcquisitionHost");
+            var host = builder.Services.First(s => s.ServiceType.FullName == "Microsoft.Identity.Web.ITokenAcquisitionHost");
             Assert.True(host.ImplementationType!.FullName == "Microsoft.Identity.Web.Hosts.DefaultTokenAcquisitionHost");
         }
 
@@ -44,7 +39,7 @@ namespace Microsoft.Identity.Web.Test
                 .AddMicrosoftIdentityWebApi(builder.Configuration)
                  .EnableTokenAcquisitionToCallDownstreamApi();
 
-            var host = builder.Services.First(s => s.ServiceType.Name == "ITokenAcquisitionHost");
+            var host = builder.Services.First(s => s.ServiceType.FullName == "Microsoft.Identity.Web.ITokenAcquisitionHost");
             Assert.True(host.ImplementationType!.FullName == "Microsoft.Identity.Web.TokenAcquisitionAspnetCoreHost");
         }
     }


### PR DESCRIPTION
# Fixes #2410, #2410
Based on customer feedback, change the condition by which a host is used rather than another (DefaultTokenAcquisitionHost vs TokenAcquisitionAspnetCoreHost)