### PR TITLE
Replace the user assigned managed identity in tests, by another one

### DIFF
--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -311,7 +311,7 @@ namespace TokenAcquirerTests
             // Arrange
             const string scope = "https://vault.azure.net/.default";
             const string baseUrl = "https://vault.azure.net";
-            const string clientId = "9c5896db-a74a-4b1a-a259-74c5080a3a6a";
+            const string clientId = "5bcd1685-b002-4fd1-8ebd-1ec3e1e4ca4d";
             TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
             IServiceProvider serviceProvider = tokenAcquirerFactory.Build();
 


### PR DESCRIPTION
# Fix User assigned managed identity tests

The user assigned managed identity used in the release builds for the tests has changed.
@jennyf19 we might also want to take this in rel/v2?

running a release build to check the fix.