### PR TITLE
Support for CIAM CUD

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -424,9 +424,9 @@ namespace Microsoft.Identity.Web
                 // generic authority - ignore all tenant information
                 if (mergedOptions.IsOidcAuthority)
                 {
-                    mergedOptions.Instance = (new Uri(mergedOptions.Authority)).Host;
+                    mergedOptions.Instance = mergedOptions.Authority;
                 }
-                else if (string.IsNullOrEmpty(mergedOptions.TenantId)) // TODO: bogavril - this is very brittle, probably won't work for dSTS etc. MSAL should have a helper for this
+                else if (string.IsNullOrEmpty(mergedOptions.TenantId))
                 {
                     string authority = mergedOptions.Authority!.TrimEnd('/');
                     int indexTenant = authority.LastIndexOf('/');

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityOptions.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Identity.Web
 #endif
 
     /// <summary>
-    /// Options for configuring authentication using Azure Active Directory. It has both AAD and B2C configuration attributes.
+    /// Options for configuring authentication using Azure Active Directory. It supports several Identity Providers, 
+    /// including AAD, B2C and CIAM configuration attributes.
     /// </summary>
     public class MicrosoftIdentityOptions : OpenIdConnectOptions
     {
@@ -99,9 +100,18 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Is considered B2C if the attribute SignUpSignInPolicyId is defined.
         /// </summary>
-        internal bool IsB2C
+        internal bool IsB2C // TODO: bogavril - how about an enum AuthorityType { AAD, B2C, CIAM, Oidc } instead?
         {
             get => !string.IsNullOrWhiteSpace(DefaultUserFlow);
+        }
+
+        /// <summary>
+        /// Is considered OIDC generic authority if Instance or Tenant are not defined. 
+        /// Hint to use MSAL's WithOidcAuthority API. Otherwise, WithAuthority API can be used.
+        /// </summary>
+        internal bool IsOidcAuthority // TODO: bogavril - how can we be more explicit here? These options are mutable.
+        {
+            get => string.IsNullOrWhiteSpace(TenantId);
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -602,7 +602,6 @@ namespace Microsoft.Identity.Web
                 var builder = ConfidentialClientApplicationBuilder
                         .CreateWithApplicationOptions(mergedOptions.ConfidentialClientApplicationOptions)
                         .WithHttpClientFactory(_httpClientFactory)
-                        //.WithInstanceDiscovery(false) // TODO: bogavril - disable instance discovery
                         .WithLogging(
                             Log,
                             ConvertMicrosoftExtensionsLogLevelToMsal(_logger),

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -602,6 +602,7 @@ namespace Microsoft.Identity.Web
                 var builder = ConfidentialClientApplicationBuilder
                         .CreateWithApplicationOptions(mergedOptions.ConfidentialClientApplicationOptions)
                         .WithHttpClientFactory(_httpClientFactory)
+                        //.WithInstanceDiscovery(false) // TODO: bogavril - disable instance discovery
                         .WithLogging(
                             Log,
                             ConvertMicrosoftExtensionsLogLevelToMsal(_logger),
@@ -625,6 +626,11 @@ namespace Microsoft.Identity.Web
                 {
                     authority = $"{mergedOptions.Instance}{ClaimConstants.Tfp}/{mergedOptions.Domain}/{mergedOptions.DefaultUserFlow}";
                     builder.WithB2CAuthority(authority);
+                }
+                else if (mergedOptions.IsOidcAuthority)
+                {
+                    authority = mergedOptions.Authority;
+                    builder.WithGenericAuthority(mergedOptions.Authority);
                 }
                 else
                 {

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -34,9 +34,9 @@ namespace Microsoft.Identity.Web
             return authority;
         }
 
-        internal static string? BuildCiamAuthorityIfNeeded(string? authority)
+        internal static string BuildCiamAuthorityIfNeeded(string authority)
         {
-            if (authority != null && authority.Contains(Constants.CiamAuthoritySuffix, StringComparison.OrdinalIgnoreCase))
+            if (authority.Contains(Constants.CiamAuthoritySuffix, StringComparison.OrdinalIgnoreCase))
             {
                 Uri baseUri = new Uri(authority);
                 string host = baseUri.Host;

--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
@@ -191,6 +192,9 @@ namespace Microsoft.Identity.Web
 
                     // This is a Microsoft identity platform web API
                     options.Authority = AuthorityHelpers.EnsureAuthorityIsV2(options.Authority);
+
+                    // TODO: bogavril - hardcoded
+                    options.MetadataAddress = "https://sammyciam.ciamextensibility.com/4710d5e4-43bb-4ff9-89af-30ed8fe31c6d/v2.0/.well-known/openid-configuration?dc=ESTS-PUB-SCUS-LZ1-FD000-TEST1";
 
                     if (options.TokenValidationParameters.AudienceValidator == null
                      && options.TokenValidationParameters.ValidAudience == null


### PR DESCRIPTION
Support for CIAM CUD

Example authority config: 

https://cats.ciamextensibility.com/123456-43bb-4ff9-89af-30ed8fe31c6d/v2.0/.well-known/openid-configuration?DC=test

Work: 

- [x] web app 
- [ ] web api
- [ ] a bunch of TODOs
- [ ] tests

@jmprieur, @jennyf19 - can you please let me know if this is going in the right direction?


Update:

- had to make a fix in MSAL to accept authority with query parameters (branch bogavril/ciamcud), fix already merged to main.
- with this new MSAL, I was able to get token in web app.