### PR TITLE
Fixed incorrect test CollectionDefinition

### DIFF
--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -19,7 +19,7 @@ namespace WebAppUiTests
 #if !FROM_GITHUB_ACTION
 {
     // since these tests change environment variables we'd prefer it not run at the same time as other tests
-    [CollectionDefinition(nameof(WebAppCallsApiCallsGraphLocally), DisableParallelization = true)]
+    [CollectionDefinition(nameof(B2CWebAppCallsWebApiLocally), DisableParallelization = true)]
     [Collection("WebAppUiTests")]
     public class B2CWebAppCallsWebApiLocally : IClassFixture<InstallPlaywrightBrowserFixture>
     {


### PR DESCRIPTION
The B2CWebAppCallsWebApiLocally CollectionDefinition incorrectly referred to a different UI test class causing it to potentially run in parrallel with the other UI test class causing failures when multiple instances of an app tried to access the same port at the same time.