### PR TITLE
Implements GetAuthorizationHeaderAsync to support 1P specific scenarios

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -86,7 +86,7 @@
     <MicrosoftGraphVersion>4.36.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
     <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
-    <MicrosoftIdentityAbstractions>5.3.0</MicrosoftIdentityAbstractions>    
+    <MicrosoftIdentityAbstractions>5.4.0-preview3-HeaderProvider</MicrosoftIdentityAbstractions>    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!--This should be passed from the VSTS build-->
     <!-- This needs to be greater than or equal to the validation baseline version -->
-    <ClientSemVer Condition="'$(ClientSemVer)' == ''">2.20.2-localbuild</ClientSemVer>
+    <ClientSemVer Condition="'$(ClientSemVer)' == ''">2.20.3-localbuild</ClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(ClientSemVer)</Version>
 
@@ -86,7 +86,7 @@
     <MicrosoftGraphVersion>4.36.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
     <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
-    <MicrosoftIdentityAbstractions>6.0.0-preview1-headerprovider</MicrosoftIdentityAbstractions>    
+    <MicrosoftIdentityAbstractions>6.0.0</MicrosoftIdentityAbstractions>    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!--This should be passed from the VSTS build-->
     <!-- This needs to be greater than or equal to the validation baseline version -->
-    <ClientSemVer Condition="'$(ClientSemVer)' == ''">2.16.0-localbuild</ClientSemVer>
+    <ClientSemVer Condition="'$(ClientSemVer)' == ''">2.20.2-localbuild</ClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(ClientSemVer)</Version>
 
@@ -86,7 +86,7 @@
     <MicrosoftGraphVersion>4.36.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
     <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
-    <MicrosoftIdentityAbstractions>5.4.0-preview3-HeaderProvider</MicrosoftIdentityAbstractions>    
+    <MicrosoftIdentityAbstractions>6.0.0-preview1-headerprovider</MicrosoftIdentityAbstractions>    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/benchmark/TokenAcquisitionBenchmark.cs
+++ b/benchmark/TokenAcquisitionBenchmark.cs
@@ -5,8 +5,6 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Web;
-using BenchmarkDotNet.Diagnostics.Windows;
-using BenchmarkDotNet.Diagnostics.Windows.Configs;
 
 namespace Benchmarks
 {
@@ -40,7 +38,7 @@ namespace Benchmarks
         {
             // Get the authorization request creator service
             IAuthorizationHeaderProvider authorizationHeaderProvider = s_serviceProvider!.GetRequiredService<IAuthorizationHeaderProvider>();
-            await authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync("https://graph.microsoft.com/.default");
+            await authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync("https://graph.microsoft.com/.default").ConfigureAwait(false);
         }
 
         [Benchmark]

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Identity.Web
             // which is done by not specifying any scopes
             if (effectiveOptions.Scopes != null && effectiveOptions.Scopes.Any())
             {
-                string? authorizationHeader = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync(
+                string authorizationHeader = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync(
                        effectiveOptions.Scopes,
                        effectiveOptions,
                        user,

--- a/src/Microsoft.Identity.Web.TokenAcquisition/BaseAuthorizationHeaderProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/BaseAuthorizationHeaderProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Web.Extensibility
     /// Base class for custom implementations of <see cref="IAuthorizationHeaderProvider"/> that
     /// would still want to leverage the default implementation for the bearer and Pop protocols.
     /// </summary>
-    public class BaseAuthorizationHeaderProvider : IAuthorizationHeaderProvider, IAuthorizationHeaderProviderExtension
+    public class BaseAuthorizationHeaderProvider : IAuthorizationHeaderProvider
     {
         /// <summary>
         /// Constructor from a service provider
@@ -28,13 +28,9 @@ namespace Microsoft.Identity.Web.Extensibility
             // is an implementation detail.
             var _tokenAcquisition = serviceProvider.GetRequiredService<ITokenAcquisition>();
             _headerProvider = new DefaultAuthorizationHeaderProvider(_tokenAcquisition);
-            _headerProviderExtension = _headerProvider as IAuthorizationHeaderProviderExtension 
-                ?? throw new InvalidOperationException("The default implementation of IAuthorizationHeaderProvider does not implement IAuthorizationHeaderProviderExtension.");
-
         }
 
         private readonly IAuthorizationHeaderProvider _headerProvider;
-        private readonly IAuthorizationHeaderProviderExtension _headerProviderExtension;
 
         /// <inheritdoc/>
         public virtual Task<string> CreateAuthorizationHeaderForUserAsync(IEnumerable<string> scopes, AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, ClaimsPrincipal? claimsPrincipal = null, CancellationToken cancellationToken = default)
@@ -50,13 +46,16 @@ namespace Microsoft.Identity.Web.Extensibility
 
         /// <inheritdoc/>
         public virtual Task<string> CreateAuthorizationHeaderAsync(
-            RequestContext requestContext,
             IEnumerable<string> scopes, 
             AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, 
             ClaimsPrincipal? claimsPrincipal = null, 
             CancellationToken cancellationToken = default)
         {
-            return _headerProviderExtension.CreateAuthorizationHeaderAsync(requestContext, scopes, authorizationHeaderProviderOptions, claimsPrincipal, cancellationToken);
+            return _headerProvider.CreateAuthorizationHeaderAsync(
+                scopes, 
+                authorizationHeaderProviderOptions, 
+                claimsPrincipal, 
+                cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/BaseAuthorizationHeaderProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/BaseAuthorizationHeaderProvider.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,7 +15,7 @@ namespace Microsoft.Identity.Web.Extensibility
     /// Base class for custom implementations of <see cref="IAuthorizationHeaderProvider"/> that
     /// would still want to leverage the default implementation for the bearer and Pop protocols.
     /// </summary>
-    public class BaseAuthorizationHeaderProvider : IAuthorizationHeaderProvider
+    public class BaseAuthorizationHeaderProvider : IAuthorizationHeaderProvider, IAuthorizationHeaderProviderExtension
     {
         /// <summary>
         /// Constructor from a service provider
@@ -29,21 +27,36 @@ namespace Microsoft.Identity.Web.Extensibility
             // in the public API as it's going to be deprecated in future versions of IdWeb. Here this
             // is an implementation detail.
             var _tokenAcquisition = serviceProvider.GetRequiredService<ITokenAcquisition>();
-            implementation = new DefaultAuthorizationHeaderProvider(_tokenAcquisition);
+            _headerProvider = new DefaultAuthorizationHeaderProvider(_tokenAcquisition);
+            _headerProviderExtension = _headerProvider as IAuthorizationHeaderProviderExtension 
+                ?? throw new InvalidOperationException("The default implementation of IAuthorizationHeaderProvider does not implement IAuthorizationHeaderProviderExtension.");
+
         }
 
-        private IAuthorizationHeaderProvider implementation;
+        private readonly IAuthorizationHeaderProvider _headerProvider;
+        private readonly IAuthorizationHeaderProviderExtension _headerProviderExtension;
 
         /// <inheritdoc/>
         public virtual Task<string> CreateAuthorizationHeaderForUserAsync(IEnumerable<string> scopes, AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, ClaimsPrincipal? claimsPrincipal = null, CancellationToken cancellationToken = default)
         {
-            return implementation.CreateAuthorizationHeaderForUserAsync(scopes, authorizationHeaderProviderOptions, claimsPrincipal, cancellationToken);
+            return _headerProvider.CreateAuthorizationHeaderForUserAsync(scopes, authorizationHeaderProviderOptions, claimsPrincipal, cancellationToken);
         }
 
         /// <inheritdoc/>
         public virtual Task<string> CreateAuthorizationHeaderForAppAsync(string scopes, AuthorizationHeaderProviderOptions? downstreamApiOptions = null, CancellationToken cancellationToken = default)
         {
-            return implementation.CreateAuthorizationHeaderForAppAsync(scopes, downstreamApiOptions, cancellationToken);
+            return _headerProvider.CreateAuthorizationHeaderForAppAsync(scopes, downstreamApiOptions, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public virtual Task<string> CreateAuthorizationHeaderAsync(
+            RequestContext requestContext,
+            IEnumerable<string> scopes, 
+            AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, 
+            ClaimsPrincipal? claimsPrincipal = null, 
+            CancellationToken cancellationToken = default)
+        {
+            return _headerProviderExtension.CreateAuthorizationHeaderAsync(requestContext, scopes, authorizationHeaderProviderOptions, claimsPrincipal, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Web
             if (downstreamApiOptions != null && downstreamApiOptions.RequestAppToken)
             {
                 result = await _tokenAcquisition.GetAuthenticationResultForAppAsync(
-                    scopes.First(),
+                    scopes.FirstOrDefault()!,
                     downstreamApiOptions?.AcquireTokenOptions.AuthenticationOptionsName,
                     downstreamApiOptions?.AcquireTokenOptions.Tenant,
                     CreateTokenAcquisitionOptionsFromApiOptions(downstreamApiOptions, cancellationToken)).ConfigureAwait(false);

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -4,12 +4,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Graph;
@@ -426,6 +424,9 @@ namespace TokenAcquirerTests
             string result = await api.CreateAuthorizationHeaderForAppAsync(scope, GetAuthHeaderOptions_ManagedId(baseUrl, clientId));
 
             // Assert: Make sure we got a token
+            Assert.False(string.IsNullOrEmpty(result));
+
+            result = await api.CreateAuthorizationHeaderAsync([scope], GetAuthHeaderOptions_ManagedId(baseUrl, clientId));
             Assert.False(string.IsNullOrEmpty(result));
         }
 

--- a/tests/Microsoft.Identity.Web.Test/BaseAuthorizationHeaderProviderTest.cs
+++ b/tests/Microsoft.Identity.Web.Test/BaseAuthorizationHeaderProviderTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Web.Test
             public override Task<string> CreateAuthorizationHeaderForAppAsync(string scopes, AuthorizationHeaderProviderOptions? downstreamApiOptions = null, CancellationToken cancellationToken = default)
             {
                 if (downstreamApiOptions?.ProtocolScheme == "Custom")
-                    return Task.FromResult("Custom");
+                    return Task.FromResult("CustomHeaderForApp");
                 else
                     return base.CreateAuthorizationHeaderForAppAsync(scopes, downstreamApiOptions, cancellationToken);
             }
@@ -40,9 +40,19 @@ namespace Microsoft.Identity.Web.Test
             public override Task<string> CreateAuthorizationHeaderForUserAsync(IEnumerable<string> scopes, AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, ClaimsPrincipal? claimsPrincipal = null, CancellationToken cancellationToken = default)
             {
                 if (authorizationHeaderProviderOptions?.ProtocolScheme == "Custom")
-                    return Task.FromResult("Custom");
+                    return Task.FromResult("CustomHeaderForUser");
                 else
                     return base.CreateAuthorizationHeaderForUserAsync(scopes, authorizationHeaderProviderOptions, claimsPrincipal, cancellationToken);
+            }
+
+            public override Task<string> CreateAuthorizationHeaderAsync(IEnumerable<string> scopes, AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, ClaimsPrincipal? claimsPrincipal = null, CancellationToken cancellationToken = default)
+            {
+                if (claimsPrincipal == null && authorizationHeaderProviderOptions?.ProtocolScheme == "Custom")
+                    return Task.FromResult("CustomHeaderForApp");
+                else if (claimsPrincipal != null && authorizationHeaderProviderOptions?.ProtocolScheme == "Custom")
+                    return Task.FromResult("CustomHeaderForUser");
+                else
+                    return base.CreateAuthorizationHeaderAsync(scopes, authorizationHeaderProviderOptions, claimsPrincipal, cancellationToken);
             }
         }
 
@@ -107,13 +117,31 @@ namespace Microsoft.Identity.Web.Test
             var serviceProvider = tokenAcquirerFactory.Build();
 
             IAuthorizationHeaderProvider authorizationHeaderProvider = serviceProvider.GetRequiredService<IAuthorizationHeaderProvider>();
+            
+            // test acquiring a header on behalf of a user
             string result = await authorizationHeaderProvider.CreateAuthorizationHeaderForUserAsync(["scope"],
-                new AuthorizationHeaderProviderOptions { ProtocolScheme = "Custom" }, null, CancellationToken.None);
-            Assert.Equal("Custom", result);
+                new AuthorizationHeaderProviderOptions { ProtocolScheme = "Custom" }, new ClaimsPrincipal(), CancellationToken.None);
+            Assert.Equal("CustomHeaderForUser", result);
 
             result = await authorizationHeaderProvider.CreateAuthorizationHeaderForUserAsync(["scope"],
-                new AuthorizationHeaderProviderOptions { }, null, CancellationToken.None);
+                new AuthorizationHeaderProviderOptions { }, new ClaimsPrincipal(), CancellationToken.None);
             Assert.Equal("Bearer eXY", result);
+
+            result = await authorizationHeaderProvider.CreateAuthorizationHeaderAsync(["scope"],
+                new AuthorizationHeaderProviderOptions { ProtocolScheme = "Custom" }, new ClaimsPrincipal(), CancellationToken.None);
+            Assert.Equal("CustomHeaderForUser", result);
+
+            TokenAcquirerFactory.ResetDefaultInstance(); // Test only
+
+            // test acquiring a header on behalf of an app
+            result = await authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync("scope",
+                new AuthorizationHeaderProviderOptions { ProtocolScheme = "Custom" }, CancellationToken.None);
+            Assert.Equal("CustomHeaderForApp", result);
+
+            result = await authorizationHeaderProvider.CreateAuthorizationHeaderAsync(["scope"],
+                new AuthorizationHeaderProviderOptions { ProtocolScheme = "Custom" }, null, CancellationToken.None);
+            Assert.Equal("CustomHeaderForApp", result);
+
             TokenAcquirerFactory.ResetDefaultInstance(); // Test only
         }
     }

--- a/tests/Microsoft.Identity.Web.Test/DownstreamWebApiSupport/CaeTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/DownstreamWebApiSupport/CaeTests.cs
@@ -45,9 +45,9 @@ namespace Microsoft.Identity.Web.Test.DownstreamWebApiSupport
 
             var appVal = await _downstreamApi.GetForAppAsync<EmptyClass>("GraphApp");
 
-            await _authorizationHeaderProvider.ReceivedWithAnyArgs(2).CreateAuthorizationHeaderForAppAsync(string.Empty);
-            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderForAppAsync(
-                Arg.Any<string>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims!.Equals(ParsedClaims, StringComparison.Ordinal)));
+            await _authorizationHeaderProvider.ReceivedWithAnyArgs(2).CreateAuthorizationHeaderAsync(Enumerable.Empty<string>());
+            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderAsync(
+                Arg.Any<IEnumerable<string>>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims!.Equals(ParsedClaims, StringComparison.Ordinal)));
         }
 
         [Fact]
@@ -61,8 +61,8 @@ namespace Microsoft.Identity.Web.Test.DownstreamWebApiSupport
 
             var userVal = await _downstreamApi.GetForUserAsync<EmptyClass>("GraphUser");
 
-            await _authorizationHeaderProvider.ReceivedWithAnyArgs(2).CreateAuthorizationHeaderForUserAsync(Enumerable.Empty<string>());
-            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderForUserAsync(
+            await _authorizationHeaderProvider.ReceivedWithAnyArgs(2).CreateAuthorizationHeaderAsync(Enumerable.Empty<string>());
+            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderAsync(
                 Arg.Any<IEnumerable<string>>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims!.Equals(ParsedClaims, StringComparison.Ordinal)));
         }
 
@@ -77,9 +77,9 @@ namespace Microsoft.Identity.Web.Test.DownstreamWebApiSupport
 
             var appVal = await _downstreamApi.GetForAppAsync<EmptyClass>("GraphApp");
 
-            await _authorizationHeaderProvider.ReceivedWithAnyArgs(1).CreateAuthorizationHeaderForAppAsync(string.Empty);
-            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderForAppAsync(
-                Arg.Any<string>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims == null));
+            await _authorizationHeaderProvider.ReceivedWithAnyArgs(1).CreateAuthorizationHeaderAsync(Enumerable.Empty<string>());
+            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderAsync(
+               Arg.Any<IEnumerable<string>>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims == null));
         }
 
         [Fact]
@@ -93,8 +93,8 @@ namespace Microsoft.Identity.Web.Test.DownstreamWebApiSupport
 
             var userVal = await _downstreamApi.GetForUserAsync<EmptyClass>("GraphUser");
 
-            await _authorizationHeaderProvider.ReceivedWithAnyArgs(1).CreateAuthorizationHeaderForUserAsync(Enumerable.Empty<string>());
-            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderForUserAsync(
+            await _authorizationHeaderProvider.ReceivedWithAnyArgs(1).CreateAuthorizationHeaderAsync(Enumerable.Empty<string>());
+            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderAsync(
                 Arg.Any<IEnumerable<string>>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims == null));
         }
 
@@ -109,9 +109,9 @@ namespace Microsoft.Identity.Web.Test.DownstreamWebApiSupport
 
             await Assert.ThrowsAsync<HttpRequestException>(() => _downstreamApi.GetForAppAsync<EmptyClass>("GraphApp"));
 
-            await _authorizationHeaderProvider.ReceivedWithAnyArgs(1).CreateAuthorizationHeaderForAppAsync(string.Empty);
-            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderForAppAsync(
-                Arg.Any<string>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims == null));
+            await _authorizationHeaderProvider.ReceivedWithAnyArgs(1).CreateAuthorizationHeaderAsync(Enumerable.Empty<string>());
+            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderAsync(
+                Arg.Any<IEnumerable<string>>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims == null));
         }
 
         [Fact]
@@ -125,8 +125,8 @@ namespace Microsoft.Identity.Web.Test.DownstreamWebApiSupport
 
             await Assert.ThrowsAsync<HttpRequestException>(() => _downstreamApi.GetForUserAsync<EmptyClass>("GraphUser"));
 
-            await _authorizationHeaderProvider.ReceivedWithAnyArgs(1).CreateAuthorizationHeaderForUserAsync(Enumerable.Empty<string>());
-            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderForUserAsync(
+            await _authorizationHeaderProvider.ReceivedWithAnyArgs(1).CreateAuthorizationHeaderAsync(Enumerable.Empty<string>());
+            await _authorizationHeaderProvider.Received().CreateAuthorizationHeaderAsync(
                 Arg.Any<IEnumerable<string>>(), Arg.Is<DownstreamApiOptions>(o => o.AcquireTokenOptions.Claims == null));
         }
 
@@ -135,6 +135,7 @@ namespace Microsoft.Identity.Web.Test.DownstreamWebApiSupport
             _authorizationHeaderProvider = Substitute.For<IAuthorizationHeaderProvider>();
             _authorizationHeaderProvider.CreateAuthorizationHeaderForAppAsync(string.Empty).ReturnsForAnyArgs("Bearer eyJhY2Nlc3NfdG9rZW4iOg==");
             _authorizationHeaderProvider.CreateAuthorizationHeaderForUserAsync(Enumerable.Empty<string>()).ReturnsForAnyArgs("Bearer eyJhY2Nlc3NfdG9rZW4iOg==");
+            _authorizationHeaderProvider.CreateAuthorizationHeaderAsync(Enumerable.Empty<string>()).ReturnsForAnyArgs("Bearer eyJhY2Nlc3NfdG9rZW4iOg==");
 
             var httpMessageHandler = new QueueHttpMessageHandler();
 


### PR DESCRIPTION
What?
- Implements IAuthorizationHeaderProvider.GetAuthorizationHeaderAsync in DefaultAuthorizationHeaderProvider
- Updates DownstreamApi, MicrosoftGraph, GraphServiceClient and BaseAuthorizationHeaderProvider to use the new higher level API that can create a header for on-behalf-of an app or user instead of separate APIs (GetAuthorizationHeaderForAppAsync and GetAuthorizationHeaderForUserAsync). There is no change to the existing DevEx.
- Adds ConfigureAwait which was previously missing for some async calls

Why?
This is being done to accommodate 1P specific protocols.