### PR TITLE
Update template-install-dependencies.yaml

### DIFF
--- a/build/template-install-dependencies.yaml
+++ b/build/template-install-dependencies.yaml
@@ -1,5 +1,7 @@
 #template-install-dependencies.yaml
-
+parameters:
+  authenticateForFeed: 'true'
+  
 #install dotnet core
 
 steps:
@@ -46,6 +48,7 @@ steps:
     
 - task: NuGetAuthenticate@1
   displayName: NuGet Authenticate
+  condition: eq('${{ parameters.authenticateForFeed }}', 'true')
   inputs:
       nuGetServiceConnections: 'IDDP Feed'
 

--- a/build/template-onebranch-release-build.yaml
+++ b/build/template-onebranch-release-build.yaml
@@ -9,6 +9,8 @@ steps:
  
 # Bootstrap the build
 - template: template-install-dependencies.yaml
+  parameters:
+    authenticateForFeed: 'false'
  
 # Nuget Restore and Build Microsoft.Identity.Web.sln
 - template: template-restore-build-MSIdentityWeb.yaml


### PR DESCRIPTION
# Fix builds requiring access to IDDP feed

- not needed to authenticate when running in IDDP itself
- needed from DevEx