### PR TITLE
Use ExtraQP to inject telemetry SDK ID

### DIFF
--- a/src/Microsoft.Identity.Web.Diagnostics/IdHelper.cs
+++ b/src/Microsoft.Identity.Web.Diagnostics/IdHelper.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Identity.Web
 {
     internal static class IdHelper
     {
+        private const string IDWebSku = "IDWeb.";
+
         private static readonly Lazy<string> s_idWebVersion = new Lazy<string>(
            () =>
            {
@@ -34,9 +36,14 @@ namespace Microsoft.Identity.Web
                return version[1];
            });
 
-        public static string CreateTelemetryInfo()
+        internal static string GetIdWebVersion()
         {
-            return string.Format(CultureInfo.InvariantCulture, Constants.IDWebSku + s_idWebVersion.Value);
+            return s_idWebVersion.Value;
+        }
+
+        internal static string CreateTelemetryInfo()
+        {
+            return string.Format(CultureInfo.InvariantCulture, IDWebSku + s_idWebVersion.Value);
         }
     }
 }

--- a/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net462/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net462/InternalAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Microsoft.Identity.Web.Diagnostics.IdHelper
+Microsoft.Identity.Web.IdHelper
+static Microsoft.Identity.Web.Diagnostics.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.Diagnostics.IdHelper.GetIdWebVersion() -> string!
+static Microsoft.Identity.Web.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.IdHelper.GetIdWebVersion() -> string!

--- a/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net472/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net472/InternalAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Microsoft.Identity.Web.Diagnostics.IdHelper
+Microsoft.Identity.Web.IdHelper
+static Microsoft.Identity.Web.Diagnostics.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.Diagnostics.IdHelper.GetIdWebVersion() -> string!
+static Microsoft.Identity.Web.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.IdHelper.GetIdWebVersion() -> string!

--- a/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net6.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net6.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Microsoft.Identity.Web.Diagnostics.IdHelper
+Microsoft.Identity.Web.IdHelper
+static Microsoft.Identity.Web.Diagnostics.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.Diagnostics.IdHelper.GetIdWebVersion() -> string!
+static Microsoft.Identity.Web.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.IdHelper.GetIdWebVersion() -> string!

--- a/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net7.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net7.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Microsoft.Identity.Web.Diagnostics.IdHelper
+Microsoft.Identity.Web.IdHelper
+static Microsoft.Identity.Web.Diagnostics.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.Diagnostics.IdHelper.GetIdWebVersion() -> string!
+static Microsoft.Identity.Web.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.IdHelper.GetIdWebVersion() -> string!

--- a/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net8.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net8.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Microsoft.Identity.Web.Diagnostics.IdHelper
+Microsoft.Identity.Web.IdHelper
+static Microsoft.Identity.Web.Diagnostics.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.Diagnostics.IdHelper.GetIdWebVersion() -> string!
+static Microsoft.Identity.Web.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.IdHelper.GetIdWebVersion() -> string!

--- a/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Microsoft.Identity.Web.Diagnostics.IdHelper
+Microsoft.Identity.Web.IdHelper
+static Microsoft.Identity.Web.Diagnostics.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.Diagnostics.IdHelper.GetIdWebVersion() -> string!
+static Microsoft.Identity.Web.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.IdHelper.GetIdWebVersion() -> string!

--- a/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Diagnostics/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Microsoft.Identity.Web.Diagnostics.IdHelper
+Microsoft.Identity.Web.IdHelper
+static Microsoft.Identity.Web.Diagnostics.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.Diagnostics.IdHelper.GetIdWebVersion() -> string!
+static Microsoft.Identity.Web.IdHelper.CreateTelemetryInfo() -> string!
+static Microsoft.Identity.Web.IdHelper.GetIdWebVersion() -> string!

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Web.Diagnostics;
 
 namespace Microsoft.Identity.Web
 {

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -16,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Web.Diagnostics;
 
 namespace Microsoft.Identity.Web
 {
@@ -451,7 +453,7 @@ namespace Microsoft.Identity.Web
             }
         }
 
-        internal async Task<HttpResponseMessage> CallApiInternalAsync(
+        internal /* for tests */ async Task<HttpResponseMessage> CallApiInternalAsync(
             string? serviceName,
             DownstreamApiOptions effectiveOptions,
             bool appToken,
@@ -494,7 +496,7 @@ namespace Microsoft.Identity.Web
             return downstreamApiResult;
         }
 
-        internal async Task UpdateRequestAsync(
+        internal /* internal for test */ async Task UpdateRequestAsync(
             HttpRequestMessage httpRequestMessage,
             HttpContent? content,
             DownstreamApiOptions effectiveOptions,
@@ -502,6 +504,8 @@ namespace Microsoft.Identity.Web
             ClaimsPrincipal? user,
             CancellationToken cancellationToken)
         {
+            AddCallerSDKTelemetry(effectiveOptions);
+
             if (content != null)
             {
                 httpRequestMessage.Content = content;
@@ -531,6 +535,27 @@ namespace Microsoft.Identity.Web
             }
             // Opportunity to change the request message
             effectiveOptions.CustomizeHttpRequestMessage?.Invoke(httpRequestMessage);
+        }
+
+        internal /* for test */ static Dictionary<string, string> CallerSDKDetails { get; } = new()
+          {
+              { "caller-sdk-id", "IdWeb_1" },  
+              { "caller-sdk-ver", IdHelper.GetIdWebVersion() }
+          };
+
+        private static void AddCallerSDKTelemetry(DownstreamApiOptions effectiveOptions)
+        {
+            if (effectiveOptions.AcquireTokenOptions.ExtraQueryParameters == null)
+            {
+                effectiveOptions.AcquireTokenOptions.ExtraQueryParameters = CallerSDKDetails;
+            }
+            else
+            {
+                effectiveOptions.AcquireTokenOptions.ExtraQueryParameters["caller-sdk-id"] =
+                    CallerSDKDetails["caller-sdk-id"];
+                effectiveOptions.AcquireTokenOptions.ExtraQueryParameters["caller-sdk-ver"] =
+                    CallerSDKDetails["caller-sdk-ver"];
+            }
         }
     }
 }

--- a/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net462/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net462/InternalAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-bn 
+static Microsoft.Identity.Web.DownstreamApi.CallerSDKDetails.get -> System.Collections.Generic.Dictionary<string!, string!>!

--- a/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net472/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net472/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Microsoft.Identity.Web.DownstreamApi.CallerSDKDetails.get -> System.Collections.Generic.Dictionary<string!, string!>!

--- a/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net6.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net6.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Microsoft.Identity.Web.DownstreamApi.CallerSDKDetails.get -> System.Collections.Generic.Dictionary<string!, string!>!

--- a/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net7.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net7.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Microsoft.Identity.Web.DownstreamApi.CallerSDKDetails.get -> System.Collections.Generic.Dictionary<string!, string!>!

--- a/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net8.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net8.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Microsoft.Identity.Web.DownstreamApi.CallerSDKDetails.get -> System.Collections.Generic.Dictionary<string!, string!>!

--- a/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Microsoft.Identity.Web.DownstreamApi.CallerSDKDetails.get -> System.Collections.Generic.Dictionary<string!, string!>!

--- a/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.DownstreamApi/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Microsoft.Identity.Web.DownstreamApi.CallerSDKDetails.get -> System.Collections.Generic.Dictionary<string!, string!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/Constants.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/Constants.cs
@@ -144,7 +144,6 @@ namespace Microsoft.Identity.Web
 
         // Telemetry headers
         internal const string TelemetryHeaderKey = "x-client-brkrver";
-        internal const string IDWebSku = "IDWeb.";
 
         // Authorize for scopes attributes
         internal const string XReturnUrl = "x-ReturnUrl";


### PR DESCRIPTION
See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/4864 for details. Goal is to identify zero-touch APIs

1. Add "caller-sdk-id" and "caller-sdk-version" as extra QP. Note that these differentiate an API used, in this case `DownstreamAPI`. Afaik this is the only zero-touch API. 

This information will be captured via OTEL and via Http telemetry by MSAL.

Alternatives we can consider:

- use the existing http header `x-client-brkver`
- use a different http header, like `x-telem-last` which is currently out of use

2. Not entirely sure how to add unit tests. Was thinking of moving the logic to `MergeOptions` but it does not seem to be called from all `CallApi` methods?