### PR TITLE
Process error AADSTS1000502 - expired certificate

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/Constants.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/Constants.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Identity.Web
         internal const string InvalidKeyError = "AADSTS700027";
         internal const string SignedAssertionInvalidTimeRange = "AADSTS700024";
         internal const string CertificateHasBeenRevoked = "AADSTS7000214";
+        internal const string CertificateIsOutsideValidityWindow = "AADSTS1000502";
         internal const string CiamAuthoritySuffix = ".ciamlogin.com";
         internal const string TestSlice = "dc";
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -585,11 +585,13 @@ namespace Microsoft.Identity.Web
 #if !NETSTANDARD2_0 && !NET462 && !NET472
                 (exMsal.Message.Contains(Constants.InvalidKeyError, StringComparison.OrdinalIgnoreCase)
                 || exMsal.Message.Contains(Constants.SignedAssertionInvalidTimeRange, StringComparison.OrdinalIgnoreCase)
-                || exMsal.Message.Contains(Constants.CertificateHasBeenRevoked, StringComparison.OrdinalIgnoreCase));
+                || exMsal.Message.Contains(Constants.CertificateHasBeenRevoked, StringComparison.OrdinalIgnoreCase)
+                || exMsal.Message.Contains(Constants.CertificateIsOutsideValidityWindow, StringComparison.OrdinalIgnoreCase));
 #else
                 (exMsal.Message.Contains(Constants.InvalidKeyError) 
                 || exMsal.Message.Contains(Constants.SignedAssertionInvalidTimeRange) 
-                || exMsal.Message.Contains(Constants.CertificateHasBeenRevoked));
+                || exMsal.Message.Contains(Constants.CertificateHasBeenRevoked)
+                || exMsal.Message.Contains(Constants.CertificateIsOutsideValidityWindow));
 #endif
         }
         


### PR DESCRIPTION
Add a clause to process the error code for a certificate outside of the validity window.