### PR TITLE
Use http instead of https

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
 jobs:
 - job: "PR_build"
   pool:
-    vmImage: 'windows-latest'
+    name: MwWilson1EsHostedPool
     demands:
     - msbuild
   steps:

--- a/build/template-install-dependencies.yaml
+++ b/build/template-install-dependencies.yaml
@@ -39,7 +39,6 @@ steps:
     KeyVaultName: buildautomation
     SecretsFilter: 'AzureADIdentityDivisionTestAgentCert'
 
-
 - powershell: |
    $kvSecretBytes = [System.Convert]::FromBase64String('$(AzureADIdentityDivisionTestAgentCert)')
    $certCollection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection

--- a/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
@@ -46,11 +46,11 @@ namespace Microsoft.Identity.Web
             X509KeyStorageFlags x509KeyStorageFlags)
         {
             Uri keyVaultUri = new Uri(keyVaultUrl);
-            /*            DefaultAzureCredentialOptions options = new()
-                        {
-                            ManagedIdentityClientId = managedIdentityClientId,
-                        };*/
-            DefaultAzureCredential credential = new();// options);
+            DefaultAzureCredentialOptions options = new()
+            {
+                ManagedIdentityClientId = managedIdentityClientId,
+            };
+            DefaultAzureCredential credential = new(options);
             CertificateClient certificateClient = new(keyVaultUri, credential);
             SecretClient secretClient = new(keyVaultUri, credential);
 

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/appsettings.json
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/appsettings.json
@@ -8,7 +8,7 @@
         "SignedOutCallbackPath ": "/signout-callback-oidc",
         "EnablePiiLogging": true,
         "EnableCacheSynchronization": false,
-        "UserAssignedManagedIdentityClientId": "a4acf71f-3855-4675-87cc-4bda64ac1a48",
+        "UserAssignedManagedIdentityClientId": "9c5896db-a74a-4b1a-a259-74c5080a3a6a",
 
         // To call an API
         "ClientCertificates": [
@@ -16,14 +16,14 @@
                 "SourceType": "KeyVault",
                 "KeyVaultUrl": "https://webappsapistests.vault.azure.net",
                 "KeyVaultCertificateName": "Self-Signed-5-5-22",
-                "ManagedIdentityClientId": "a4acf71f-3855-4675-87cc-4bda64ac1a48"
+                "ManagedIdentityClientId": "9c5896db-a74a-4b1a-a259-74c5080a3a6a"
             }
         ]
     },
     "TodoList": {
         // TodoListScope is the scope of the Web API you want to call.
         "Scopes": [ "api://a4c2469b-cf84-4145-8f5f-cb7bacf814bc/access_as_user" ],
-        "BaseUrl": "https://localhost:44351"
+        "BaseUrl": "http://localhost:44350"
 
     },
     "SayHello": {

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/TodoListService/Properties/launchSettings.json
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/TodoListService/Properties/launchSettings.json
@@ -8,7 +8,7 @@
         "environmentVariables": {
             "ASPNETCORE_ENVIRONMENT": "Development"
         },
-        "applicationUrl": "https://localhost:44351/"
+        "applicationUrl": "https://localhost:44351;http://localhost:44350/"
     }
   }
 }

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/TodoListService/appsettings.json
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/TodoListService/appsettings.json
@@ -17,13 +17,13 @@
         // "Authority": "https://localhost:1234/v2.0",
         "ClientId": "a4c2469b-cf84-4145-8f5f-cb7bacf814bc", //"712ae8d7-548a-4306-95b6-ee9117ee86f0", JWE clientID
         //"ClientSecret": null,
-        "UserAssignedManagedIdentityClientId": "a4acf71f-3855-4675-87cc-4bda64ac1a48",
+        "UserAssignedManagedIdentityClientId": "9c5896db-a74a-4b1a-a259-74c5080a3a6a",
         "ClientCertificates": [
             {
                 "SourceType": "KeyVault",
                 "KeyVaultUrl": "https://webappsapistests.vault.azure.net",
                 "KeyVaultCertificateName": "Self-Signed-5-5-22",
-                "ManagedIdentityClientId": "a4acf71f-3855-4675-87cc-4bda64ac1a48"
+                "ManagedIdentityClientId": "9c5896db-a74a-4b1a-a259-74c5080a3a6a"
             }
         ],
         "Scopes": "access_as_user",
@@ -73,7 +73,7 @@
         }
     },
     "AllowedHosts": "*",
-    "Urls": "https://localhost:44351"
+    "Urls": "http://localhost:44350"
 //    "ConnectionStrings": {
 //        "Redis": "localhost:5002" // configure w/docker
 //    }

--- a/tests/IntegrationTests/WebAppCallsApiCallsGraphUiTests/TestingWebAppCallsApiCallsGraphLocally.cs
+++ b/tests/IntegrationTests/WebAppCallsApiCallsGraphUiTests/TestingWebAppCallsApiCallsGraphLocally.cs
@@ -25,13 +25,13 @@ namespace WebAppCallsApiCallsGraphUiTests
         private const string TodoListServiceExecutable = @"\TodoListService.exe";
         private const string TodoListClientExecutable = @"\TodoListClient.exe";
         private const string GrpcExecutable = @"\grpc.exe";
-        private const string TodoListServicePort = "44351";
+        private const string TodoListServicePort = "44350";
         private const string TodoListClientPort = "44321";
         private const string GrpcPort = "5001";
         private const string SignOutPagePath = @"/MicrosoftIdentity/Account/SignedOut";
         private const string TodoTitle1 = "Testing create todo item";
         private const string TodoTitle2 = "Testing edit todo item";
-        private const string ManagedIdentityObjectId = "a4acf71f-3855-4675-87cc-4bda64ac1a48";
+        private const string ManagedIdentityObjectId = "9c5896db-a74a-4b1a-a259-74c5080a3a6a";
         private string UiTestAssemblyLocation = typeof(TestingWebAppCallsApiCallsGraphLocally).Assembly.Location;
         private readonly ITestOutputHelper _output;
 
@@ -50,11 +50,11 @@ namespace WebAppCallsApiCallsGraphUiTests
             Environment.SetEnvironmentVariable("AzureAd_ClientCredentials_0_ManagedIdentityClientId", ManagedIdentityObjectId);
             Process? grpcProcess = UiTestHelpers.StartProcessLocally(UiTestAssemblyLocation, DevAppPath + GrpcPath, GrpcExecutable, GrpcPort);
             Process? clientProcess = UiTestHelpers.StartProcessLocally(UiTestAssemblyLocation, DevAppPath + TodoListClientPath, TodoListClientExecutable, TodoListClientPort);
-            Process? serviceProcess = UiTestHelpers.StartProcessLocally(UiTestAssemblyLocation, DevAppPath + TodoListServicePath, TodoListServiceExecutable, TodoListServicePort);
+            Process? serviceProcess = UiTestHelpers.StartProcessLocally(UiTestAssemblyLocation, DevAppPath + TodoListServicePath, TodoListServiceExecutable, TodoListServicePort, true);
             
             // Arrange Playwright setup, to see the browser UI, set Headless = false
             using var playwright = await Playwright.CreateAsync();
-            var browser = await playwright.Chromium.LaunchAsync(new() { Headless = true }); // 
+            var browser = await playwright.Chromium.LaunchAsync(new() { Headless = true });
             var context = await browser.NewContextAsync(new BrowserNewContextOptions { IgnoreHTTPSErrors = true });
             await context.Tracing.StartAsync(new() { Screenshots = true, Snapshots = true, Sources = true });
 

--- a/tests/IntegrationTests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/IntegrationTests/WebAppUiTests/UiTestHelpers.cs
@@ -133,8 +133,9 @@ namespace WebAppUiTests
         /// <param name="appLocation">The path to the processes directory</param>
         /// <param name="executableName">The name of the executable that launches the process</param>
         /// <param name="portNumber">The port for the process to listen on</param>
+        /// <param name="isHttp">If the launch URL is http or https. Default is https.</param>
         /// <returns></returns>
-        public static Process? StartProcessLocally(string testAssemblyLocation, string appLocation, string executableName, string? portNumber = null)
+        public static Process? StartProcessLocally(string testAssemblyLocation, string appLocation, string executableName, string? portNumber = null, bool? isHttp = false)
         {
             string applicationWorkingDirectory = GetApplicationWorkingDirectory(testAssemblyLocation, appLocation);
             ProcessStartInfo processStartInfo = new ProcessStartInfo(applicationWorkingDirectory + executableName);
@@ -144,7 +145,14 @@ namespace WebAppUiTests
 
             if (!portNumber.IsNullOrEmpty())
             {
-                processStartInfo.EnvironmentVariables["Kestrel:Endpoints:Https:Url"] = "https://*:" + portNumber;
+                if (isHttp != null && isHttp.Value)
+                {
+                    processStartInfo.EnvironmentVariables["Kestrel:Endpoints:Http:Url"] = "http://*:" + portNumber;
+                }
+                else
+                {
+                    processStartInfo.EnvironmentVariables["Kestrel:Endpoints:Https:Url"] = "https://*:" + portNumber;
+                }
             }
             return Process.Start(processStartInfo);
         }


### PR DESCRIPTION
Was hitting this error:
<img width="653" alt="image" src="https://github.com/AzureAD/microsoft-identity-web/assets/19942418/f0237fe4-1a36-4953-b090-55e77860019d">
So changed the web API to use `http`, as could not get the vm to pick up the cert without manual intervention.

Had to do a few other changes, such as using a different pool, which had the managed identity enabled.