### PR TITLE
Fix DevEx and IDDP builds

### DIFF
--- a/build/template-install-dependencies.yaml
+++ b/build/template-install-dependencies.yaml
@@ -1,6 +1,4 @@
 #template-install-dependencies.yaml
-parameters:
-  authenticateForFeed: 'true'
   
 #install dotnet core
 
@@ -46,11 +44,11 @@ steps:
     KeyVaultName: 'msidlabs'
     SecretsFilter: 'LabAuth'
     
-- task: NuGetAuthenticate@1
-  displayName: NuGet Authenticate
-  condition: eq('${{ parameters.authenticateForFeed }}', 'true')
-  inputs:
-      nuGetServiceConnections: 'IDDP Feed'
+# - task: NuGetAuthenticate@1
+#   displayName: NuGet Authenticate
+#   condition: eq('${{ parameters.authenticateForFeed }}', 'true')
+#   inputs:
+#       nuGetServiceConnections: 'IDDP Feed'
 
 - powershell: |
    $kvSecretBytes = [System.Convert]::FromBase64String('$(LabAuth)')

--- a/build/template-install-dependencies.yaml
+++ b/build/template-install-dependencies.yaml
@@ -44,11 +44,8 @@ steps:
     KeyVaultName: 'msidlabs'
     SecretsFilter: 'LabAuth'
     
-# - task: NuGetAuthenticate@1
-#   displayName: NuGet Authenticate
-#   condition: eq('${{ parameters.authenticateForFeed }}', 'true')
-#   inputs:
-#       nuGetServiceConnections: 'IDDP Feed'
+- task: NuGetAuthenticate@1
+  displayName: NuGet Authenticate
 
 - powershell: |
    $kvSecretBytes = [System.Convert]::FromBase64String('$(LabAuth)')

--- a/build/template-onebranch-release-build.yaml
+++ b/build/template-onebranch-release-build.yaml
@@ -9,8 +9,6 @@ steps:
  
 # Bootstrap the build
 - template: template-install-dependencies.yaml
-  parameters:
-    authenticateForFeed: 'false'
  
 # Nuget Restore and Build Microsoft.Identity.Web.sln
 - template: template-restore-build-MSIdentityWeb.yaml

--- a/build/template-pack-nuget.yaml
+++ b/build/template-pack-nuget.yaml
@@ -16,8 +16,6 @@ steps:
     nobuild: '${{parameters.NoBuild}}'
     packagesToPack: '${{ parameters.ProjectRootPath }}\${{ parameters.AssemblyName }}.csproj'
     IncludeSymbols: true
-    feedsToUse: 'config'
-    nugetConfigPath: NuGet.config
     verbosityPack: normal
     packDirectory:
     arguments: '--configuration ${{ parameters.BuildConfiguration }}'

--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -18,9 +18,11 @@ steps:
 
 - script: dotnet nuget remove source NuGet
   displayName: 'Remove external "NuGet" Source'
+  continueOnError: true # could have been run already in a different job on the same machine
 
 - script: dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
   displayName: 'Add IDDP artifacts as NuGet Source'
+  continueOnError: true # could have been run already in a different job on the same machine
 
 - task: DotNetCoreCLI@2
   displayName: 'Build solution Microsoft.Identity.Web.sln'

--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -11,13 +11,16 @@ steps:
     dotnet workload restore $(IdWebSourceDir)tests\DevApps\blazorwasm-b2c\blazorwasm2-b2c.csproj
   displayName: 'Install wasm-tools'
 
-- task: NuGetAuthenticate@1
-  displayName: NuGet Authenticate
-  inputs:
-      nuGetServiceConnections: 'IDDP Feed'
+# - task: NuGetAuthenticate@1
+#   displayName: NuGet Authenticate
+#   inputs:
+#       nuGetServiceConnections: 'IDDP Feed'
 
-- script: dotnet nuget update source NuGet --source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json --configfile  "$(Build.SourcesDirectory)\Nuget.config"
-  displayName: 'Add NuGet Source for MISE'
+- script: dotnet nuget remove source NuGet
+  displayName: 'Remove external "NuGet" Source'
+
+- script: dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
+  displayName: 'Add IDDP artifacts as NuGet Source'
 
 - task: DotNetCoreCLI@2
   displayName: 'Build solution Microsoft.Identity.Web.sln'
@@ -25,8 +28,6 @@ steps:
     command: 'custom'
     custom: 'build'
     projects: '$(IdWebSourceDir)Microsoft.Identity.Web.sln'
-    feedsToUse: 'config'
-    nugetConfigPath: NuGet.config
     arguments: '-p:configuration=${{ parameters.BuildConfiguration }} -p:RunCodeAnalysis=true -p:MicrosoftIdentityWebVersion=${{ parameters.MicrosoftIdentityWebVersion }} -p:SourceLinkCreate=true'
 
 # This task is needed so that the 1CS Rolsyn analyzers task works.

--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -16,6 +16,7 @@ steps:
     if ($nugetSourceIsExternal) {
         dotnet nuget remove source NuGet
         dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
+        dotnet nuget list source
     }
   displayName: 'Remove external "NuGet" Source and add "IDDP artifacts" as a NuGet Source, if needed.'
 

--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -11,18 +11,13 @@ steps:
     dotnet workload restore $(IdWebSourceDir)tests\DevApps\blazorwasm-b2c\blazorwasm2-b2c.csproj
   displayName: 'Install wasm-tools'
 
-# - task: NuGetAuthenticate@1
-#   displayName: NuGet Authenticate
-#   inputs:
-#       nuGetServiceConnections: 'IDDP Feed'
-
-- script: dotnet nuget remove source NuGet
-  displayName: 'Remove external "NuGet" Source'
-  continueOnError: true # could have been run already in a different job on the same machine
-
-- script: dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
-  displayName: 'Add IDDP artifacts as NuGet Source'
-  continueOnError: true # could have been run already in a different job on the same machine
+- powershell: |
+    $nugetSourceIsExternal = (dotnet nuget list source --format Short).Contains("https://api.nuget.org/v3/index.json")
+    if ($nugetSourceIsExternal) {
+        dotnet nuget remove source NuGet
+        dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
+    }
+  displayName: 'Remove external "NuGet" Source and add "IDDP artifacts" as a NuGet Source, if needed.'
 
 - task: DotNetCoreCLI@2
   displayName: 'Build solution Microsoft.Identity.Web.sln'


### PR DESCRIPTION
# Fix DevEx and IDDP builds

**Goal:**
When building internally, use an internal Nuget feed, instead of nuget.org

**Did you know?** 
When you are accessing an artifact's feed in the same project, you don't need to specify a service connection in Azure DevOps, NuGetAuthenticate@1 without it a service connection works. If you specify a service connection, you'll need some credentials, like a PAT that will need to be rotated ...

**What** this PR does:
This PR modifies the build scripts to just run nuget authenticate (no service connection), and removes the Nuget.org source, and adds the IDDP source

