### PR TITLE
Use named http client for dSTS

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/MsalAspNetCoreHttpClientFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MsalAspNetCoreHttpClientFactory.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Identity.Web
 
         public HttpClient GetHttpClient()
         {
-            HttpClient httpClient = _httpClientFactory.CreateClient();
+            // The HttpClient will be created with the name of the client registered in the DI container
+            // If the named client(dSTS) is not found, the factory will fall back to the default client
+            HttpClient httpClient = _httpClientFactory.CreateClient("dSTS");
             httpClient.DefaultRequestHeaders.Add(Constants.TelemetryHeaderKey, IdHelper.CreateTelemetryInfo());
             return httpClient;
         }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MsalAspNetCoreHttpClientFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MsalAspNetCoreHttpClientFactory.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Identity.Web
 
         public HttpClient GetHttpClient()
         {
-            // The HttpClient will be created with the name of the client registered in the DI container
-            // If the named client(dSTS) is not found, the factory will fall back to the default client
-            HttpClient httpClient = _httpClientFactory.CreateClient("dSTS");
+            // The HttpClient will be created with the named client registered in the DI container
+            // If the named client is not found, the factory will fall back to the default client
+            HttpClient httpClient = _httpClientFactory.CreateClient("token_acquisition_httpclient");
             httpClient.DefaultRequestHeaders.Add(Constants.TelemetryHeaderKey, IdHelper.CreateTelemetryInfo());
             return httpClient;
         }


### PR DESCRIPTION
Use named client for token acquistion propose to prefer IPv6 address.

Design doc:
https://microsoft.sharepoint.com/:w:/t/aad/devex/ERmovf1YilVOhNwNSKOWyeoBCumEwCaDiY-O0YIzv9i7oQ?e=6TfbRC&wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1715629585046&web=1

Spec: 
https://learn.microsoft.com/en-us/dotnet/api/system.net.http.ihttpclientfactory.createclient?view=net-8.0

IHttpClientFactory is guaranteed to return a new HttpClient if named http client is not registered.
The extension to add named client won't affect the current behaviour.