### PR TITLE
Fix ServiceDescriptor access when Keyed Services are present

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -44,20 +45,20 @@ namespace Microsoft.Identity.Web
             bool forceSdk = !services.Any(s => s.ServiceType.FullName == "Microsoft.AspNetCore.Authentication.IAuthenticationService");
 #endif
 
-            if (services.FirstOrDefault(s => s.ImplementationType == typeof(DefaultCertificateLoader)) == null)
+            if (!HasImplementationType(services, typeof(DefaultCertificateLoader)))
             {
                 services.TryAddSingleton<ICredentialsLoader, DefaultCertificateLoader>();
             }
 
-            if (services.FirstOrDefault(s => s.ImplementationType == typeof(MicrosoftIdentityOptionsMerger)) == null)
+            if (!HasImplementationType(services, typeof(MicrosoftIdentityOptionsMerger)))
             {
                 services.TryAddSingleton<IPostConfigureOptions<MicrosoftIdentityOptions>, MicrosoftIdentityOptionsMerger>();
             }
-            if (services.FirstOrDefault(s => s.ImplementationType == typeof(MicrosoftIdentityApplicationOptionsMerger)) == null)
+            if (!HasImplementationType(services, typeof(MicrosoftIdentityApplicationOptionsMerger)))
             {
                 services.TryAddSingleton<IPostConfigureOptions<MicrosoftIdentityApplicationOptions>, MicrosoftIdentityApplicationOptionsMerger>();
             }
-            if (services.FirstOrDefault(s => s.ImplementationType == typeof(ConfidentialClientApplicationOptionsMerger)) == null)
+            if (!HasImplementationType(services, typeof(ConfidentialClientApplicationOptionsMerger)))
             {
                 services.TryAddSingleton<IPostConfigureOptions<ConfidentialClientApplicationOptions>, ConfidentialClientApplicationOptionsMerger>();
             }
@@ -138,6 +139,15 @@ namespace Microsoft.Identity.Web
 
             services.AddSingleton<IMergedOptionsStore, MergedOptionsStore>();
             return services;
+        }
+
+        private static bool HasImplementationType(IServiceCollection services, Type implementationType)
+        {
+            return services.Any(s =>
+#if NET8_0_OR_GREATER
+                s.ServiceKey is null &&
+#endif
+                s.ImplementationType == implementationType);
         }
     }
 }

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -148,11 +148,11 @@ namespace Microsoft.Identity.Web
             builder.Services.AddRequiredScopeAuthorization();
             builder.Services.AddRequiredScopeOrAppPermissionAuthorization();
             builder.Services.AddOptions<AadIssuerValidatorOptions>();
-            if (builder.Services.FirstOrDefault(s => s.ImplementationType == typeof(MicrosoftIdentityOptionsMerger)) == null)
+            if (!HasImplementationType(builder.Services, typeof(MicrosoftIdentityOptionsMerger)))
             {
                 builder.Services.TryAddSingleton<IPostConfigureOptions<MicrosoftIdentityOptions>, MicrosoftIdentityOptionsMerger>();
             }
-            if (builder.Services.FirstOrDefault(s => s.ImplementationType == typeof(JwtBearerOptionsMerger)) == null)
+            if (!HasImplementationType(builder.Services, typeof(JwtBearerOptionsMerger)))
             {
                 builder.Services.TryAddSingleton<IPostConfigureOptions<JwtBearerOptions>, JwtBearerOptionsMerger>();
             }
@@ -307,6 +307,15 @@ namespace Microsoft.Identity.Web
 
                 await tokenValidatedHandler(context).ConfigureAwait(false);
             };
+        }
+
+        private static bool HasImplementationType(IServiceCollection services, Type implementationType)
+        {
+            return services.Any(s =>
+#if NET8_0_OR_GREATER
+                s.ServiceKey is null &&
+#endif
+                s.ImplementationType == implementationType);
         }
     }
 }

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -238,7 +238,11 @@ namespace Microsoft.Identity.Web
             _ = Throws.IfNull(builder);
             _ = Throws.IfNull(configureMicrosoftIdentityOptions);
 
-            if (builder.Services.FirstOrDefault(s => s.ImplementationType == typeof(MicrosoftIdentityOptionsMerger)) == null)
+            if (builder.Services.FirstOrDefault(s =>
+#if NET8_0_OR_GREATER
+                s.ServiceKey is null &&
+#endif
+                s.ImplementationType == typeof(MicrosoftIdentityOptionsMerger)) == null)
             {
                 builder.Services.AddSingleton<IPostConfigureOptions<MicrosoftIdentityOptions>, MicrosoftIdentityOptionsMerger>();
             }

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -104,6 +104,23 @@ namespace Microsoft.Identity.Web.Test
                 });
         }
 
+#if NET8_0_OR_GREATER
+        [Fact]
+        public void AddTokenAcquisition_Sdk_SupportsKeyedServices()
+        {
+            var services = new ServiceCollection();
+
+            // Add a keyed service.
+            services.AddKeyedSingleton<ServiceCollectionExtensionsTests>("test", this);
+
+            // This should not throw.
+            services.AddTokenAcquisition();
+
+            // Verify the number of services added by AddTokenAcquisition (ignoring the service we added here).
+            Assert.Equal(10, services.Count(t => t.ServiceType != typeof(ServiceCollectionExtensionsTests)));
+        }
+#endif
+
         [Fact]
         public void AddTokenAcquisition_AbleToOverrideICredentialsLoader()
         {


### PR DESCRIPTION
# Fix ServiceDescriptor access when Keyed Services are present

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fixes the use of `ServiceDescriptor` for containers which have keyed services present. This can be an issue on .NET 8.0 and has been reported by some users of the library here: https://github.com/AzureAD/microsoft-identity-web/issues/2604

## Description

The issue is caused by unconditional access to `ServiceDescriptor.ImplementationType` and the fix is to first check whether `ServiceDescriptor.ServiceKey` is set. If it is, we can safely ignore that descriptor.

For more information on keyed services, see the dotnet/runtime thread here: https://github.com/dotnet/runtime/issues/64427 and the PR here: https://github.com/dotnet/runtime/pull/87183.

Fixes #2604
