### PR TITLE
Fix AT POP tests

### DIFF
--- a/tests/Microsoft.Identity.Web.Test.Common/Mocks/MockHttpClientFactory.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/Mocks/MockHttpClientFactory.cs
@@ -17,26 +17,6 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
     /// </summary>
     public class MockHttpClientFactory : IMsalHttpClientFactory, IDisposable
     {
-        // MSAL will statically cache instance discovery, so we need to add 
-        private static bool s_instanceDiscoveryAdded = false;
-        private static object s_instanceDiscoveryLock = new object();
-
-        public MockHttpClientFactory()
-        {
-            // Auto-add instance discovery call, but only once per process
-            if (!s_instanceDiscoveryAdded)
-            {
-                lock (s_instanceDiscoveryLock)
-                {
-                    if (!s_instanceDiscoveryAdded)
-                    {
-                        _httpMessageHandlerQueue.Enqueue(MockHttpCreator.CreateInstanceDiscoveryMockHandler());
-                        s_instanceDiscoveryAdded = true;
-                    }
-                }
-            }
-        }
-
         /// <inheritdoc />
         public void Dispose()
         {
@@ -66,8 +46,6 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
 
         public HttpClient GetHttpClient()
         {
-          
-                
             HttpMessageHandler messageHandler;
 
             Assert.NotEmpty(_httpMessageHandlerQueue);

--- a/tests/Microsoft.Identity.Web.Test.Common/Mocks/MockHttpMessageHandler.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/Mocks/MockHttpMessageHandler.cs
@@ -15,13 +15,12 @@ namespace Microsoft.Identity.Web.Test.Common.Mocks
     {
         public Func<MockHttpMessageHandler, MockHttpMessageHandler> ReplaceMockHttpMessageHandler;
 
-        private readonly bool _ignoreInstanceDiscovery;
-
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public MockHttpMessageHandler()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
         }
+
         public HttpResponseMessage ResponseMessage { get; set; }
 
         public string ExpectedUrl { get; set; }

--- a/tests/Microsoft.Identity.Web.Test/MsAuth10AtPopTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MsAuth10AtPopTests.cs
@@ -26,6 +26,9 @@ namespace Microsoft.Identity.Web.Test
             //mockHttpClientFactory.AddMockHandler(MockHttpCreator.CreateInstanceDiscoveryMockHandler());
             mockHttpClientFactory.AddMockHandler(httpTokenRequest);
 
+            //Enables the mock handler to requeue requests that have been intercepted for instance discovery for example
+            httpTokenRequest.ReplaceMockHttpMessageHandler = mockHttpClientFactory.AddMockHandler;
+
             var certificateDescription = CertificateDescription.FromBase64Encoded(
                 TestConstants.CertificateX5cWithPrivateKey,
                 TestConstants.CertificateX5cWithPrivateKeyPassword);
@@ -39,7 +42,6 @@ namespace Microsoft.Identity.Web.Test
                             .WithCertificate(certificateDescription.Certificate)
                             .WithHttpClientFactory(mockHttpClientFactory)
                             .Build();
-
 
             var popPublicKey = "pop_key";
             var jwkClaim = "jwk_claim";


### PR DESCRIPTION
Use existing pattern in cache extensions test in
MsAuth10AtPopTests

Continuation of #2971 

Fixes test instability introduced by #2950 
