### PR TITLE
Fix TokenCacheEncryption tests in .NET 9

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/CacheEncryptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CacheEncryptionTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Web.Test
                 .GetType()
                 .GetField("_entries", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
                 .GetValue(content1) as IDictionary)!;
-#elif NET8_0_OR_GREATER
+#elif NET8_0
             dynamic content1 = memoryCache
                 .GetType()
                 .GetField("_coherentState", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
@@ -73,6 +73,15 @@ namespace Microsoft.Identity.Web.Test
             memoryCacheContent = (content1?
                 .GetType()
                 .GetField("_stringEntries", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .GetValue(content1) as IDictionary)!;
+#elif NET9_0_OR_GREATER
+            dynamic content1 = memoryCache
+                .GetType()
+                .GetField("_coherentState", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(memoryCache)!;
+            memoryCacheContent = (content1?
+                .GetType()
+                .GetProperty("EntriesCollection", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
                 .GetValue(content1) as IDictionary)!;
 #else
             memoryCacheContent = (memoryCache


### PR DESCRIPTION
# Fix TokenCacheEncryption tests in .NET 9
