### PR TITLE
Make MicrosoftIdentityWebAppAuthenticationBuilder's OpenIdConnectScheme publicly gettable

### DIFF
--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
@@ -46,7 +46,10 @@ namespace Microsoft.Identity.Web
 
         private Action<MicrosoftIdentityOptions> ConfigureMicrosoftIdentityOptions { get; set; }
 
-        private string OpenIdConnectScheme { get; set; }
+        /// <summary>
+        /// The OpenID Connect scheme name to be used.
+        /// </summary>
+        public string OpenIdConnectScheme { get; private set; }
 
         /// <summary>
         /// The web app calls a web API.


### PR DESCRIPTION
# Make MicrosoftIdentityWebAppAuthenticationBuilder's OpenIdConnectScheme publicly gettable<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Makes `MicrosoftIdentityWebAppAuthenticationBuilder` extensible by users by giving its `OpenIdConnectScheme` property a public getter.

## Description

The following changes:

```cs
private string OpenIdConnectScheme { get; set; }
```

becomes

```cs
public string OpenIdConnectScheme { get; private set; }
```

Fixes #2638