### PR TITLE
Adding Check Against Injection Attacks

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/IDWebErrorMessage.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Identity.Web
         public const string MicrosoftIdentityWebChallengeUserException = "IDW10502: An MsalUiRequiredException was thrown due to a challenge for the user. " +
            "See https://aka.ms/ms-id-web/ca_incremental-consent. ";
         public const string ProvidedAuthenticationSchemeIsIncorrect = "IDW10503: Cannot determine the cloud Instance. The provided authentication scheme was '{0}'. Microsoft.Identity.Web inferred '{1}' as the authentication scheme. Available authentication schemes are '{2}'. See https://aka.ms/id-web/authSchemes. ";
+        public const string InvalidAssertion = "IDW10504: Invalid assertion: contains unsupported character(s).";
+        public const string InvalidSubAssertion = "IDW10505: Invalid sub_assertion: contains unsupported character(s).";
 
         // Encoding IDW10600 = "IDW10600:"
         public const string InvalidBase64UrlString = "IDW10601: Invalid Base64URL string. ";

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -783,6 +783,9 @@ namespace Microsoft.Identity.Web
                             // Special case when the OBO inbound token is composite (for instance PFT)
                             if (dict.ContainsKey(assertionConstant) && dict.ContainsKey(subAssertionConstant))
                             {
+
+                                CheckAssertionsForInjectionAttempt(dict[assertionConstant], dict[subAssertionConstant]);
+
                                 builder.OnBeforeTokenRequest((data) =>
                                 {
                                     // Replace the assertion and adds sub_assertion with the values from the extra query parameters
@@ -828,6 +831,20 @@ namespace Microsoft.Identity.Web
                     LogMessages.ErrorAcquiringTokenForDownstreamWebApi + ex.Message,
                     ex);
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Checks assertion and sub_assertion passed from merging extra query parameters to ensure they do not contain unsupported characters.
+        /// </summary>
+        /// <param name="assertion">The assertion.</param>
+        /// <param name="subAssertion">The sub_assertion.</param>
+        private static void CheckAssertionsForInjectionAttempt(string assertion, string subAssertion)
+        {
+            if (assertion != null || subAssertion != null)
+            {
+                if (assertion.Contains('&')) throw new ArgumentException(IDWebErrorMessage.InvalidAssertion, nameof(assertion));
+                else if (subAssertion.Contains('&')) throw new ArgumentException(IDWebErrorMessage.InvalidSubAssertion, nameof(subAssertion));
             }
         }
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -841,7 +841,7 @@ namespace Microsoft.Identity.Web
         /// <param name="subAssertion">The sub_assertion.</param>
         private static void CheckAssertionsForInjectionAttempt(string assertion, string subAssertion)
         {
-            if (assertion.IsNullOrEmpty() || subAssertion.IsNullOrEmpty())
+            if (!assertion.IsNullOrEmpty() || !subAssertion.IsNullOrEmpty())
             {
                 if (assertion.Contains('&', StringComparison.InvariantCultureIgnoreCase)) throw new ArgumentException(IDWebErrorMessage.InvalidAssertion, nameof(assertion));
                 else if (subAssertion.Contains('&', StringComparison.InvariantCultureIgnoreCase)) throw new ArgumentException(IDWebErrorMessage.InvalidSubAssertion, nameof(subAssertion));

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -841,10 +841,10 @@ namespace Microsoft.Identity.Web
         /// <param name="subAssertion">The sub_assertion.</param>
         private static void CheckAssertionsForInjectionAttempt(string assertion, string subAssertion)
         {
-            if (assertion != null || subAssertion != null)
+            if (assertion.IsNullOrEmpty() || subAssertion.IsNullOrEmpty())
             {
-                if (assertion.Contains('&')) throw new ArgumentException(IDWebErrorMessage.InvalidAssertion, nameof(assertion));
-                else if (subAssertion.Contains('&')) throw new ArgumentException(IDWebErrorMessage.InvalidSubAssertion, nameof(subAssertion));
+                if (assertion.Contains('&', StringComparison.InvariantCultureIgnoreCase)) throw new ArgumentException(IDWebErrorMessage.InvalidAssertion, nameof(assertion));
+                else if (subAssertion.Contains('&', StringComparison.InvariantCultureIgnoreCase)) throw new ArgumentException(IDWebErrorMessage.InvalidSubAssertion, nameof(subAssertion));
             }
         }
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -784,6 +784,7 @@ namespace Microsoft.Identity.Web
                             if (dict.ContainsKey(assertionConstant) && dict.ContainsKey(subAssertionConstant))
                             {
 
+                                // Check assertion and sub_assertion passed from merging extra query parameters to ensure they do not contain unsupported character(s).
                                 CheckAssertionsForInjectionAttempt(dict[assertionConstant], dict[subAssertionConstant]);
 
                                 builder.OnBeforeTokenRequest((data) =>
@@ -843,8 +844,8 @@ namespace Microsoft.Identity.Web
         {
             if (!assertion.IsNullOrEmpty() || !subAssertion.IsNullOrEmpty())
             {
-                if (assertion.Contains('&', StringComparison.InvariantCultureIgnoreCase)) throw new ArgumentException(IDWebErrorMessage.InvalidAssertion, nameof(assertion));
-                else if (subAssertion.Contains('&', StringComparison.InvariantCultureIgnoreCase)) throw new ArgumentException(IDWebErrorMessage.InvalidSubAssertion, nameof(subAssertion));
+                if (!assertion.IsNullOrEmpty() && assertion.Contains('&', StringComparison.InvariantCultureIgnoreCase)) throw new ArgumentException(IDWebErrorMessage.InvalidAssertion, nameof(assertion));
+                if (!subAssertion.IsNullOrEmpty() && (subAssertion.Contains('&', StringComparison.InvariantCultureIgnoreCase))) throw new ArgumentException(IDWebErrorMessage.InvalidSubAssertion, nameof(subAssertion));
             }
         }
 


### PR DESCRIPTION
## Description

Add a check in ID.Web to check for the presence of '&' for assertion and sub-assertion in ExtraQueryParameters dictionary.

