### PR TITLE
Revert "add queryParams when building authority (#2826)"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,6 @@ Pending Next Release
 - `GraphAuthenticationProvider` checks that the `RequestInformation.URI` is a Graph URI before appending the authorization header, resolving [#2710](https://github.com/AzureAD/microsoft-identity-web/issues/2710). See PR [#2818](https://github.com/AzureAD/microsoft-identity-web/pull/2818) for details.
 - `TokenAcquisition` processes the error code `AADSTS1000502 (The provided certificate is not within its specified validity window)`. See PR [#2840](https://github.com/AzureAD/microsoft-identity-web/pull/2840) for details.
 
-### New features
-- Respect and propagate the query portion when present in the `Authority`, resolving [#2697](https://github.com/AzureAD/microsoft-identity-web/issues/2697). See PR [#2826](https://github.com/AzureAD/microsoft-identity-web/pull/2826) for details.
-
 3.0.0-preview1
 =========
 ### Breaking changes

--- a/src/Microsoft.Identity.Web/AuthorityHelpers.cs
+++ b/src/Microsoft.Identity.Web/AuthorityHelpers.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.Identity.Web
@@ -14,28 +13,25 @@ namespace Microsoft.Identity.Web
             Uri baseUri = new Uri(options.Instance);
             var domain = options.Domain;
             var tenantId = options.TenantId;
-            QueryString queryParams = options.ExtraQueryParameters == null ? QueryString.Empty : QueryString.Create(options.ExtraQueryParameters as IEnumerable<KeyValuePair<string, string?>>);
 
             if (options.IsB2C)
             {
                 var userFlow = options.DefaultUserFlow;
-                return new Uri(baseUri, new PathString($"{baseUri.PathAndQuery}{domain}/{userFlow}/v2.0").Add(queryParams)).ToString();
+                return new Uri(baseUri, new PathString($"{baseUri.PathAndQuery}{domain}/{userFlow}/v2.0")).ToString();
             }
 
-            return new Uri(baseUri, new PathString($"{baseUri.PathAndQuery}{tenantId}/v2.0").Add(queryParams)).ToString();
+            return new Uri(baseUri, new PathString($"{baseUri.PathAndQuery}{tenantId}/v2.0")).ToString();
         }
 
         internal static string EnsureAuthorityIsV2(string authority)
         {
-            int index = authority.LastIndexOf("?", StringComparison.Ordinal);
-            var authorityWithoutQuery = index > 0 ? authority[..index] : authority;
-            authorityWithoutQuery = authorityWithoutQuery.Trim().TrimEnd('/');
+            authority = authority.Trim().TrimEnd('/');
+            if (!authority.EndsWith("v2.0", StringComparison.Ordinal))
+            {
+                authority += "/v2.0";
+            }
 
-            if (!authorityWithoutQuery.EndsWith("v2.0", StringComparison.Ordinal))
-                authorityWithoutQuery += "/v2.0";
-
-            var query = index > 0 ? authority[index..] : string.Empty;
-            return authorityWithoutQuery + query;
+            return authority;
         }
 
         internal static string? BuildCiamAuthorityIfNeeded(string authority, out bool preserveAuthority)

--- a/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthorityHelpersTests.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.Test.Common;
 using Xunit;
 
@@ -100,72 +99,6 @@ namespace Microsoft.Identity.Web.Test
             Assert.True(preserveAuthority);
         }
 
-        [Fact]
-        public void BuildAuthority_WithQueryParams_ReturnsValidAadAuthority()
-        {
-            // arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
-            {
-                TenantId = TestConstants.TenantIdAsGuid,
-                Instance = TestConstants.AadInstance,
-                ExtraQueryParameters = new Dictionary <string, string>
-                {
-                    { "queryParam1", "value1" },
-                    { "queryParam2", "value2" },
-                }
-            };
-            var expectedQuery = QueryString.Create(options.ExtraQueryParameters as IEnumerable<KeyValuePair<string, string?>>);
-            string expectedResult = $"{options.Instance}/{options.TenantId}/v2.0{expectedQuery}";
-
-            // act
-            string result = AuthorityHelpers.BuildAuthority(options);
-            
-            // assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedResult, result);
-        }
-
-        [Fact]
-        public void BuildAuthority_EmptyQueryParams_ReturnsValidAadAuthority()
-        {
-            // arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
-            {
-                TenantId = TestConstants.TenantIdAsGuid,
-                Instance = TestConstants.AadInstance,
-                ExtraQueryParameters = new Dictionary<string, string>()
-            };
-
-            string expectedResult = $"{options.Instance}/{options.TenantId}/v2.0";
-
-            // act
-            string result = AuthorityHelpers.BuildAuthority(options);
-
-            // assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedResult, result);
-        }
-
-        [Fact]
-        public void BuildAuthority_NullQueryParams_ReturnsValidAadAuthority()
-        {
-            // arrange
-            MicrosoftIdentityOptions options = new MicrosoftIdentityOptions
-            {
-                TenantId = TestConstants.TenantIdAsGuid,
-                Instance = TestConstants.AadInstance,
-                ExtraQueryParameters = null
-            };
-            string expectedResult = $"{options.Instance}/{options.TenantId}/v2.0";
-
-            // act
-            string result = AuthorityHelpers.BuildAuthority(options);
-
-            // assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedResult, result);
-        }
-
         [Theory]
         [InlineData(TestConstants.AuthorityCommonTenant, TestConstants.AuthorityCommonTenantWithV2)]
         [InlineData(TestConstants.AuthorityOrganizationsUSTenant, TestConstants.AuthorityOrganizationsUSWithV2)]
@@ -175,30 +108,6 @@ namespace Microsoft.Identity.Web.Test
         [InlineData(TestConstants.B2CCustomDomainAuthorityWithV2, TestConstants.B2CCustomDomainAuthorityWithV2)]
         [InlineData(TestConstants.B2CAuthority, TestConstants.B2CAuthorityWithV2)]
         [InlineData(TestConstants.B2CCustomDomainAuthority, TestConstants.B2CCustomDomainAuthorityWithV2)]
-        [InlineData(TestConstants.AuthorityCommonTenant + "?key1=value1", TestConstants.AuthorityCommonTenantWithV2 + "?key1=value1")]
-        [InlineData(TestConstants.AuthorityCommonTenant + "?key1=value1&key2=value2", TestConstants.AuthorityCommonTenantWithV2 + "?key1=value1&key2=value2")]
-        [InlineData(TestConstants.AuthorityCommonTenant + "?", TestConstants.AuthorityCommonTenantWithV2 + "?")]
-        [InlineData(TestConstants.AuthorityOrganizationsUSTenant + "?key1=value1", TestConstants.AuthorityOrganizationsUSWithV2 + "?key1=value1")]
-        [InlineData(TestConstants.AuthorityOrganizationsUSTenant + "?key1=value1&key2=value2", TestConstants.AuthorityOrganizationsUSWithV2 + "?key1=value1&key2=value2")]
-        [InlineData(TestConstants.AuthorityOrganizationsUSTenant + "?", TestConstants.AuthorityOrganizationsUSWithV2 + "?")]
-        [InlineData(TestConstants.AuthorityCommonTenantWithV2 + "?key1=value1", TestConstants.AuthorityCommonTenantWithV2 + "?key1=value1")]
-        [InlineData(TestConstants.AuthorityCommonTenantWithV2 + "?key1=value1&key2=value2", TestConstants.AuthorityCommonTenantWithV2 + "?key1=value1&key2=value2")]
-        [InlineData(TestConstants.AuthorityCommonTenantWithV2 + "?", TestConstants.AuthorityCommonTenantWithV2 + "?")]
-        [InlineData(TestConstants.AuthorityCommonTenantWithV2 + "/" + "?key1=value1", TestConstants.AuthorityCommonTenantWithV2 + "?key1=value1")]
-        [InlineData(TestConstants.AuthorityCommonTenantWithV2 + "/" + "?key1=value1&key2=value2", TestConstants.AuthorityCommonTenantWithV2 + "?key1=value1&key2=value2")]
-        [InlineData(TestConstants.AuthorityCommonTenantWithV2 + "/" + "?", TestConstants.AuthorityCommonTenantWithV2 + "?")]
-        [InlineData(TestConstants.B2CAuthorityWithV2 + "?key1=value1", TestConstants.B2CAuthorityWithV2 + "?key1=value1")]
-        [InlineData(TestConstants.B2CAuthorityWithV2 + "?key1=value1&key2=value2", TestConstants.B2CAuthorityWithV2 + "?key1=value1&key2=value2")]
-        [InlineData(TestConstants.B2CAuthorityWithV2 + "?", TestConstants.B2CAuthorityWithV2 + "?")]
-        [InlineData(TestConstants.B2CCustomDomainAuthorityWithV2 + "?key1=value1", TestConstants.B2CCustomDomainAuthorityWithV2 + "?key1=value1")]
-        [InlineData(TestConstants.B2CCustomDomainAuthorityWithV2 + "?key1=value1&key2=value2", TestConstants.B2CCustomDomainAuthorityWithV2 + "?key1=value1&key2=value2")]
-        [InlineData(TestConstants.B2CCustomDomainAuthorityWithV2 + "?", TestConstants.B2CCustomDomainAuthorityWithV2 + "?")]
-        [InlineData(TestConstants.B2CAuthority + "?key1=value1", TestConstants.B2CAuthorityWithV2 + "?key1=value1")]
-        [InlineData(TestConstants.B2CAuthority + "?key1=value1&key2=value2", TestConstants.B2CAuthorityWithV2 + "?key1=value1&key2=value2")]
-        [InlineData(TestConstants.B2CAuthority + "?", TestConstants.B2CAuthorityWithV2 + "?")]
-        [InlineData(TestConstants.B2CCustomDomainAuthority + "?key1=value1", TestConstants.B2CCustomDomainAuthorityWithV2 + "?key1=value1")]
-        [InlineData(TestConstants.B2CCustomDomainAuthority + "?key1=value1&key2=value2", TestConstants.B2CCustomDomainAuthorityWithV2 + "?key1=value1&key2=value2")]
-        [InlineData(TestConstants.B2CCustomDomainAuthority + "?", TestConstants.B2CCustomDomainAuthorityWithV2 + "?")]
         public void EnsureAuthorityIsV2(string initialAuthority, string expectedAuthority)
         {
             OpenIdConnectOptions options = new OpenIdConnectOptions


### PR DESCRIPTION
The purpose of the issue #2697 was to respect user-provided query params. The goal is to actually parse the query params from options.Authority into options.ExtraQueryParams, rather than add options.ExtraQueryParams to the authority.