### PR TITLE
Update OwinWebApp DevApp to configure the redirect_uri parameter.

### DIFF
--- a/tests/DevApps/aspnet-mvc/OwinWebApi/OwinWebApi.csproj
+++ b/tests/DevApps/aspnet-mvc/OwinWebApi/OwinWebApi.csproj
@@ -103,9 +103,6 @@
     <Content Include="Views\Shared\_Layout.cshtml" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="App_Data\" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Antlr">
       <Version>3.5.0.2</Version>
     </PackageReference>

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/App_Start/Startup.Auth.cs
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/App_Start/Startup.Auth.cs
@@ -1,13 +1,11 @@
-﻿using Microsoft.Owin.Security;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.OWIN;
+using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
+using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Owin;
-using Microsoft.Identity.Web;
-using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Abstractions;
-using Microsoft.Identity.Web.OWIN;
-using System.Web.Services.Description;
 
 namespace OwinWebApp
 {
@@ -21,7 +19,11 @@ namespace OwinWebApp
 
             OwinTokenAcquirerFactory factory = TokenAcquirerFactory.GetDefaultInstance<OwinTokenAcquirerFactory>();
 
-            app.AddMicrosoftIdentityWebApp(factory);
+            app.AddMicrosoftIdentityWebApp(factory, updateOptions: (options) =>
+            {
+                options.RedirectUri = "https://localhost:44386/";
+            });
+            
             factory.Services
                 .Configure<ConfidentialClientApplicationOptions>(options => { options.RedirectUri = "https://localhost:44386/"; })
                 .AddMicrosoftGraph()

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/OwinWebApp.csproj
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/OwinWebApp.csproj
@@ -136,10 +136,6 @@
     <Content Include="Views\Account\SignOutCallback.cshtml" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="App_Data\" />
-    <Folder Include="Models\" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Antlr">
       <Version>3.5.0.2</Version>
     </PackageReference>


### PR DESCRIPTION
# Update OwinWebApp DevApp to configure the redirect_uri parameter.
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x ] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x ] You've included unit or integration tests for your change, where applicable.
- [x ] You've included inline docs for your change, where applicable.
- [x ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

The redirect_uri parameter is appended to the authorize request while authenticating a user. It is used by the Identity Provider to redirect back to the relying party after the authentication is completed.

The current app implementation seems to suggest that the redirect_uri parameter is configured in the Startup.Auth.cs file already, as part of the ConfidentialClientApplicationOptions. However, this is not the case, this parameter is configured in OpenIdConnectAuthenticationOptions instead.
