### PR TITLE
Ensure that SimulateOidc is built before IntegrationTests (that use it)

### DIFF
--- a/tests/Microsoft.Identity.Web.Test.Integration/Microsoft.Identity.Web.Test.Integration.csproj
+++ b/tests/Microsoft.Identity.Web.Test.Integration/Microsoft.Identity.Web.Test.Integration.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />
     <ProjectReference Include="..\E2E Tests\IntegrationTestService\IntegrationTestService.csproj" />
+    <ProjectReference Include="..\E2E Tests\SimulateOidc\SimulateOidc.csproj" />
     <ProjectReference Include="..\Microsoft.Identity.Web.Test.Common\Microsoft.Identity.Web.Test.Common.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Ensure that SimulateOidc is built before IntegrationTests (that use it)
