### PR TITLE
Update GitHub Action to run unit tests

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,4 +1,4 @@
-name: Build and run Id Web tests
+name: "Run unit tests"
 
 on:
   push:
@@ -17,60 +17,60 @@ jobs:
   build:
     runs-on: windows-latest
     continue-on-error: true
-    name: IdWeb GitHub Action Test
+    name: "Build and run unit tests"
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v4.2.1
 
-    - name: Setup .NET 6.0.301
-      uses: actions/setup-dotnet@v2.1.0
+    - name: Setup .NET 6.0.x
+      uses: actions/setup-dotnet@v4.0.1
       with:
-        dotnet-version: 6.0.301
+        dotnet-version: 6.0.x
 
     - name: Setup .NET 7.0.x
-      uses: actions/setup-dotnet@v2.1.0
+      uses: actions/setup-dotnet@v4.0.1
       with:
         dotnet-version: 7.0.x
 
     - name: Setup .NET 8.0.x
-      uses: actions/setup-dotnet@v2.1.0
+      uses: actions/setup-dotnet@v4.0.1
       with:
         dotnet-version: 8.0.x
 
     - name: Setup .NET 9.0.x
-      uses: actions/setup-dotnet@v2.1.0
+      uses: actions/setup-dotnet@v4.0.1
       with:
         dotnet-version: 9.0.100-rc.2.24474.11
 
-    - name: 'Setup msbuild'
-      uses: microsoft/setup-msbuild@v1.1
+    - name: 'Setup MSBuild'
+      uses: microsoft/setup-msbuild@v2
       with:
         msbuild-architecture: x64
 
     - name: Setup wasm-tools
       run: dotnet workload install wasm-tools
 
-    - name: Build IdWeb for release
+    - name: Build solution
       run: msbuild Microsoft.Identity.Web.sln -r -t:build -verbosity:m -property:Configuration=Release
 
     - name: Test with .NET 6.0.x
       run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net6.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 
     - name: Test with .NET 7.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net7.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName=IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net7.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
     
     - name: Test with .NET 8.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net8.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName=IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net8.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 
     - name: Test with .NET 9.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net9.0 -p:FROM_GITHUB_ACTION=true -p:TargetNet9=True --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName=IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net9.0 -p:FROM_GITHUB_ACTION=true -p:TargetNet9=True --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 
     - name: Test with .NET 462
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net462 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName=IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net462 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 
     - name: Test with .NET 472
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net472 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName=IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net472 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 
-    - name: Test with .NET standard2.0
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f netstandard2.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName=IntegrationTests)"
+    - name: Test with .NET Standard 2.0
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f netstandard2.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -54,16 +54,16 @@ jobs:
       run: msbuild Microsoft.Identity.Web.sln -r -t:build -verbosity:m -property:Configuration=Release
 
     - name: Test with .NET 6.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net6.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net6.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
 
     - name: Test with .NET 7.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net7.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net7.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
     
     - name: Test with .NET 8.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net8.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net8.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
 
     - name: Test with .NET 9.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net9.0 -p:FROM_GITHUB_ACTION=true -p:TargetNet9=True --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net9.0 -p:FROM_GITHUB_ACTION=true -p:TargetNet9=True --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
 
     - name: Test with .NET 462
       run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net462 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -54,23 +54,23 @@ jobs:
       run: msbuild Microsoft.Identity.Web.sln -r -t:build -verbosity:m -property:Configuration=Release
 
     - name: Test with .NET 6.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net6.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net6.0 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
 
     - name: Test with .NET 7.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net7.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net7.0 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
     
     - name: Test with .NET 8.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net8.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net8.0 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
 
     - name: Test with .NET 9.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net9.0 -p:FROM_GITHUB_ACTION=true -p:TargetNet9=True --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net9.0 -v normal -p:FROM_GITHUB_ACTION=true -p:TargetNet9=True --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
 
     - name: Test with .NET 462
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net462 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net462 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 
     - name: Test with .NET 472
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net472 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net472 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 
     - name: Test with .NET Standard 2.0
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f netstandard2.0 -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
+      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f netstandard2.0 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -18,7 +18,7 @@
 		<XunitVersion>2.9.2</XunitVersion>
 		<XunitRunnerVisualStudioVersion>2.8.2</XunitRunnerVisualStudioVersion>
     <XunitAssertVersion>2.9.2</XunitAssertVersion>
-    <XunitExtensibilityCoreVersion>2.4.2</XunitExtensibilityCoreVersion>
+    <XunitExtensibilityCoreVersion>2.9.2</XunitExtensibilityCoreVersion>
     <NSubstituteVersion>4.2.2</NSubstituteVersion>
     <NSubstituteAnalyzersCSharpVersion>1.0.13</NSubstituteAnalyzersCSharpVersion>
 		<CoverletCollectorVersion>3.1.2</CoverletCollectorVersion>


### PR DESCRIPTION
Update GitHub Action to run unit tests:
- Fixes test filters, only .NET 6 tests were running
- Updates task versions to the latest