### PR TITLE
ManagedIdentityClientAssertion: Set clientId for both ManagedIdentity and WorkloadIdentity

### DIFF
--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -25,7 +25,14 @@ namespace Microsoft.Identity.Web
                 new DefaultAzureCredentialOptions
                 {
                     ManagedIdentityClientId = managedIdentityClientId,
-                    WorkloadIdentityClientId = managedIdentityClientId
+                    WorkloadIdentityClientId = managedIdentityClientId,
+                    ExcludeAzureCliCredential = true,
+                    ExcludeAzureDeveloperCliCredential = true
+                    ExcludeAzurePowerShellCredential = true,
+                    ExcludeInteractiveBrowserCredential = true,
+                    ExcludeSharedTokenCacheCredential = true,
+                    ExcludeVisualStudioCodeCredential = true,
+                    ExcludeVisualStudioCredential = true
                 });
         }
 

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -13,16 +13,21 @@ namespace Microsoft.Identity.Web
     /// </summary>
     public class ManagedIdentityClientAssertion : ClientAssertionProviderBase
     {
+        private readonly TokenCredential _credential;
+
         /// <summary>
         /// See https://aka.ms/ms-id-web/certificateless.
         /// </summary>
-        /// <param name="managedIdentityClientId"></param>
+        /// <param name="managedIdentityClientId">Optional ClientId of the Managed Identity or Workload Identity</param>
         public ManagedIdentityClientAssertion(string? managedIdentityClientId)
         {
-            _managedIdentityClientId = managedIdentityClientId;
+            _credential = new DefaultAzureCredential(
+                new DefaultAzureCredentialOptions
+                {
+                    ManagedIdentityClientId = managedIdentityClientId,
+                    WorkloadIdentityClientId = managedIdentityClientId
+                });
         }
-
-        private readonly string? _managedIdentityClientId;
 
         /// <summary>
         /// Prototype of certificate-less authentication using a signed assertion
@@ -31,10 +36,8 @@ namespace Microsoft.Identity.Web
         /// <returns>The signed assertion.</returns>
         protected override async Task<ClientAssertion> GetClientAssertion(CancellationToken cancellationToken)
         {
-            var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = _managedIdentityClientId });
-
-            var result = await credential.GetTokenAsync(
-                new TokenRequestContext(new[] { "api://AzureADTokenExchange/.default" }, null),
+            var result = await _credential.GetTokenAsync(
+                new TokenRequestContext(["api://AzureADTokenExchange/.default"], null),
                 cancellationToken).ConfigureAwait(false);
             return new ClientAssertion(result.Token, result.ExpiresOn);
         }

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Web
                     ManagedIdentityClientId = managedIdentityClientId,
                     WorkloadIdentityClientId = managedIdentityClientId,
                     ExcludeAzureCliCredential = true,
-                    ExcludeAzureDeveloperCliCredential = true
+                    ExcludeAzureDeveloperCliCredential = true,
                     ExcludeAzurePowerShellCredential = true,
                     ExcludeInteractiveBrowserCredential = true,
                     ExcludeSharedTokenCacheCredential = true,


### PR DESCRIPTION
# ManagedIdentityClientAssertion: Set clientId for both ManagedIdentity and WorkloadIdentity
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

See issue below

Fixes https://github.com/AzureAD/microsoft-identity-web/issues/2643

Kind of clashes with https://github.com/AzureAD/microsoft-identity-web/issues/2644 but this will work at least as a short-term fix for people wanting to use WorkloadIdentity (on AKS)


## Alternative

An alternative approach would be a completely new class dedicated for WorkloadIdentity:

```csharp
public class WorkloadIdentityClientAssertion : ClientAssertionProviderBase
{
    private readonly TokenCredential _credential;

    /// <summary>
    /// See https://aka.ms/ms-id-web/certificateless.
    /// </summary>
    /// <param name="managedIdentityClientId">ClientId of the managed identity, in case multiple identities are federated with the service account</param>
    public WorkloadIdentityClientAssertion(string? managedIdentityClientId)
    {
        _credential = new WorkloadIdentityCredential(
            new WorkloadIdentityCredentialOptions
            {
                ClientId = managedIdentityClientId
            });
    }

    /// <summary>
    /// Prototype of certificate-less authentication using a signed assertion
    /// acquired with managed identity (certificateless).
    /// </summary>
    /// <returns>The signed assertion.</returns>
    protected override async Task<ClientAssertion> GetClientAssertion(CancellationToken cancellationToken)
    {
        var result = await _credential.GetTokenAsync(
            new TokenRequestContext(["api://AzureADTokenExchange/.default"], null),
            cancellationToken).ConfigureAwait(false);
        return new ClientAssertion(result.Token, result.ExpiresOn);
    }
}
```
