### PR TITLE
Use ManagedIdentityCredential instead of DefaultAzureCredential for FIC scenario (PR for ID.Web 3.x)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -105,7 +105,7 @@
     <MicrosoftExtensionsConfigurationBinderVersion>9.0.100-preview.4.24267.66</MicrosoftExtensionsConfigurationBinderVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsDependencyInjectionVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>8.0.0</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>8.0.0</MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>

--- a/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
@@ -45,8 +45,41 @@ namespace Microsoft.Identity.Web
             string? managedIdentityClientId,
             X509KeyStorageFlags x509KeyStorageFlags)
         {
-            Uri keyVaultUri = new Uri(keyVaultUrl);
-            ManagedIdentityCredential credential = new(managedIdentityClientId);
+            Uri keyVaultUri = new(keyVaultUrl);
+
+            bool disableInteractiveCreds = false;
+            var disableInteractiveCredsEnvVar = Environment.GetEnvironmentVariable("IDWEB_DISABLE_INTERACTIVE_AKV_CREDENTIALS");
+
+            if (disableInteractiveCredsEnvVar != null && (disableInteractiveCredsEnvVar == "1" || disableInteractiveCredsEnvVar.Equals("true", StringComparison.OrdinalIgnoreCase)))
+            {
+                disableInteractiveCreds = true;
+            }
+
+            DefaultAzureCredentialOptions options;
+
+            if (disableInteractiveCreds)
+            {
+                options = new DefaultAzureCredentialOptions
+                {
+                    ManagedIdentityClientId = managedIdentityClientId,
+                    ExcludeAzureCliCredential = true,
+                    ExcludeAzureDeveloperCliCredential = true,
+                    ExcludeAzurePowerShellCredential = true,
+                    ExcludeInteractiveBrowserCredential = true,
+                    ExcludeSharedTokenCacheCredential = true,
+                    ExcludeVisualStudioCodeCredential = true,
+                    ExcludeVisualStudioCredential = true
+                };
+            }
+            else
+            {
+                options = new DefaultAzureCredentialOptions
+                {
+                    ManagedIdentityClientId = managedIdentityClientId,
+                };
+            }
+
+            DefaultAzureCredential credential = new(options);
             CertificateClient certificateClient = new(keyVaultUri, credential);
             SecretClient secretClient = new(keyVaultUri, credential);
 

--- a/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
@@ -45,41 +45,8 @@ namespace Microsoft.Identity.Web
             string? managedIdentityClientId,
             X509KeyStorageFlags x509KeyStorageFlags)
         {
-            Uri keyVaultUri = new(keyVaultUrl);
-
-            bool disableInteractiveCreds = false;
-            var disableInteractiveCredsEnvVar = Environment.GetEnvironmentVariable("IDWEB_DISABLE_INTERACTIVE_AKV_CREDENTIALS");
-
-            if (disableInteractiveCredsEnvVar != null && (disableInteractiveCredsEnvVar == "1" || disableInteractiveCredsEnvVar.Equals("true", StringComparison.OrdinalIgnoreCase)))
-            {
-                disableInteractiveCreds = true;
-            }
-
-            DefaultAzureCredentialOptions options;
-
-            if (disableInteractiveCreds)
-            {
-                options = new DefaultAzureCredentialOptions
-                {
-                    ManagedIdentityClientId = managedIdentityClientId,
-                    ExcludeAzureCliCredential = true,
-                    ExcludeAzureDeveloperCliCredential = true,
-                    ExcludeAzurePowerShellCredential = true,
-                    ExcludeInteractiveBrowserCredential = true,
-                    ExcludeSharedTokenCacheCredential = true,
-                    ExcludeVisualStudioCodeCredential = true,
-                    ExcludeVisualStudioCredential = true
-                };
-            }
-            else
-            {
-                options = new DefaultAzureCredentialOptions
-                {
-                    ManagedIdentityClientId = managedIdentityClientId,
-                };
-            }
-
-            DefaultAzureCredential credential = new(options);
+            Uri keyVaultUri = new Uri(keyVaultUrl);
+            ManagedIdentityCredential credential = new(managedIdentityClientId);
             CertificateClient certificateClient = new(keyVaultUri, credential);
             SecretClient secretClient = new(keyVaultUri, credential);
 

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -24,19 +24,7 @@ namespace Microsoft.Identity.Web
         /// <param name="managedIdentityClientId">Optional ClientId of the Managed Identity or Workload Identity</param>
         public ManagedIdentityClientAssertion(string? managedIdentityClientId)
         {
-            _credential = new DefaultAzureCredential(
-                new DefaultAzureCredentialOptions
-                {
-                    ManagedIdentityClientId = managedIdentityClientId,
-                    WorkloadIdentityClientId = managedIdentityClientId,
-                    ExcludeAzureCliCredential = true,
-                    ExcludeAzureDeveloperCliCredential = true,
-                    ExcludeAzurePowerShellCredential = true,
-                    ExcludeInteractiveBrowserCredential = true,
-                    ExcludeSharedTokenCacheCredential = true,
-                    ExcludeVisualStudioCodeCredential = true,
-                    ExcludeVisualStudioCredential = true
-                });
+            _credential = new ManagedIdentityCredential(managedIdentityClientId);
             _tokenExchangeUrl = CertificatelessConstants.DefaultTokenExchangeUrl;
         }
 

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// See https://aka.ms/ms-id-web/certificateless.
         /// </summary>
-        /// <param name="managedIdentityClientId">Optional ClientId of the Managed Identity or Workload Identity</param>
+        /// <param name="managedIdentityClientId">Optional ClientId of the Managed Identity</param>
         public ManagedIdentityClientAssertion(string? managedIdentityClientId)
         {
             _credential = new ManagedIdentityCredential(managedIdentityClientId);
@@ -31,8 +31,8 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// See https://aka.ms/ms-id-web/certificateless.
         /// </summary>
-        /// <param name="managedIdentityClientId">Optional ClientId of the Managed Identity or Workload Identity</param>
-        /// <param name="tokenExchangeUrl">Optional token exchange resource url. Default value is "api://AzureADTokenExchange/.default".</param>
+        /// <param name="managedIdentityClientId">Optional ClientId of the Managed Identity</param>
+        /// <param name="tokenExchangeUrl">Optional audience of the token to be requested from Managed Identity. Default value is "api://AzureADTokenExchange/.default". This value is different on other clouds.</param>
         public ManagedIdentityClientAssertion(string? managedIdentityClientId, string? tokenExchangeUrl) : this (managedIdentityClientId)
         {
             _tokenExchangeUrl = tokenExchangeUrl ?? CertificatelessConstants.DefaultTokenExchangeUrl;
@@ -48,6 +48,7 @@ namespace Microsoft.Identity.Web
             var result = await _credential.GetTokenAsync(
                 new TokenRequestContext([_tokenExchangeUrl], null),
                 assertionRequestOptions?.CancellationToken ?? default).ConfigureAwait(false);
+
             return new ClientAssertion(result.Token, result.ExpiresOn);
         }
     }

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -31,9 +31,7 @@ namespace Microsoft.Identity.Web
                 id = ManagedIdentityId.WithUserAssignedClientId(managedIdentityClientId);
             }
 
-            _managedIdentityApplication = ManagedIdentityApplicationBuilder.Create(id).Build();
-
-
+            _managedIdentityApplication = ManagedIdentityApplicationBuilder.Create(id).Build();           
             _tokenExchangeUrl = CertificatelessConstants.DefaultTokenExchangeUrl;
         }
 
@@ -41,7 +39,8 @@ namespace Microsoft.Identity.Web
         /// See https://aka.ms/ms-id-web/certificateless.
         /// </summary>
         /// <param name="managedIdentityClientId">Optional ClientId of the Managed Identity</param>
-        /// <param name="tokenExchangeUrl">Optional audience of the token to be requested from Managed Identity. Default value is "api://AzureADTokenExchange". This value is different on other clouds.</param>
+        /// <param name="tokenExchangeUrl">Optional audience of the token to be requested from Managed Identity. Default value is "api://AzureADTokenExchange". 
+        /// This value is different on clouds other than Azure Public</param>
         public ManagedIdentityClientAssertion(string? managedIdentityClientId, string? tokenExchangeUrl) : this (managedIdentityClientId)
         {
             _tokenExchangeUrl = tokenExchangeUrl ?? CertificatelessConstants.DefaultTokenExchangeUrl;

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -3,8 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
-using Azure.Identity;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Web.Certificateless;
@@ -25,7 +23,7 @@ namespace Microsoft.Identity.Web
         /// <param name="managedIdentityClientId">Optional ClientId of the Managed Identity</param>
         public ManagedIdentityClientAssertion(string? managedIdentityClientId)
         {
-            ManagedIdentityId id = ManagedIdentityId.SystemAssigned;
+            var id = ManagedIdentityId.SystemAssigned;
             if (!string.IsNullOrEmpty(managedIdentityClientId))
             {
                 id = ManagedIdentityId.WithUserAssignedClientId(managedIdentityClientId);

--- a/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
+++ b/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens " Version="$(IdentityModelVersion)" />

--- a/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
+++ b/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
@@ -14,5 +14,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens " Version="$(IdentityModelVersion)" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Use `ManagedIdentityCredential` instead of `DefaultAzureCredential` for MI scenarios

## Description
For Azure.Identity credential scenarios where Managed Identity is needed, we should use `ManagedIdentityCredential` rather than `DefaultAzureCredential`.

`DefaultAzureCredential` now has more aggressive "fail fast" behavior which could lead to timeouts for token requests.