### PR TITLE
Fix reflection in MemoryCache tests to support both versions seen in .NET 9 RCs

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/CacheEncryptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CacheEncryptionTests.cs
@@ -79,9 +79,12 @@ namespace Microsoft.Identity.Web.Test
                 .GetType()
                 .GetField("_coherentState", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
                 .GetValue(memoryCache)!;
-            memoryCacheContent = (content1?
-                .GetType()
-                .GetProperty("EntriesCollection", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+            Type? content1Type = content1?.GetType();
+            // The internals of CoherentState seem to change between .NET 9 RCs
+            memoryCacheContent = ((
+                content1Type?.GetProperty("_entries", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic) ??
+                content1Type?.GetProperty("_stringEntries", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                )
                 .GetValue(content1) as IDictionary)!;
 #else
             memoryCacheContent = (memoryCache


### PR DESCRIPTION
Fix reflection in `MemoryCache` tests to support both versions seen in .NET 9 RCs. In RC1 there was one entry collection while in RC2 it was split back out as seen in previous versions of .NET: https://github.com/dotnet/runtime/commit/7ca789e12cbd9c1da8a9de68448d9835e5aa9784