### PR TITLE
removed ConfigureAwait(false) from all tests

### DIFF
--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/TestMsalDistributedTokenCacheAdapter.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/TestMsalDistributedTokenCacheAdapter.cs
@@ -31,22 +31,22 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
 
         public async Task TestRemoveKeyAsync(string cacheKey)
         {
-            await RemoveKeyAsync(cacheKey).ConfigureAwait(false);
+            await RemoveKeyAsync(cacheKey);
         }
 
         public async Task TestWriteCacheBytesAsync(string cacheKey, byte[] bytes, CacheSerializerHints? cacheSerializerHints = null)
         {
-            await WriteCacheBytesAsync(cacheKey, bytes, cacheSerializerHints).ConfigureAwait(false);
+            await WriteCacheBytesAsync(cacheKey, bytes, cacheSerializerHints);
         }
 
         public async Task<byte[]?> TestReadCacheBytesAsync(string cacheKey)
         {
-            return await ReadCacheBytesAsync(cacheKey).ConfigureAwait(false);
+            return await ReadCacheBytesAsync(cacheKey);
         }
 
         public async Task<byte[]?> TestReadCacheBytesAsync(string cacheKey, TelemetryData telemetryData)
         {
-            return await ReadCacheBytesAsync(cacheKey, new CacheSerializerHints() { TelemetryData = telemetryData }).ConfigureAwait(false);
+            return await ReadCacheBytesAsync(cacheKey, new CacheSerializerHints() { TelemetryData = telemetryData });
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AzureADB2COpenIDConnectEventHandlersTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Web.Test
                 },
             };
 
-            await handler.OnRedirectToIdentityProvider(context).ConfigureAwait(false);
+            await handler.OnRedirectToIdentityProvider(context);
 
             errorAccessor.DidNotReceive().SetMessage(httpContext, Arg.Any<string>());
             Assert.Equal(TestConstants.Scopes, context.ProtocolMessage.Scope);
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Web.Test
             authProperties.Items.Add(OidcConstants.PolicyKey, DefaultUserFlow);
             var context = new RedirectContext(httpContext, _authScheme, new OpenIdConnectOptions(), authProperties) { ProtocolMessage = new OpenIdConnectMessage() { IssuerAddress = _defaultIssuer } };
 
-            await handler.OnRedirectToIdentityProvider(context).ConfigureAwait(false);
+            await handler.OnRedirectToIdentityProvider(context);
 
             errorAccessor.DidNotReceive().SetMessage(httpContext, Arg.Any<string>());
             Assert.Null(context.ProtocolMessage.Scope);
@@ -101,7 +101,7 @@ namespace Microsoft.Identity.Web.Test
 
             var passwordResetException = "'access_denied', error_description: 'AADB2C90118: The user has forgotten their password. Correlation ID: f99deff4-f43b-43cc-b4e7-36141dbaf0a0 Timestamp: 2018-03-05 02:49:35Z', error_uri: 'error_uri is null'";
 
-            await handler.OnRemoteFailure(new RemoteFailureContext(httpContext, _authScheme, new OpenIdConnectOptions(), new OpenIdConnectProtocolException(passwordResetException))).ConfigureAwait(false);
+            await handler.OnRemoteFailure(new RemoteFailureContext(httpContext, _authScheme, new OpenIdConnectOptions(), new OpenIdConnectProtocolException(passwordResetException)));
 
             errorAccessor.DidNotReceive().SetMessage(httpContext, Arg.Any<string>());
             httpContext.Response.Received().Redirect($"{httpContext.Request.PathBase}/MicrosoftIdentity/Account/ResetPassword/{OpenIdConnectDefaults.AuthenticationScheme}");
@@ -122,7 +122,7 @@ namespace Microsoft.Identity.Web.Test
                     httpContext,
                     _authScheme,
                     new OpenIdConnectOptions(),
-                    new OpenIdConnectProtocolException(cancelException))).ConfigureAwait(false);
+                    new OpenIdConnectProtocolException(cancelException)));
 
             errorAccessor.DidNotReceive().SetMessage(httpContext, Arg.Any<string>());
 
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Web.Test
                     httpContext,
                     _authScheme,
                     new OpenIdConnectOptions(),
-                    new OpenIdConnectProtocolException(otherException))).ConfigureAwait(false);
+                    new OpenIdConnectProtocolException(otherException)));
 
             errorAccessor.Received(1).SetMessage(httpContext, otherException);
             httpContext.Response.Received().Redirect($"{httpContext.Request.PathBase}/MicrosoftIdentity/Account/Error");

--- a/tests/Microsoft.Identity.Web.Test/CacheEncryptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CacheEncryptionTests.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Identity.Web.Test
             _testCacheAdapter.Initialize(tokenCache);
 
             // Act
-            await tokenCache._beforeAccess(args).ConfigureAwait(false);
+            await tokenCache._beforeAccess(args);
             tokenCache.cache = cache;
-            await tokenCache._afterAccess(args).ConfigureAwait(false);
+            await tokenCache._afterAccess(args);
 
             // Assert
             Assert.NotNull(_testCacheAdapter._memoryCache);

--- a/tests/Microsoft.Identity.Web.Test/Certificates/WithClientCredentialsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/WithClientCredentialsTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
                 credentialDescriptions,
                 logger,
                 credLoader,
-                null).ConfigureAwait(false);
+                null);
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 
             Assert.Equal(credentialDescriptions[1], cd);

--- a/tests/Microsoft.Identity.Web.Test/ClientAssertionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ClientAssertionTests.cs
@@ -31,15 +31,15 @@ namespace Microsoft.Identity.Web.Test
             TestClientAssertion clientAssertionDescription = new TestClientAssertion();
             AssertionRequestOptions options = new AssertionRequestOptions();
 
-            string assertion = await clientAssertionDescription.GetSignedAssertionAsync(options).ConfigureAwait(false);
+            string assertion = await clientAssertionDescription.GetSignedAssertionAsync(options);
 
             Assert.Equal("1", assertion);
-            assertion = await clientAssertionDescription.GetSignedAssertionAsync(options).ConfigureAwait(false);
+            assertion = await clientAssertionDescription.GetSignedAssertionAsync(options);
             Assert.Equal("1", assertion);
 
             Assert.NotNull(clientAssertionDescription.Expiry);
-            await Task.Delay(clientAssertionDescription.Expiry.Value - DateTimeOffset.Now + TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
-            assertion = await clientAssertionDescription.GetSignedAssertionAsync(options).ConfigureAwait(false);
+            await Task.Delay(clientAssertionDescription.Expiry.Value - DateTimeOffset.Now + TimeSpan.FromMilliseconds(100));
+            assertion = await clientAssertionDescription.GetSignedAssertionAsync(options);
             Assert.Equal("2", assertion);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Web.Test
 
             // Act
             TestDistributedCache.ResetEvent.Reset();
-            await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache).ConfigureAwait(false);
+            await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache);
 
             // Assert
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
@@ -64,13 +64,13 @@ namespace Microsoft.Identity.Web.Test
         public async Task WriteCache_NegativeExpiry_TestAsync()
         {
             // Arrange & Act
-            await CreateL1L2TestWithSerializerHints(System.DateTimeOffset.Now - System.TimeSpan.FromHours(1), 0).ConfigureAwait(false);
+            await CreateL1L2TestWithSerializerHints(System.DateTimeOffset.Now - System.TimeSpan.FromHours(1), 0);
 
             // Assert
             Assert.NotNull(_testCacheAdapter._memoryCache);
             Assert.Null(_testCacheAdapter._memoryCache.Get(DefaultCacheKey));
 
-            await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
         }
 
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Web.Test
         public async Task WriteCacheL1L2_NegativeExpiry_TestAsync()
         {
             // Arrange & Act
-            await CreateL1L2TestWithSerializerHints(System.DateTimeOffset.Now - System.TimeSpan.FromHours(1), 0).ConfigureAwait(false);
+            await CreateL1L2TestWithSerializerHints(System.DateTimeOffset.Now - System.TimeSpan.FromHours(1), 0);
 
             // Assert
             Assert.NotNull(_testCacheAdapter._memoryCache);
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Web.Test
             var options = (_testCacheAdapter._distributedCache as TestDistributedCache)!.GetDistributedCacheEntryOptions(DefaultCacheKey);
             Assert.NotNull(options);
             Assert.NotNull(options.AbsoluteExpiration);
-            await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Web.Test
             // Arrange & Act
             var timespan = System.TimeSpan.FromHours(1);
             var expiry = System.DateTimeOffset.UtcNow + timespan;
-            await CreateL1L2TestWithSerializerHints(expiry, 1).ConfigureAwait(false);
+            await CreateL1L2TestWithSerializerHints(expiry, 1);
 
             // Assert
             Assert.NotNull(_testCacheAdapter._memoryCache);
@@ -107,20 +107,20 @@ namespace Microsoft.Identity.Web.Test
             Assert.NotNull(options);
             Assert.NotNull(options.AbsoluteExpiration);
             Assert.Equal(expiry, options.AbsoluteExpiration.Value);
-            await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
         }
 
         [Fact]
         public async Task WriteCacheL1L2_PositiveExpiryAndAbsoluteOptions_TestAsync()
         {
-            await CreateL1L2TestWithAbsoluteOptions(1.5).ConfigureAwait(false);
+            await CreateL1L2TestWithAbsoluteOptions(1.5);
         }
 
         [Fact]
         public async Task WriteCacheL1L2_PositiveExpiryAndAbsoluteOptionsLessThanSuggestedExpiry_TestAsync()
         {
-            await CreateL1L2TestWithAbsoluteOptions(.5).ConfigureAwait(false);
+            await CreateL1L2TestWithAbsoluteOptions(.5);
         }
 
         private async Task CreateL1L2TestWithAbsoluteOptions(double time)
@@ -131,7 +131,7 @@ namespace Microsoft.Identity.Web.Test
             var absoluteOptions = Provider.GetService<IOptions<MsalDistributedTokenCacheAdapterOptions>>();
             Assert.NotNull(absoluteOptions);
             absoluteOptions.Value.AbsoluteExpiration = System.DateTimeOffset.Now + System.TimeSpan.FromHours(time);
-            await CreateL1L2TestWithSerializerHints(suggestedExpiry, 1).ConfigureAwait(false);
+            await CreateL1L2TestWithSerializerHints(suggestedExpiry, 1);
 
             // Assert
             Assert.NotNull(_testCacheAdapter._memoryCache);
@@ -150,7 +150,7 @@ namespace Microsoft.Identity.Web.Test
             }
 
             absoluteOptions.Value.AbsoluteExpiration = null;
-            await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
         }
 
@@ -169,7 +169,7 @@ namespace Microsoft.Identity.Web.Test
 
             // Act
             TestDistributedCache.ResetEvent.Reset();
-            await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache, cacheSerializerHints).ConfigureAwait(false);
+            await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache, cacheSerializerHints);
 
             // Assert
             Assert.Equal(memoryCacheExpectedCount, _testCacheAdapter._memoryCache.Count);
@@ -192,7 +192,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Empty(L2Cache._dict);
 
             // Act
-            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData);
 
             // Assert
             Assert.NotNull(result);
@@ -214,7 +214,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
 
             // Act
-            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData);
 
             // Assert
             Assert.NotNull(result);
@@ -238,7 +238,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
 
             // Act
-            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData);
 
             // Assert
             Assert.NotNull(result);
@@ -248,7 +248,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(CacheLevel.L2Cache, telemetryData.CacheLevel);
 
             // Act
-            result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData).ConfigureAwait(false);
+            result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData);
 
             // Assert
             Assert.NotNull(result);
@@ -270,7 +270,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
 
             // Act
-            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, telemetryData);
 
             // Assert
             Assert.Null(result);
@@ -293,7 +293,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
 
             // Act
-            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey);
 
             // Assert
             Assert.Null(result);
@@ -317,13 +317,13 @@ namespace Microsoft.Identity.Web.Test
             Assert.Single(L2Cache._dict);
 
             // Act & Assert
-            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey).ConfigureAwait(false);
+            byte[]? result = await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey);
             Assert.NotNull(result);
             Assert.Equal(9, result[0]);
             Assert.Equal(2, _testCacheAdapter._memoryCache.Count);
             Assert.Single(L2Cache._dict);
 
-            byte[]? result2 = await _testCacheAdapter.TestReadCacheBytesAsync(AnotherCacheKey).ConfigureAwait(false);
+            byte[]? result2 = await _testCacheAdapter.TestReadCacheBytesAsync(AnotherCacheKey);
             Assert.NotNull(result2);
             Assert.Equal(4, result2[0]);
             Assert.Equal(2, _testCacheAdapter._memoryCache.Count);
@@ -343,7 +343,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
 
             // Act
-            await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey).ConfigureAwait(false);
+            await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey);
 
             // Assert
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
@@ -362,7 +362,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Single(L2Cache._dict);
 
             // Act
-            await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey).ConfigureAwait(false);
+            await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey);
 
             // Assert
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
@@ -382,10 +382,10 @@ namespace Microsoft.Identity.Web.Test
             _testCacheAdapter._distributedCache.Set(DefaultCacheKey, cacheL2);
 
             // Act & Assert
-            await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey).ConfigureAwait(false);
+            await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey);
             Assert.Equal(1, _testCacheAdapter._memoryCache.Count);
             Assert.Empty(L2Cache._dict);
-            await _testCacheAdapter.TestRemoveKeyAsync(AnotherCacheKey).ConfigureAwait(false);
+            await _testCacheAdapter.TestRemoveKeyAsync(AnotherCacheKey);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             Assert.Empty(L2Cache._dict);
         }

--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityAuthenticationMessageHandlerTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityAuthenticationMessageHandlerTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Web.Test
             using var request = new HttpRequestMessage(HttpMethod.Get, TestConstants.GraphBaseUrlBeta);
 
             // act
-            var response = await client.SendAsync(request).ConfigureAwait(false);
+            var response = await client.SendAsync(request);
 
             // assert
             if (useApp)
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Web.Test
                     _handlerOptions.AuthenticationScheme,
                     _handlerOptions.Tenant,
                     Arg.Any<TokenAcquisitionOptions>() /* options are cloned */)
-                    .ConfigureAwait(false);
+                    ;
             }
             else
             {
@@ -118,7 +118,7 @@ namespace Microsoft.Identity.Web.Test
                     tenantId: _handlerOptions.Tenant,
                     userFlow: _handlerOptions.UserFlow,
                     tokenAcquisitionOptions: Arg.Any<TokenAcquisitionOptions>() /* options are cloned */)
-                    .ConfigureAwait(false);
+                    ;
             }
 
             Assert.True(_mockedMessageHandler.Requests[0].Headers.Contains(Constants.Authorization));
@@ -166,7 +166,7 @@ namespace Microsoft.Identity.Web.Test
             request.Headers.Add(Constants.Authorization, "auth");
 
             // act
-            var response = await client.SendAsync(request).ConfigureAwait(false);
+            var response = await client.SendAsync(request);
 
             // assert
             Assert.True(_mockedMessageHandler.Requests[0].Headers.Contains(Constants.Authorization));

--- a/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         public async Task TokenValidated_MissingScopesAndRoles_AuthenticationFails()
         {
             Assert.True(_tokenContext.Result.Succeeded);
-            await _jwtEvents.TokenValidated(_tokenContext).ConfigureAwait(false);
+            await _jwtEvents.TokenValidated(_tokenContext);
             Assert.False(_tokenContext.Result.Succeeded);
         }
     }
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         public async Task TokenValidated_WithScopesAndRoles_AuthenticationSucceeds()
         {
             Assert.True(_tokenContext.Result.Succeeded);
-            await _jwtEvents.TokenValidated(_tokenContext).ConfigureAwait(false);
+            await _jwtEvents.TokenValidated(_tokenContext);
             Assert.True(_tokenContext.Result.Succeeded);
         }
     }

--- a/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerMiddlewareDiagnosticsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerMiddlewareDiagnosticsTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _jwtEvents.OnAuthenticationFailed = _eventHandler;
             _jwtDiagnostics.Subscribe(_jwtEvents);
-            await _jwtEvents.AuthenticationFailed(new AuthenticationFailedContext(_httpContext, _authScheme, _jwtOptions)).ConfigureAwait(false);
+            await _jwtEvents.AuthenticationFailed(new AuthenticationFailedContext(_httpContext, _authScheme, _jwtOptions));
 
             AssertSuccess();
         }
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _jwtEvents.OnMessageReceived = _eventHandler;
             _jwtDiagnostics.Subscribe(_jwtEvents);
-            await _jwtEvents.MessageReceived(new MessageReceivedContext(_httpContext, _authScheme, _jwtOptions)).ConfigureAwait(false);
+            await _jwtEvents.MessageReceived(new MessageReceivedContext(_httpContext, _authScheme, _jwtOptions));
 
             AssertSuccess();
         }
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _jwtEvents.OnTokenValidated = _eventHandler;
             _jwtDiagnostics.Subscribe(_jwtEvents);
-            await _jwtEvents.TokenValidated(new TokenValidatedContext(_httpContext, _authScheme, _jwtOptions)).ConfigureAwait(false);
+            await _jwtEvents.TokenValidated(new TokenValidatedContext(_httpContext, _authScheme, _jwtOptions));
 
             AssertSuccess();
         }
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _jwtEvents.OnChallenge = _eventHandler;
             _jwtDiagnostics.Subscribe(_jwtEvents);
-            await _jwtEvents.Challenge(new JwtBearerChallengeContext(_httpContext, _authScheme, _jwtOptions, new AuthenticationProperties())).ConfigureAwait(false);
+            await _jwtEvents.Challenge(new JwtBearerChallengeContext(_httpContext, _authScheme, _jwtOptions, new AuthenticationProperties()));
 
             AssertSuccess();
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         public async void Subscribe_OnAuthenticationFailedDefault_CompletesSuccessfully()
         {
             _jwtEvents = _jwtDiagnostics.Subscribe(null!);
-            await _jwtEvents.AuthenticationFailed(new AuthenticationFailedContext(_httpContext, _authScheme, _jwtOptions)).ConfigureAwait(false);
+            await _jwtEvents.AuthenticationFailed(new AuthenticationFailedContext(_httpContext, _authScheme, _jwtOptions));
 
             AssertSuccess(false);
         }
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         public async void Subscribe_OnMessageReceivedDefault_CompletesSuccessfully()
         {
             _jwtEvents = _jwtDiagnostics.Subscribe(_jwtEvents);
-            await _jwtEvents.MessageReceived(new MessageReceivedContext(_httpContext, _authScheme, _jwtOptions)).ConfigureAwait(false);
+            await _jwtEvents.MessageReceived(new MessageReceivedContext(_httpContext, _authScheme, _jwtOptions));
 
             AssertSuccess(false);
         }
@@ -107,7 +107,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         public async void Subscribe_OnTokenValidatedDefault_CompletesSuccessfully()
         {
             _jwtEvents = _jwtDiagnostics.Subscribe(_jwtEvents);
-            await _jwtEvents.TokenValidated(new TokenValidatedContext(_httpContext, _authScheme, _jwtOptions)).ConfigureAwait(false);
+            await _jwtEvents.TokenValidated(new TokenValidatedContext(_httpContext, _authScheme, _jwtOptions));
 
             AssertSuccess(false);
         }
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         public async void Subscribe_OnChallengeDefault_CompletesSuccessfully()
         {
             _jwtEvents = _jwtDiagnostics.Subscribe(_jwtEvents);
-            await _jwtEvents.Challenge(new JwtBearerChallengeContext(_httpContext, _authScheme, _jwtOptions, new AuthenticationProperties())).ConfigureAwait(false);
+            await _jwtEvents.Challenge(new JwtBearerChallengeContext(_httpContext, _authScheme, _jwtOptions, new AuthenticationProperties()));
 
             AssertSuccess(false);
         }

--- a/tests/Microsoft.Identity.Web.Test/Resource/OpenIdConnectMiddlewareDiagnosticsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/OpenIdConnectMiddlewareDiagnosticsTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnRedirectToIdentityProvider = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.RedirectToIdentityProvider(new RedirectContext(_httpContext, _authScheme, _openIdOptions, _authProperties) { ProtocolMessage = new OpenIdConnectMessage() }).ConfigureAwait(false);
+            await _openIdEvents.RedirectToIdentityProvider(new RedirectContext(_httpContext, _authScheme, _openIdOptions, _authProperties) { ProtocolMessage = new OpenIdConnectMessage() });
 
             AssertSuccess();
         }
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnMessageReceived = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.MessageReceived(new MessageReceivedContext(_httpContext, _authScheme, _openIdOptions, _authProperties) { ProtocolMessage = new OpenIdConnectMessage() }).ConfigureAwait(false);
+            await _openIdEvents.MessageReceived(new MessageReceivedContext(_httpContext, _authScheme, _openIdOptions, _authProperties) { ProtocolMessage = new OpenIdConnectMessage() });
 
             AssertSuccess();
         }
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnAuthorizationCodeReceived = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.AuthorizationCodeReceived(new AuthorizationCodeReceivedContext(_httpContext, _authScheme, _openIdOptions, _authProperties)).ConfigureAwait(false);
+            await _openIdEvents.AuthorizationCodeReceived(new AuthorizationCodeReceivedContext(_httpContext, _authScheme, _openIdOptions, _authProperties));
 
             AssertSuccess();
         }
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnTokenResponseReceived = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.TokenResponseReceived(new TokenResponseReceivedContext(_httpContext, _authScheme, _openIdOptions, _httpContext.User, _authProperties)).ConfigureAwait(false);
+            await _openIdEvents.TokenResponseReceived(new TokenResponseReceivedContext(_httpContext, _authScheme, _openIdOptions, _httpContext.User, _authProperties));
 
             AssertSuccess();
         }
@@ -93,7 +93,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnTokenValidated = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.TokenValidated(new TokenValidatedContext(_httpContext, _authScheme, _openIdOptions, _httpContext.User, _authProperties)).ConfigureAwait(false);
+            await _openIdEvents.TokenValidated(new TokenValidatedContext(_httpContext, _authScheme, _openIdOptions, _httpContext.User, _authProperties));
 
             AssertSuccess();
         }
@@ -103,7 +103,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnUserInformationReceived = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.UserInformationReceived(new UserInformationReceivedContext(_httpContext, _authScheme, _openIdOptions, _httpContext.User, _authProperties)).ConfigureAwait(false);
+            await _openIdEvents.UserInformationReceived(new UserInformationReceivedContext(_httpContext, _authScheme, _openIdOptions, _httpContext.User, _authProperties));
 
             AssertSuccess();
         }
@@ -113,7 +113,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnAuthenticationFailed = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.AuthenticationFailed(new AuthenticationFailedContext(_httpContext, _authScheme, _openIdOptions)).ConfigureAwait(false);
+            await _openIdEvents.AuthenticationFailed(new AuthenticationFailedContext(_httpContext, _authScheme, _openIdOptions));
 
             AssertSuccess();
         }
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnRemoteSignOut = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.RemoteSignOut(new RemoteSignOutContext(_httpContext, _authScheme, _openIdOptions, new OpenIdConnectMessage())).ConfigureAwait(false);
+            await _openIdEvents.RemoteSignOut(new RemoteSignOutContext(_httpContext, _authScheme, _openIdOptions, new OpenIdConnectMessage()));
 
             AssertSuccess();
         }
@@ -133,7 +133,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnRedirectToIdentityProviderForSignOut = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.RedirectToIdentityProviderForSignOut(new RedirectContext(_httpContext, _authScheme, _openIdOptions, _authProperties)).ConfigureAwait(false);
+            await _openIdEvents.RedirectToIdentityProviderForSignOut(new RedirectContext(_httpContext, _authScheme, _openIdOptions, _authProperties));
 
             AssertSuccess();
         }
@@ -143,7 +143,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         {
             _openIdEvents.OnSignedOutCallbackRedirect = _eventHandler;
             _openIdDiagnostics.Subscribe(_openIdEvents);
-            await _openIdEvents.SignedOutCallbackRedirect(new RemoteSignOutContext(_httpContext, _authScheme, _openIdOptions, new OpenIdConnectMessage())).ConfigureAwait(false);
+            await _openIdEvents.SignedOutCallbackRedirect(new RemoteSignOutContext(_httpContext, _authScheme, _openIdOptions, new OpenIdConnectMessage()));
 
             AssertSuccess();
         }

--- a/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopeOrAppPermissionPolicyTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopeOrAppPermissionPolicyTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(claimType, AppPermission) }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName);
 
             // Assert
             Assert.True(allowed.Succeeded);
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(claimType, MultipleAppPermissions) }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName);
 
             // Assert
             Assert.True(allowed.Succeeded);
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Role, "access_as_app2") }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName);
 
             // Assert
             Assert.False(allowed.Succeeded);
@@ -110,7 +110,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Role, AppPermission) }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName);
 
             // Assert
             Assert.True(allowed.Succeeded);
@@ -129,7 +129,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Role, AppPermission) }));
 
             // Act & Assert
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => authorizationService.AuthorizeAsync(user, PolicyName)).ConfigureAwait(false);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => authorizationService.AuthorizeAsync(user, PolicyName));
             Assert.Equal("No policy found: foo.", exception.Message);
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Role, AppPermission), new Claim(ClaimConstants.Scp, Scope) }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName);
 
             // Assert
             Assert.True(allowed.Succeeded);

--- a/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopePolicyTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopePolicyTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(claimType, SingleScope) }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, policyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, policyName);
 
             // Assert
             Assert.True(allowed.Succeeded);
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(claimType, MultipleScopes) }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, policyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, policyName);
 
             // Assert
             Assert.True(allowed.Succeeded);
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Scp, UserRead) }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName);
 
             // Assert
             Assert.False(allowed.Succeeded);
@@ -109,7 +109,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Scp, UserRead) }));
 
             // Act
-            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName).ConfigureAwait(false);
+            var allowed = await authorizationService.AuthorizeAsync(user, PolicyName);
 
             // Assert
             Assert.True(allowed.Succeeded);
@@ -127,7 +127,7 @@ namespace Microsoft.Identity.Web.Test.Resource
                 new CaseSensitiveClaimsIdentity(new Claim[] { new Claim(ClaimConstants.Scp, SingleScope) }));
 
             // Act & Assert
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => authorizationService.AuthorizeAsync(user, PolicyName)).ConfigureAwait(false);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => authorizationService.AuthorizeAsync(user, PolicyName));
             Assert.Equal("No policy found: foo.", exception.Message);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/UtilityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/UtilityTests.cs
@@ -16,23 +16,23 @@ namespace Microsoft.Identity.Web.Test
             // measure task with no result
             var taskDuration = TimeSpan.FromMilliseconds(100);
             var epsilon = TimeSpan.FromMilliseconds(30).Ticks;
-            var measure = await Task.Delay(taskDuration).Measure().ConfigureAwait(false);
+            var measure = await Task.Delay(taskDuration).Measure();
             Assert.True(Math.Abs(measure.Ticks - taskDuration.Ticks) < epsilon, $"{(measure.Ticks - taskDuration.Ticks) / TimeSpan.TicksPerMillisecond}ms exceeds epsilon of 30ms");
             Assert.Equal(measure.Ticks * 1000.0, measure.MilliSeconds);
 
             // measure task with a result
             var test = "test";
-            var measureResult = await DelayAndReturn(test, taskDuration).Measure().ConfigureAwait(false);
+            var measureResult = await DelayAndReturn(test, taskDuration).Measure();
             Assert.True(Math.Abs(measureResult.Ticks - taskDuration.Ticks) < epsilon);
             Assert.Same(test, measureResult.Result);
 
             // verify that an exception is thrown
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await Task.Run(() => throw new InvalidOperationException()).Measure().ConfigureAwait(false)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await Task.Run(() => throw new InvalidOperationException()).Measure());
         }
 
         private async Task<string> DelayAndReturn(string test, TimeSpan taskDuration)
         {
-            await Task.Delay(taskDuration).ConfigureAwait(false);
+            await Task.Delay(taskDuration);
             return test;
         }
     }

--- a/tests/Microsoft.Identity.Web.Test/WebApiExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebApiExtensionsTests.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Identity.Web.Test
 
             configMock.Received(1).GetSection(ConfigSectionName);
 
-            await AddMicrosoftIdentityWebApiCallsWebApi_TestCommon(services, provider, tokenValidatedFuncMock).ConfigureAwait(false);
+            await AddMicrosoftIdentityWebApiCallsWebApi_TestCommon(services, provider, tokenValidatedFuncMock);
         }
 
 #if NET8_0
@@ -332,7 +332,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Contains(configuredAppOptions, o => o.Action == _configureAppOptions);
             Assert.Contains(configuredMsOptions, o => o.Action == _configureMsOptions);
 
-            await AddMicrosoftIdentityWebApiCallsWebApi_TestCommon(services, provider, tokenValidatedFuncMock).ConfigureAwait(false);
+            await AddMicrosoftIdentityWebApiCallsWebApi_TestCommon(services, provider, tokenValidatedFuncMock);
         }
 
         private async Task AddMicrosoftIdentityWebApiCallsWebApi_TestCommon(IServiceCollection services, ServiceProvider provider, Func<TokenValidatedContext, Task> tokenValidatedFuncMock)
@@ -359,10 +359,10 @@ namespace Microsoft.Identity.Web.Test
                 {
                         new Claim(ClaimConstants.Scope, Constants.Scope),
                 }));
-            await jwtOptions.Events.TokenValidated(tokenValidatedContext).ConfigureAwait(false);
+            await jwtOptions.Events.TokenValidated(tokenValidatedContext);
 
             // Assert events called
-            await tokenValidatedFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<TokenValidatedContext>()).ConfigureAwait(false);
+            await tokenValidatedFuncMock.ReceivedWithAnyArgs().Invoke(Arg.Any<TokenValidatedContext>());
             Assert.NotNull(httpContext.GetTokenUsedToCallWebAPI());
         }
     }


### PR DESCRIPTION
Per [the guidance in the XUnit docs](https://xunit.net/xunit.analyzers/rules/xUnit1030), removing await configurations can cause unexpected behavior as the test framework is not able to control the awaited processes without these configurations. This has led to flaky tests through intermittent race conditions.