### PR TITLE
Fix Graph Version Warning

### DIFF
--- a/src/Microsoft.Identity.Web.GraphServiceClient/Microsoft.Identity.Web.GraphServiceClient.csproj
+++ b/src/Microsoft.Identity.Web.GraphServiceClient/Microsoft.Identity.Web.GraphServiceClient.csproj
@@ -13,17 +13,15 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Graph" Version="5.40.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Graph" Version="5.40.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(NetNineRuntimeVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != 'NET8_0_OR_GREATER'">
-    <PackageReference Include="Microsoft.Graph" Version="5.31.0" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Graph" Version="5.40.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Identity.Web.GraphServiceClientBeta/Microsoft.Identity.Web.GraphServiceClientBeta.csproj
+++ b/src/Microsoft.Identity.Web.GraphServiceClientBeta/Microsoft.Identity.Web.GraphServiceClientBeta.csproj
@@ -13,17 +13,15 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Graph.Beta" Version="5.56.0-preview" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Graph.Beta" Version="5.56.0-preview" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(NetNineRuntimeVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != 'NET8_0_OR_GREATER'">
-    <PackageReference Include="Microsoft.Graph.Beta" Version="5.52.0-preview" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Graph.Beta" Version="5.56.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -215,7 +215,13 @@ namespace Microsoft.Identity.Web
             mergedOptions.TimeProvider = microsoftIdentityOptions.TimeProvider;
 #endif
 #if NET9_0_OR_GREATER
-            mergedOptions.AdditionalAuthorizationParameters = microsoftIdentityOptions.AdditionalAuthorizationParameters;
+            if (microsoftIdentityOptions.AdditionalAuthorizationParameters != null)
+            {
+                foreach (var parameter in microsoftIdentityOptions.AdditionalAuthorizationParameters)
+                {
+                    mergedOptions.AdditionalAuthorizationParameters.Add(parameter.Key, parameter.Value);
+                }
+            }
 #endif
             mergedOptions.TokenValidationParameters = microsoftIdentityOptions.TokenValidationParameters.Clone();
             mergedOptions.UsePkce |= microsoftIdentityOptions.UsePkce;

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -536,7 +536,13 @@ namespace Microsoft.Identity.Web
             options.TokenHandler = mergedOptions.TokenHandler;
 #endif
 #if NET9_0_OR_GREATER
-            options.AdditionalAuthorizationParameters = mergedOptions.AdditionalAuthorizationParameters;
+            if (mergedOptions.AdditionalAuthorizationParameters != null)
+            {
+                foreach (var parameter in mergedOptions.AdditionalAuthorizationParameters)
+                {
+                    options.AdditionalAuthorizationParameters.Add(parameter.Key, parameter.Value);
+                }
+            }
 #endif
         }
     }


### PR DESCRIPTION
## Description

Fixes warning NU1504: Duplicate 'PackageReference' items found in Microsoft.Identity.Web.GraphServiceClient.csproj and Microsoft.Identity.Web.GraphServiceClientBeta.csproj post targeting NET9.

Passing build: https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1288661&view=results


Fixes #2748 
