### PR TITLE
Fix 2912

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Web
             // await authorizationHeaderProvider.CreateAuthorizationHeaderAsync(
             //  new [] { "https://graph.microsoft.com/.default" },
             //  new AuthorizationHeaderProviderOptions { RequestAppToken = true }).ConfigureAwait(false);
-            if (downstreamApiOptions != null && downstreamApiOptions.RequestAppToken)
+            if (downstreamApiOptions != null && (downstreamApiOptions.RequestAppToken || downstreamApiOptions.AcquireTokenOptions?.ManagedIdentity != null))
             {
                 result = await _tokenAcquisition.GetAuthenticationResultForAppAsync(
                     scopes.FirstOrDefault()!,


### PR DESCRIPTION
# Fix 2912

Add a case to of the changes (Less than 80 chars)

## Description

CreateAuthorizationHeaderAsync now tests the presence of the managed identity in the authorizationHeaderProviderOptions in addition to the presence of RequestAppToken to decide to call CreateAuthorizationHeaderForAppAsync

Fixes #2912
The test already exists and is one of the tests failing in the release build (it's managed identity, so not testable locally). but this was hidden by other failures.