### PR TITLE
Fix metadata address creation when using AddMicrosoftIdentityWebApp

### DIFF
--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Identity.Web
                         mergedOptions.PreserveAuthority = preserveAuthority;
                         if (mergedOptions.ExtraQueryParameters != null)
                         {
-                            options.MetadataAddress = mergedOptions.Authority + "/.well-known/openid-configuration?" + string.Join("&", mergedOptions.ExtraQueryParameters.Select(p => $"{p.Key}={p.Value}"));
+                            mergedOptions.MetadataAddress = mergedOptions.Authority + "/.well-known/openid-configuration?" + string.Join("&", mergedOptions.ExtraQueryParameters.Select(p => $"{p.Key}={p.Value}"));
                         }
                     }
 


### PR DESCRIPTION
# Fix metadata address creation when using AddMicrosoftIdentityWebApp

Altered how the metadataAddress is set to prevent overwriting the correct value.

Fixes #2752
