### PR TITLE
Use AzureRegion while calculating key

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Identity.Web
 
         private static string GetApplicationKey(MergedOptions mergedOptions)
         {
-            return mergedOptions.Instance! + mergedOptions.ClientId + mergedOptions.AzureRegion;
+            return DefaultTokenAcquirerFactoryImplementation.GetKey(mergedOptions.Authority, mergedOptions.ClientId, mergedOptions.AzureRegion);
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -196,6 +196,13 @@ namespace Microsoft.Identity.Web
             }
         }
 
+
+        /// <summary>
+        /// Allows creation of confidential client applications targeting regional and global authorities
+        /// when supporting managed identities.
+        /// </summary>
+        /// <param name="mergedOptions"></param>
+        /// <returns></returns>
         private static string GetApplicationKey(MergedOptions mergedOptions)
         {
             return DefaultTokenAcquirerFactoryImplementation.GetKey(mergedOptions.Authority, mergedOptions.ClientId, mergedOptions.AzureRegion);

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -201,8 +201,8 @@ namespace Microsoft.Identity.Web
         /// Allows creation of confidential client applications targeting regional and global authorities
         /// when supporting managed identities.
         /// </summary>
-        /// <param name="mergedOptions"></param>
-        /// <returns></returns>
+        /// <param name="mergedOptions">Merged configuration options</param>
+        /// <returns>Concatenated string of authority, cliend id and azure region</returns>
         private static string GetApplicationKey(MergedOptions mergedOptions)
         {
             return DefaultTokenAcquirerFactoryImplementation.GetKey(mergedOptions.Authority, mergedOptions.ClientId, mergedOptions.AzureRegion);

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Identity.Web
 
         private static string GetApplicationKey(MergedOptions mergedOptions)
         {
-            return mergedOptions.Instance! + mergedOptions.ClientId;
+            return mergedOptions.Instance! + mergedOptions.ClientId + mergedOptions.AzureRegion;
         }
 
         /// <summary>


### PR DESCRIPTION
# Use AzureRegion while calculating key



## Description

AzureRegion was used while calculating key in DefaultTokenAcquirerFactoryImplementation but not in TokenAcquisition.cs file. Now the GetKey method in TokenAcquisition calls the method with same name in DefaultTokenAcquirerFactoryImplementation . This will ensure that both methods rely on the same set of attributes while creating key.

Fixes #{3001194} (https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3001194)
