### PR TITLE
Do not use EphemeralKey on MacOS for loading certs

### DIFF
--- a/src/Microsoft.Identity.Web.Certificate/CertificateDescription.cs
+++ b/src/Microsoft.Identity.Web.Certificate/CertificateDescription.cs
@@ -153,17 +153,10 @@ namespace Microsoft.Identity.Web
             };
         }
 
-#if NET462 || NETSTANDARD2_0
         /// <summary>
         ///  Defines where and how to import the private key of an X.509 certificate.
         /// </summary>
-        public X509KeyStorageFlags X509KeyStorageFlags { get; set; } = X509KeyStorageFlags.MachineKeySet;
-#else
-        /// <summary>
-        ///  Defines where and how to import the private key of an X.509 certificate.
-        /// </summary>
-        public X509KeyStorageFlags X509KeyStorageFlags { get; set; } = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet;
-#endif
+        public X509KeyStorageFlags X509KeyStorageFlags { get; set; } = CertificateLoaderHelper.DetermineX509KeyStorageFlag();
 
         // Should Container and ReferenceOrValue be moved to
         // the tests (As extension methods)

--- a/src/Microsoft.Identity.Web.Certificate/CertificateLoaderHelper.cs
+++ b/src/Microsoft.Identity.Web.Certificate/CertificateLoaderHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Web
 {
     internal sealed class CertificateLoaderHelper
     {
-        private static Lazy<X509KeyStorageFlags> s_x509KeyStorageFlags = 
+        private static Lazy<X509KeyStorageFlags> s_x509KeyStorageFlagsLazy = 
             new Lazy<X509KeyStorageFlags>(DetermineX509KeyStorageFlagLazy);
 
         internal static X509KeyStorageFlags DetermineX509KeyStorageFlag(CredentialDescription credentialDescription)
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Web
         
         internal static X509KeyStorageFlags DetermineX509KeyStorageFlag()
         {
-            return s_x509KeyStorageFlags.Value;
+            return s_x509KeyStorageFlagsLazy.Value;
         }
 
         private static X509KeyStorageFlags DetermineX509KeyStorageFlagLazy()

--- a/src/Microsoft.Identity.Web.Certificate/CertificateLoaderHelper.cs
+++ b/src/Microsoft.Identity.Web.Certificate/CertificateLoaderHelper.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Web.Diagnostics;
 
 namespace Microsoft.Identity.Web
 {
@@ -13,22 +14,30 @@ namespace Microsoft.Identity.Web
     {
         internal static X509KeyStorageFlags DetermineX509KeyStorageFlag(CredentialDescription credentialDescription)
         {
-            X509KeyStorageFlags x509KeyStorageFlags;
-            var credDescription = credentialDescription as CertificateDescription;
-            if (credDescription != null)
+            if (credentialDescription is CertificateDescription credDescription)
             {
-                x509KeyStorageFlags = ((CertificateDescription)credentialDescription).X509KeyStorageFlags;
+                return ((CertificateDescription)credentialDescription).X509KeyStorageFlags;
             }
             else
             {
+                return DetermineX509KeyStorageFlag();
+            }
+        }
+        
+        internal static X509KeyStorageFlags DetermineX509KeyStorageFlag()
+        {
 #if NET462 || NETSTANDARD2_0
-                x509KeyStorageFlags = X509KeyStorageFlags.MachineKeySet;
+            return X509KeyStorageFlags.MachineKeySet;
 #else
-                x509KeyStorageFlags = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet;
-#endif
+            // This is for app developers using MacOS. MacOS does not support the EphemeralKeySet flag.
+            // See https://learn.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography#write-a-pkcs12pfx
+            if (OsHelper.IsMacPlatform())
+            {
+                return X509KeyStorageFlags.DefaultKeySet;
             }
 
-            return x509KeyStorageFlags;
+            return X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet;
+#endif
         }
 
         internal static void ParseStoreLocationAndName(

--- a/src/Microsoft.Identity.Web.Certificate/CertificateLoaderHelper.cs
+++ b/src/Microsoft.Identity.Web.Certificate/CertificateLoaderHelper.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Identity.Web
 {
     internal sealed class CertificateLoaderHelper
     {
+        private static Lazy<X509KeyStorageFlags> s_x509KeyStorageFlags = 
+            new Lazy<X509KeyStorageFlags>(DetermineX509KeyStorageFlagLazy);
+
         internal static X509KeyStorageFlags DetermineX509KeyStorageFlag(CredentialDescription credentialDescription)
         {
             if (credentialDescription is CertificateDescription credDescription)
@@ -26,10 +29,15 @@ namespace Microsoft.Identity.Web
         
         internal static X509KeyStorageFlags DetermineX509KeyStorageFlag()
         {
+            return s_x509KeyStorageFlags.Value;
+        }
+
+        private static X509KeyStorageFlags DetermineX509KeyStorageFlagLazy()
+        {
 #if NET462 || NETSTANDARD2_0
             return X509KeyStorageFlags.MachineKeySet;
 #else
-            // This is for app developers using MacOS. MacOS does not support the EphemeralKeySet flag.
+            // This is for app developers using a Mac. MacOS does not support the EphemeralKeySet flag.
             // See https://learn.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography#write-a-pkcs12pfx
             if (OsHelper.IsMacPlatform())
             {

--- a/src/Microsoft.Identity.Web.Certificate/FromPathCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/FromPathCertificateLoader.cs
@@ -24,17 +24,12 @@ namespace Microsoft.Identity.Web
          string certificateFileName,
          string? password = null)
         {
-#if NET462 || NETSTANDARD2_0
+            X509KeyStorageFlags x509KeyStorageFlags = CertificateLoaderHelper.DetermineX509KeyStorageFlag();
+
             return new X509Certificate2(
                 certificateFileName,
                 password,
-                X509KeyStorageFlags.MachineKeySet);
-#else
-            return new X509Certificate2(
-                certificateFileName,
-                password,
-                X509KeyStorageFlags.EphemeralKeySet);
-#endif
+                x509KeyStorageFlags);
         }
     }
 }

--- a/src/Microsoft.Identity.Web.Diagnostics/OsHelper.cs
+++ b/src/Microsoft.Identity.Web.Diagnostics/OsHelper.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web.Diagnostics
+{
+    internal class OsHelper
+    {
+        /// <summary>
+        ///  Is this a windows platform
+        /// </summary>
+        /// <returns>A  value indicating if we are running on windows or not</returns>
+        internal static bool IsWindowsPlatform()
+        {
+#if NETFRAMEWORK
+            return Environment.OSVersion.Platform == PlatformID.Win32NT;
+#else
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+        }
+
+        /// <summary>
+        /// Is this a MAC platform
+        /// </summary>
+        /// <returns>A value indicating if we are running on mac or not</returns>
+        internal static bool IsMacPlatform()
+        {
+#if NETFRAMEWORK
+            return Environment.OSVersion.Platform == PlatformID.MacOSX;
+#else
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+#endif
+        }
+
+        /// <summary>
+        /// Is this a linux platform
+        /// </summary>
+        /// <returns>A  value indicating if we are running on linux or not</returns>
+        internal static bool IsLinuxPlatform()
+        {
+#if NETFRAMEWORK
+            return Environment.OSVersion.Platform == PlatformID.Unix;
+#else
+            return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
+#endif
+        }
+    }
+}


### PR DESCRIPTION
# do not use EphemeralKey on MacOS for loading certs



Summary of the changes (Less than 80 chars)

- do not use EphemeralKey on MacOS for loading certs. Instead, use the user key. 

## Description

{Detail}

Fixes #1976
