### PR TITLE
Removed ConfigureAwait(false) from flaky tests

### DIFF
--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -103,7 +103,7 @@ namespace WebAppUiTests
                         if (InitialConnectionRetryCount == 0) { throw ex; }
                     }
                 }
-                LabResponse labResponse = await LabUserHelper.GetB2CLocalAccountAsync().ConfigureAwait(false);
+                LabResponse labResponse = await LabUserHelper.GetB2CLocalAccountAsync();
 
                 // Initial sign in
                 _output.WriteLine("Starting web app sign-in flow.");

--- a/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
@@ -39,11 +39,11 @@ public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixtur
     [SupportedOSPlatform("windows")]
     public async Task ChallengeUser_MicrosoftIdFlow_LocalApp_ValidEmailPassword()
     {
-        LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
+        LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync();
 
         var clientEnvVars = new Dictionary<string, string>();
 
-        await ExecuteWebAppCallsGraphFlow(labResponse.User.Upn, labResponse.User.GetOrFetchPassword(), clientEnvVars, TraceFileClassName).ConfigureAwait(false);
+        await ExecuteWebAppCallsGraphFlow(labResponse.User.Upn, labResponse.User.GetOrFetchPassword(), clientEnvVars, TraceFileClassName);
     }
 
     [Theory]
@@ -61,7 +61,7 @@ public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixtur
             {"AzureAd__Instance", "" }
         };
 
-        await ExecuteWebAppCallsGraphFlow("idlab@msidlabciam6.onmicrosoft.com", LabUserHelper.FetchUserPassword("msidlabciam6"), clientEnvVars, TraceFileClassNameCiam).ConfigureAwait(false);
+        await ExecuteWebAppCallsGraphFlow("idlab@msidlabciam6.onmicrosoft.com", LabUserHelper.FetchUserPassword("msidlabciam6"), clientEnvVars, TraceFileClassNameCiam);
     }
 
     private async Task ExecuteWebAppCallsGraphFlow(string upn, string credential, Dictionary<string, string>? clientEnvVars, string traceFileClassName)

--- a/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
@@ -97,8 +97,8 @@ namespace WebAppUiTests
                     Assert.Fail(TC.WebAppCrashedString + " " + runningProcesses.ToString());
                 }
 
-                page = await NavigateToWebApp(context, TodoListClientPort).ConfigureAwait(false);
-                LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
+                page = await NavigateToWebApp(context, TodoListClientPort);
+                LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync();
 
                 // Initial sign in
                 _output.WriteLine("Starting web app sign-in flow.");

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Identity.Web.Test.Integration
                 }
 
                 AuthenticationResult authResult =
-                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_scopeForApp, tokenAcquisitionOptions: tokenAcquisitionOptions).ConfigureAwait(false);
+                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_scopeForApp, tokenAcquisitionOptions: tokenAcquisitionOptions);
 
                 // Assert
                 Assert.NotNull(authResult);
@@ -97,7 +97,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             else
             {
                 string token =
-                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp).ConfigureAwait(false);
+                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp);
 
                 // Assert
                 Assert.NotNull(token);
@@ -116,16 +116,16 @@ namespace Microsoft.Identity.Web.Test.Integration
 
             // Act & Assert
             async Task tokenResult() =>
-                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp, tenant: metaTenant).ConfigureAwait(false);
+                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp, tenant: metaTenant);
 
-            ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(tokenResult).ConfigureAwait(false);
+            ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(tokenResult);
             Assert.Contains(IDWebErrorMessage.ClientCredentialTenantShouldBeTenanted, ex.Message, System.StringComparison.OrdinalIgnoreCase);
 
             // Act & Assert
             async Task authResult() =>
-                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_scopeForApp, tenant: metaTenant).ConfigureAwait(false);
+                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_scopeForApp, tenant: metaTenant);
 
-            ArgumentException ex2 = await Assert.ThrowsAsync<ArgumentException>(authResult).ConfigureAwait(false);
+            ArgumentException ex2 = await Assert.ThrowsAsync<ArgumentException>(authResult);
             Assert.Contains(IDWebErrorMessage.ClientCredentialTenantShouldBeTenanted, ex2.Message, System.StringComparison.OrdinalIgnoreCase);
 
             Assert.Equal(0, _msalTestTokenCacheProvider.Count);
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             if (getAuthResult)
             {
                 AuthenticationResult authResult =
-                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_scopeForApp, tenant: Constants.Consumers).ConfigureAwait(false);
+                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_scopeForApp, tenant: Constants.Consumers);
 
                 // Assert
                 Assert.NotNull(authResult);
@@ -155,7 +155,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             else
             {
                 string token =
-                    await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp, tenant: Constants.Consumers).ConfigureAwait(false);
+                    await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_scopeForApp, tenant: Constants.Consumers);
 
                 // Assert
                 Assert.NotNull(token);
@@ -177,7 +177,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             if (getAuthResult)
             {
                 AuthenticationResult authResult =
-                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_scopeForApp, tenant: TestConstants.ConfidentialClientLabTenant).ConfigureAwait(false);
+                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_scopeForApp, tenant: TestConstants.ConfidentialClientLabTenant);
 
                 // Assert
                 Assert.NotNull(authResult);
@@ -190,7 +190,7 @@ namespace Microsoft.Identity.Web.Test.Integration
                 string token =
                     await _tokenAcquisition.GetAccessTokenForAppAsync(
                         TestConstants.s_scopeForApp,
-                        tenant: TestConstants.ConfidentialClientLabTenant).ConfigureAwait(false);
+                        tenant: TestConstants.ConfidentialClientLabTenant);
 
                 // Assert
                 Assert.NotNull(token);
@@ -207,17 +207,17 @@ namespace Microsoft.Identity.Web.Test.Integration
 
             // Act & Assert
             async Task result() =>
-                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_userReadScope.First()).ConfigureAwait(false);
+                await _tokenAcquisition.GetAccessTokenForAppAsync(TestConstants.s_userReadScope.First());
 
-            ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(result).ConfigureAwait(false);
+            ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(result);
 
             Assert.Contains(IDWebErrorMessage.ClientCredentialScopeParameterShouldEndInDotDefault, ex.Message, System.StringComparison.OrdinalIgnoreCase);
 
             // Act & Assert
             async Task authResult() =>
-                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_userReadScope.First()).ConfigureAwait(false);
+                await _tokenAcquisition.GetAuthenticationResultForAppAsync(TestConstants.s_userReadScope.First());
 
-            ArgumentException ex2 = await Assert.ThrowsAsync<ArgumentException>(authResult).ConfigureAwait(false);
+            ArgumentException ex2 = await Assert.ThrowsAsync<ArgumentException>(authResult);
 
             Assert.Contains(IDWebErrorMessage.ClientCredentialScopeParameterShouldEndInDotDefault, ex2.Message, System.StringComparison.OrdinalIgnoreCase);
             Assert.Equal(0, _msalTestTokenCacheProvider.Count);
@@ -247,7 +247,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             var tokenAcquisition = services.GetRequiredService<ITokenAcquisition>();
             var tokenAcquisitionHost = services.GetRequiredService<ITokenAcquisitionHost>();
 
-            var token = await tokenAcquisition.GetAccessTokenForAppAsync("https://graph.microsoft.com/.default").ConfigureAwait(false);
+            var token = await tokenAcquisition.GetAccessTokenForAppAsync("https://graph.microsoft.com/.default");
 
             Assert.NotNull(token);
         }

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForUserIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForUserIntegrationTests.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Identity.Web.Test.Integration
             // Arrange
             HttpClient client = CreateHttpClient(addInMemoryTokenCache);
 
-            var result = await AcquireTokenForLabUserAsync().ConfigureAwait(false);
+            var result = await AcquireTokenForLabUserAsync();
 
             // Act
-            HttpResponseMessage response = await CreateHttpResponseMessage(webApiUrl, client, result).ConfigureAwait(false);
+            HttpResponseMessage response = await CreateHttpResponseMessage(webApiUrl, client, result);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);
@@ -78,10 +78,10 @@ namespace Microsoft.Identity.Web.Test.Integration
             // Arrange
             HttpClient client = CreateHttpClient(addInMemoryTokenCache);
 
-            var result = await AcquireTokenForLabUserAsync().ConfigureAwait(false);
+            var result = await AcquireTokenForLabUserAsync();
 
             // Act
-            HttpResponseMessage response = await CreateHttpResponseMessage(webApiUrl, client, result).ConfigureAwait(false);
+            HttpResponseMessage response = await CreateHttpResponseMessage(webApiUrl, client, result);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);
@@ -119,11 +119,11 @@ namespace Microsoft.Identity.Web.Test.Integration
               );
 
                 // Act
-                var result = await AcquireTokenForLabUserAsync().ConfigureAwait(false);
+                var result = await AcquireTokenForLabUserAsync();
                 HttpResponseMessage response = await CreateHttpResponseMessage(
                     TestConstants.SecurePage2GetTokenForUserAsync,
                     client,
-                    result).ConfigureAwait(false);
+                    result);
                 p.Kill();
 
                 // Assert
@@ -154,7 +154,7 @@ namespace Microsoft.Identity.Web.Test.Integration
                             Constants.Bearer,
                             result.AccessToken));
                 }
-                response = await client.SendAsync(httpRequestMessage).ConfigureAwait(false);
+                response = await client.SendAsync(httpRequestMessage);
             }
 
             return response;
@@ -194,7 +194,7 @@ namespace Microsoft.Identity.Web.Test.Integration
 
         private static async Task<AuthenticationResult> AcquireTokenForLabUserAsync()
         {
-            var labResponse = await LabUserHelper.GetSpecificUserAsync(TestConstants.OBOUser).ConfigureAwait(false);
+            var labResponse = await LabUserHelper.GetSpecificUserAsync(TestConstants.OBOUser);
             var msalPublicClient = PublicClientApplicationBuilder
                .Create(TestConstants.OBOClientSideClientId)
                .WithAuthority(labResponse.Lab.Authority, TestConstants.Organizations)
@@ -206,7 +206,7 @@ namespace Microsoft.Identity.Web.Test.Integration
                 TestConstants.OBOUser,
                 labResponse.User.GetOrFetchPassword())
                 .ExecuteAsync(CancellationToken.None)
-                .ConfigureAwait(false);
+                ;
 
             return authResult;
         }

--- a/tests/Microsoft.Identity.Web.Test/CacheExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CacheExtensionsTests.cs
@@ -37,11 +37,11 @@ namespace Microsoft.Identity.Web.Test
         {
             AuthenticationResult result;
             // new InMemory serializer and new cca
-            result = await CreateAppAndGetTokenAsync(CacheType.InMemory).ConfigureAwait(false);
+            result = await CreateAppAndGetTokenAsync(CacheType.InMemory);
             Assert.Equal(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
             AssertCacheTelemetry(result, CacheLevel.None);
 
-            result = await CreateAppAndGetTokenAsync(CacheType.InMemory, addTokenMock: false).ConfigureAwait(false);
+            result = await CreateAppAndGetTokenAsync(CacheType.InMemory, addTokenMock: false);
             Assert.Equal(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
             AssertCacheTelemetry(result, CacheLevel.L1Cache);
 
@@ -49,11 +49,11 @@ namespace Microsoft.Identity.Web.Test
             TokenCacheExtensions.s_serviceProviderFromAction.Clear();
 
             // new DistributedInMemory and same cca
-            result = await CreateAppAndGetTokenAsync(CacheType.DistributedInMemory).ConfigureAwait(false);
+            result = await CreateAppAndGetTokenAsync(CacheType.DistributedInMemory);
             Assert.Equal(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
             AssertCacheTelemetry(result, CacheLevel.None);
 
-            result = await CreateAppAndGetTokenAsync(CacheType.DistributedInMemory, addTokenMock: false).ConfigureAwait(false);
+            result = await CreateAppAndGetTokenAsync(CacheType.DistributedInMemory, addTokenMock: false);
             Assert.Equal(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
             AssertCacheTelemetry(result, CacheLevel.L1Cache);
         }
@@ -63,11 +63,11 @@ namespace Microsoft.Identity.Web.Test
         {
             AuthenticationResult result;
             // new DistributedInMemory serializer with L1 cache disabled
-            result = await CreateAppAndGetTokenAsync(CacheType.DistributedInMemory, disableL1Cache: true).ConfigureAwait(false);
+            result = await CreateAppAndGetTokenAsync(CacheType.DistributedInMemory, disableL1Cache: true);
             Assert.Equal(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
             AssertCacheTelemetry(result, CacheLevel.None);
 
-            result = await CreateAppAndGetTokenAsync(CacheType.DistributedInMemory, addTokenMock: false, disableL1Cache: true).ConfigureAwait(false);
+            result = await CreateAppAndGetTokenAsync(CacheType.DistributedInMemory, addTokenMock: false, disableL1Cache: true);
             Assert.Equal(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
             AssertCacheTelemetry(result, CacheLevel.L2Cache);
         }
@@ -181,10 +181,10 @@ namespace Microsoft.Identity.Web.Test
                 // Different tenants used to created different cache entries
                 var result1 = await confidentialApp.AcquireTokenForClient(new[] { TestConstants.s_scopeForApp })
                     .WithTenantId(tenantId1)
-                    .ExecuteAsync().ConfigureAwait(false);
+                    .ExecuteAsync();
                 var result2 = await confidentialApp.AcquireTokenForClient(new[] { TestConstants.s_scopeForApp })
                     .WithTenantId(tenantId2)
-                    .ExecuteAsync().ConfigureAwait(false);
+                    .ExecuteAsync();
 
                 Assert.Equal(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource);
                 Assert.Equal(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource);
@@ -261,12 +261,12 @@ namespace Microsoft.Identity.Web.Test
                                     .WithClientSecret(TestConstants.ClientSecret)
                                     .Build();
 
-                await msalMemoryTokenCacheProvider.InitializeAsync(confidentialApp.AppTokenCache).ConfigureAwait(false);
+                await msalMemoryTokenCacheProvider.InitializeAsync(confidentialApp.AppTokenCache);
 
                 AuthenticationResult result = await confidentialApp
                     .AcquireTokenForClient(["https://graph.microsoft.com/.default"])
                     .ExecuteAsync()
-                    .ConfigureAwait(false);
+                    ;
 
                 Assert.Equal(
                     expectCacheHit ?
@@ -289,13 +289,13 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public async Task CacheKeyExtensibility()
         {
-            var result = await GetTokensAssociatedWithKey("foo", expectCacheHit: false).ConfigureAwait(false);
-            result = await GetTokensAssociatedWithKey("bar", expectCacheHit: false).ConfigureAwait(false);
-            result = await GetTokensAssociatedWithKey(null, expectCacheHit: false).ConfigureAwait(false);
+            var result = await GetTokensAssociatedWithKey("foo", expectCacheHit: false);
+            result = await GetTokensAssociatedWithKey("bar", expectCacheHit: false);
+            result = await GetTokensAssociatedWithKey(null, expectCacheHit: false);
 
-            result = await GetTokensAssociatedWithKey("foo", expectCacheHit: true).ConfigureAwait(false);
-            result = await GetTokensAssociatedWithKey("bar", expectCacheHit: true).ConfigureAwait(false);
-            result = await GetTokensAssociatedWithKey(null, expectCacheHit: true).ConfigureAwait(false);
+            result = await GetTokensAssociatedWithKey("foo", expectCacheHit: true);
+            result = await GetTokensAssociatedWithKey("bar", expectCacheHit: true);
+            result = await GetTokensAssociatedWithKey(null, expectCacheHit: true);
         }
 
         private enum CacheType
@@ -353,7 +353,7 @@ namespace Microsoft.Identity.Web.Test
             }
 
             var result = await confidentialApp.AcquireTokenForClient(new[] { TestConstants.s_scopeForApp })
-                .ExecuteAsync().ConfigureAwait(false);
+                .ExecuteAsync();
 
             tokenHandler.ReplaceMockHttpMessageHandler = null!;
             return result;

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddAuthentication()
                 .AddMicrosoftIdentityWebApp(configMock, ConfigSectionName, OidcScheme, CookieScheme, subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: false);
 
-            await AddMicrosoftIdentityWebApp_TestRedirectToIdentityProviderEvent(services, redirectFunc).ConfigureAwait(false);
+            await AddMicrosoftIdentityWebApp_TestRedirectToIdentityProviderEvent(services, redirectFunc);
         }
 
         [Fact]
@@ -257,7 +257,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddAuthentication()
                     .AddMicrosoftIdentityWebApp(_configureMsOptions, _configureCookieOptions, OidcScheme, CookieScheme, subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: false);
 
-            await AddMicrosoftIdentityWebApp_TestRedirectToIdentityProviderEvent(services, redirectFunc).ConfigureAwait(false);
+            await AddMicrosoftIdentityWebApp_TestRedirectToIdentityProviderEvent(services, redirectFunc);
         }
 
         [Fact]
@@ -281,7 +281,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddAuthentication()
                 .AddMicrosoftIdentityWebApp(configMock, ConfigSectionName, OidcScheme, CookieScheme, subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: false);
 
-            await AddMicrosoftIdentityWebApp_TestB2cSpecificSetup(services, remoteFailureFuncMock).ConfigureAwait(false);
+            await AddMicrosoftIdentityWebApp_TestB2cSpecificSetup(services, remoteFailureFuncMock);
         }
 
         [Fact]
@@ -312,7 +312,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddAuthentication()
                 .AddMicrosoftIdentityWebApp(_configureMsOptions, _configureCookieOptions, OidcScheme, CookieScheme, subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: false);
 
-            await AddMicrosoftIdentityWebApp_TestB2cSpecificSetup(services, remoteFailureFuncMock).ConfigureAwait(false);
+            await AddMicrosoftIdentityWebApp_TestB2cSpecificSetup(services, remoteFailureFuncMock);
         }
 
         [Fact]
@@ -355,9 +355,9 @@ namespace Microsoft.Identity.Web.Test
             var oidcOptions = provider.GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>().Get(OidcScheme);
 
             AddMicrosoftIdentityWebAppCallsWebApi_TestCommon(services, provider, oidcOptions, initialScopes);
-            await AddMicrosoftIdentityWebAppCallsWebApi_TestAuthorizationCodeReceivedEvent(provider, oidcOptions, authCodeReceivedFuncMock, tokenAcquisitionMock).ConfigureAwait(false);
-            await AddMicrosoftIdentityWebAppCallsWebApi_TestTokenValidatedEvent(provider, oidcOptions, tokenValidatedFuncMock).ConfigureAwait(false);
-            await AddMicrosoftIdentityWebAppCallsWebApi_TestRedirectToIdentityProviderForSignOutEvent(provider, oidcOptions, redirectFuncMock, tokenAcquisitionMock).ConfigureAwait(false);
+            await AddMicrosoftIdentityWebAppCallsWebApi_TestAuthorizationCodeReceivedEvent(provider, oidcOptions, authCodeReceivedFuncMock, tokenAcquisitionMock);
+            await AddMicrosoftIdentityWebAppCallsWebApi_TestTokenValidatedEvent(provider, oidcOptions, tokenValidatedFuncMock);
+            await AddMicrosoftIdentityWebAppCallsWebApi_TestRedirectToIdentityProviderForSignOutEvent(provider, oidcOptions, redirectFuncMock, tokenAcquisitionMock);
         }
 
         [Fact]
@@ -400,9 +400,9 @@ namespace Microsoft.Identity.Web.Test
             var oidcOptions = provider.GetRequiredService<IOptionsFactory<OpenIdConnectOptions>>().Create(OidcScheme);
 
             AddMicrosoftIdentityWebAppCallsWebApi_TestCommon(services, provider, oidcOptions, initialScopes);
-            await AddMicrosoftIdentityWebAppCallsWebApi_TestAuthorizationCodeReceivedEvent(provider, oidcOptions, authCodeReceivedFuncMock, tokenAcquisitionMock).ConfigureAwait(false);
-            await AddMicrosoftIdentityWebAppCallsWebApi_TestTokenValidatedEvent(provider, oidcOptions, tokenValidatedFuncMock).ConfigureAwait(false);
-            await AddMicrosoftIdentityWebAppCallsWebApi_TestRedirectToIdentityProviderForSignOutEvent(provider, oidcOptions, redirectFuncMock, tokenAcquisitionMock).ConfigureAwait(false);
+            await AddMicrosoftIdentityWebAppCallsWebApi_TestAuthorizationCodeReceivedEvent(provider, oidcOptions, authCodeReceivedFuncMock, tokenAcquisitionMock);
+            await AddMicrosoftIdentityWebAppCallsWebApi_TestTokenValidatedEvent(provider, oidcOptions, tokenValidatedFuncMock);
+            await AddMicrosoftIdentityWebAppCallsWebApi_TestRedirectToIdentityProviderForSignOutEvent(provider, oidcOptions, redirectFuncMock, tokenAcquisitionMock);
         }
 
         [Fact]
@@ -461,8 +461,8 @@ namespace Microsoft.Identity.Web.Test
                 },
             };
 
-            await oidcOptions.Events.RedirectToIdentityProvider(redirectContext).ConfigureAwait(false);
-            await oidcOptions.Events.RedirectToIdentityProviderForSignOut(redirectContext).ConfigureAwait(false);
+            await oidcOptions.Events.RedirectToIdentityProvider(redirectContext);
+            await oidcOptions.Events.RedirectToIdentityProviderForSignOut(redirectContext);
 
             Assert.Equal(expectedUri, redirectContext.ProtocolMessage.RedirectUri);
         }
@@ -734,10 +734,10 @@ namespace Microsoft.Identity.Web.Test
             var redirectContext = new RedirectContext(httpContext, authScheme, oidcOptions, authProperties);
             redirectContext.ProtocolMessage = new OpenIdConnectMessage();
 
-            await oidcOptions.Events.RedirectToIdentityProvider(redirectContext).ConfigureAwait(false);
+            await oidcOptions.Events.RedirectToIdentityProvider(redirectContext);
 
             // Assert properties set, events called
-            await redirectFunc.ReceivedWithAnyArgs().Invoke(Arg.Any<RedirectContext>()).ConfigureAwait(false);
+            await redirectFunc.ReceivedWithAnyArgs().Invoke(Arg.Any<RedirectContext>());
             Assert.NotNull(redirectContext.ProtocolMessage.LoginHint);
             Assert.NotNull(redirectContext.ProtocolMessage.DomainHint);
             Assert.NotNull(redirectContext.ProtocolMessage.Parameters[OidcConstants.AdditionalClaims]);
@@ -786,10 +786,10 @@ namespace Microsoft.Identity.Web.Test
 
             var remoteFailureContext = new RemoteFailureContext(httpContext, authScheme, new RemoteAuthenticationOptions(), new Exception());
 
-            await oidcOptions.Events.RedirectToIdentityProvider(redirectContext).ConfigureAwait(false);
-            await oidcOptions.Events.RemoteFailure(remoteFailureContext).ConfigureAwait(false);
+            await oidcOptions.Events.RedirectToIdentityProvider(redirectContext);
+            await oidcOptions.Events.RemoteFailure(remoteFailureContext);
 
-            await remoteFailureFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<RemoteFailureContext>()).ConfigureAwait(false);
+            await remoteFailureFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<RemoteFailureContext>());
             // Assert issuer is updated to non-default user flow
             Assert.Contains(TestConstants.B2CEditProfileUserFlow, redirectContext.ProtocolMessage.IssuerAddress, System.StringComparison.OrdinalIgnoreCase);
             Assert.NotNull(redirectContext.ProtocolMessage.Parameters[ClaimConstants.ClientInfo]);
@@ -825,11 +825,11 @@ namespace Microsoft.Identity.Web.Test
         {
             var (httpContext, authScheme, authProperties) = CreateContextParameters(provider);
 
-            await oidcOptions.Events.AuthorizationCodeReceived(new AuthorizationCodeReceivedContext(httpContext, authScheme, oidcOptions, authProperties)).ConfigureAwait(false);
+            await oidcOptions.Events.AuthorizationCodeReceived(new AuthorizationCodeReceivedContext(httpContext, authScheme, oidcOptions, authProperties));
 
             // Assert original AuthorizationCodeReceived event and TokenAcquisition method were called
-            await authCodeReceivedFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<AuthorizationCodeReceivedContext>()).ConfigureAwait(false);
-            await tokenAcquisitionMock.ReceivedWithAnyArgs().AddAccountToCacheFromAuthorizationCodeAsync(Arg.Any<AuthorizationCodeReceivedContext>(), Arg.Any<IEnumerable<string>>()).ConfigureAwait(false);
+            await authCodeReceivedFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<AuthorizationCodeReceivedContext>());
+            await tokenAcquisitionMock.ReceivedWithAnyArgs().AddAccountToCacheFromAuthorizationCodeAsync(Arg.Any<AuthorizationCodeReceivedContext>(), Arg.Any<IEnumerable<string>>());
         }
 
         private async Task AddMicrosoftIdentityWebAppCallsWebApi_TestTokenValidatedEvent(IServiceProvider provider, OpenIdConnectOptions oidcOptions, Func<TokenValidatedContext, Task> tokenValidatedFuncMock)
@@ -845,10 +845,10 @@ namespace Microsoft.Identity.Web.Test
                     }),
             };
 
-            await oidcOptions.Events.TokenValidated(tokenValidatedContext).ConfigureAwait(false);
+            await oidcOptions.Events.TokenValidated(tokenValidatedContext);
 
             // Assert original TokenValidated event was called; properties were set
-            await tokenValidatedFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<TokenValidatedContext>()).ConfigureAwait(false);
+            await tokenValidatedFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<TokenValidatedContext>());
             Assert.True(tokenValidatedContext?.Principal?.HasClaim(c => c.Type == ClaimConstants.UniqueTenantIdentifier));
             Assert.True(tokenValidatedContext?.Principal?.HasClaim(c => c.Type == ClaimConstants.UniqueObjectIdentifier));
         }
@@ -861,11 +861,11 @@ namespace Microsoft.Identity.Web.Test
         {
             var (httpContext, authScheme, authProperties) = CreateContextParameters(provider);
 
-            await oidcOptions.Events.RedirectToIdentityProviderForSignOut(new RedirectContext(httpContext, authScheme, oidcOptions, authProperties)).ConfigureAwait(false);
+            await oidcOptions.Events.RedirectToIdentityProviderForSignOut(new RedirectContext(httpContext, authScheme, oidcOptions, authProperties));
 
             // Assert original RedirectToIdentityProviderForSignOut event and TokenAcquisition method were called
-            await redirectFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<RedirectContext>()).ConfigureAwait(false);
-            await tokenAcquisitionMock.ReceivedWithAnyArgs().RemoveAccountAsync(Arg.Any<ClaimsPrincipal>()).ConfigureAwait(false);
+            await redirectFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<RedirectContext>());
+            await tokenAcquisitionMock.ReceivedWithAnyArgs().RemoveAccountAsync(Arg.Any<ClaimsPrincipal>());
         }
 
         private (HttpContext, AuthenticationScheme, AuthenticationProperties) CreateContextParameters(IServiceProvider provider)


### PR DESCRIPTION
According to this guidance from [XUnit](https://xunit.net/xunit.analyzers/rules/xUnit1030), using `ConfigureAwait(false)` in tests can lead to issues with synchronization and parallelization. In local testing removing ConfigureAwait seemed to work as I could repro flakiness locally in about 1-3 attempts but post-fix there was no observed flakiness locally after 14 attempts.

That doesn't guarantee it fixes the build pipeline, but it looks promising so far. There is a risk of recurrence in the build pipeline even if this method is successful as I only edited tests that were observed as flaky in the last two weeks. Therefore, if a test still using ConfigureAwait(false) triggers flakiness but hasn't been failing itself, it would still be capable of breaking the build.