### PR TITLE
ASP.NET Core (and other) cross-link updates

### DIFF
--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/Shared/MainLayout.Auth.razor
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/Shared/MainLayout.Auth.razor
@@ -7,7 +7,7 @@
 <div class="main">
     <div class="top-row px-4 auth">
         <LoginDisplay />
-        <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
+        <a href="https://learn.microsoft.com/aspnet/" target="_blank">About</a>
     </div>
 
     <div class="content px-4">

--- a/ProjectTemplates/templates/BlazorServerWeb-CSharp/Shared/MainLayout.NoAuth.razor
+++ b/ProjectTemplates/templates/BlazorServerWeb-CSharp/Shared/MainLayout.NoAuth.razor
@@ -6,7 +6,7 @@
 
 <div class="main">
     <div class="top-row px-4">
-        <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
+        <a href="https://learn.microsoft.com/aspnet/" target="_blank">About</a>
     </div>
 
     <div class="content px-4">

--- a/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/Shared/MainLayout.Auth.razor
+++ b/ProjectTemplates/templates/ComponentsWebAssembly-CSharp/Client/Shared/MainLayout.Auth.razor
@@ -7,7 +7,7 @@
 <div class="main">
     <div class="top-row px-4 auth">
         <LoginDisplay />
-        <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
+        <a href="https://learn.microsoft.com/aspnet/" target="_blank">About</a>
     </div>
 
     <div class="content px-4">

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/Pages/Index.cshtml
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/Pages/Index.cshtml
@@ -6,7 +6,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>
 @*#if (GenerateApiOrGraph)
 

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 a.navbar-brand {

--- a/ProjectTemplates/templates/RazorPagesWeb-CSharp/wwwroot/js/site.js
+++ b/ProjectTemplates/templates/RazorPagesWeb-CSharp/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.

--- a/ProjectTemplates/templates/StarterWeb-CSharp/Views/Home/Index.cshtml
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/Views/Home/Index.cshtml
@@ -4,7 +4,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>
 @*#if (GenerateApiOrGraph)
 

--- a/ProjectTemplates/templates/StarterWeb-CSharp/wwwroot/css/site.css
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 a.navbar-brand {

--- a/ProjectTemplates/templates/StarterWeb-CSharp/wwwroot/js/site.js
+++ b/ProjectTemplates/templates/StarterWeb-CSharp/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ If you find a security issue with our libraries or services, please report it to
 
 ## Trademarks.
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
 
 Copyright (c) Microsoft Corporation.  All rights reserved. Licensed under the MIT License (the "License").

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft Identity Web
 
-[Microsoft Identity Web](https://www.nuget.org/packages/Microsoft.Identity.Web) is a library which contains a set of reusable classes used in conjunction with ASP.NET Core for integrating with the [Microsoft identity platform](https://docs.microsoft.com/en-us/azure/active-directory/develop/) (formerly *Azure AD v2.0 endpoint*) and [AAD B2C](https://docs.microsoft.com/en-us/azure/active-directory-b2c/).
+[Microsoft Identity Web](https://www.nuget.org/packages/Microsoft.Identity.Web) is a library which contains a set of reusable classes used in conjunction with ASP.NET Core for integrating with the [Microsoft identity platform](https://learn.microsoft.com/azure/active-directory/develop/) (formerly *Azure AD v2.0 endpoint*) and [AAD B2C](https://learn.microsoft.com/azure/active-directory-b2c/).
 
 This library is for specific usage with:
 
@@ -9,7 +9,7 @@ This library is for specific usage with:
 
 Quick links:
 
-| [Conceptual documentation](https://github.com/AzureAD/microsoft-identity-web/wiki) | [Getting Started](https://github.com/AzureAD/microsoft-identity-web/wiki#getting-started-with-microsoft-identity-web) | [Reference documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identity.web?view=azure-dotnet-preview) | [Sample Code Web App](https://github.com/AzureAD/microsoft-identity-web/wiki/web-app-samples) | [Sample Code Web API](https://github.com/AzureAD/microsoft-identity-web/wiki/web-api-samples) | [Support](README.md#community-help-and-support) |
+| [Conceptual documentation](https://github.com/AzureAD/microsoft-identity-web/wiki) | [Getting Started](https://github.com/AzureAD/microsoft-identity-web/wiki#getting-started-with-microsoft-identity-web) | [Reference documentation](https://learn.microsoft.com/dotnet/api/microsoft.identity.web?view=azure-dotnet-preview) | [Sample Code Web App](https://github.com/AzureAD/microsoft-identity-web/wiki/web-app-samples) | [Sample Code Web API](https://github.com/AzureAD/microsoft-identity-web/wiki/web-api-samples) | [Support](README.md#community-help-and-support) |
 | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------| ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
 
 ## Nuget package

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets Microsoft's [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)) of a security vulnerability, please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets Microsoft's [Microsoft's definition of a security vulnerability](https://learn.microsoft.com/previous-versions/tn-archive/cc751383(v=technet.10)) of a security vulnerability, please report it to us as described below.
 
 ## Reporting Security Issues
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/msrc/pgp-key-msrc).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
@@ -36,6 +36,6 @@ We prefer all communications to be in English.
 
 ## Policy
 
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/msrc/cvd).
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -1,7 +1,7 @@
 # ASP.NET Core
 # Build and test ASP.NET Core projects targeting .NET Core.
 # Add steps that run tests, create a NuGet package, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+# https://learn.microsoft.com/azure/devops/pipelines/languages/dotnet-core
  
 trigger: none
 pr: none

--- a/changelog.md
+++ b/changelog.md
@@ -313,7 +313,7 @@ Support new AzureAD key issuer validator in AddMicrosoftIdentityWebApi by defaul
 - Update to MSAL 4.54.0
 
 ### New Features
-- **Id Web now supports [trimming](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained)**. See [#2210](https://github.com/AzureAD/microsoft-identity-web/pull/2210)
+- **Id Web now supports [trimming](https://learn.microsoft.com/dotnet/core/deploying/trimming/trim-self-contained)**. See [#2210](https://github.com/AzureAD/microsoft-identity-web/pull/2210)
 
 2.10.0
 ==========
@@ -616,7 +616,7 @@ Update to Microsoft.Graph 4.8.0, Microsoft.Graph.Beta 4.18.0-preview, Microsoft.
 ### New Features:
 **A new assembly, [Microsoft.IdentityModel.Validators](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/tree/dev/src/Microsoft.IdentityModel.Validators), is now leveraged in Microsoft.Identity.Web as the AadIssuerValidator. It provides an issuer validator for the Microsoft identity platform (AAD and AAD B2C)**, working for single and multi-tenant applications and v1 and v2 token types. See [Identity.Model](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/1736) and [#1487](https://github.com/AzureAD/microsoft-identity-web/issues/1487). The `MicrosoftIdentityIssuerValidatorFactory` is still in Microsoft.Identity.Web and leverages this new Identity.Model library
 
-**Microsoft.Identity.Web now supports authentication handlers other than JwtBearer,** and the token acquisition in web API understands a higher level abstraction of [SecurityToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.securitytoken?view=azure-dotnet), not only `JwtSecurityToken` . See [#1498](https://github.com/AzureAD/microsoft-identity-web/pull/1498).
+**Microsoft.Identity.Web now supports authentication handlers other than JwtBearer,** and the token acquisition in web API understands a higher level abstraction of [SecurityToken](https://learn.microsoft.com/dotnet/api/microsoft.identitymodel.tokens.securitytoken?view=azure-dotnet), not only `JwtSecurityToken` . See [#1498](https://github.com/AzureAD/microsoft-identity-web/pull/1498).
 
 ### Bug Fixes:
 **Make `Certificate` in `CertificateDescription.cs` `protected internal`.** See [#1484](https://github.com/AzureAD/microsoft-identity-web/pull/1484).
@@ -1105,7 +1105,7 @@ services.AddProtectedWebApi() | services.AddAuthentication().AddMicrosoftWebApi(
 
 - See the [wiki](https://aka.ms/ms-id-web/net5) for migration assistance and more information on the new API.
 - Rename `MsalMemoryTokenCacheOptions.SlidingExpiration` to align with ASP.NET Core and use `AbsoluteExpirationRelativeToNow`. See [issue for details](https://github.com/AzureAD/microsoft-identity-web/issues/250).
-- Removed the `ForceHttpsRedirectUris`, `RedirectUri`, and `PostLogoutRedirectUri` options from `MicrosoftIdentityOptions`. ASP.NET Core recommends the [following guidance](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-3.1) on working with proxies. See [issue for more details](https://github.com/AzureAD/microsoft-identity-web/issues/223).
+- Removed the `ForceHttpsRedirectUris`, `RedirectUri`, and `PostLogoutRedirectUri` options from `MicrosoftIdentityOptions`. ASP.NET Core recommends the [following guidance](https://learn.microsoft.com/aspnet/core/host-and-deploy/proxy-load-balancer) on working with proxies. See [issue for more details](https://github.com/AzureAD/microsoft-identity-web/issues/223).
 - Removed the `SingletonTokenAcquisition` property from `MicrosoftIdentityOptions`. See [issue for details](https://github.com/AzureAD/microsoft-identity-web/issues/249).
 - Microsoft Identity Web now has an `MsalDistributedTokenCacheAdapterOptions` class inheriting from `DistributedCacheEntryOptions` so the token cache serialization can expose their own options. See [issue for details](https://github.com/AzureAD/microsoft-identity-web/issues/251).
 

--- a/docfx_project/articles/intro.md
+++ b/docfx_project/articles/intro.md
@@ -1,6 +1,6 @@
 # Microsoft.Identity.Web
 
-[Microsoft Identity Web](https://www.nuget.org/packages/Microsoft.Identity.Web) is a library which contains a set of reusable classes that you can use to integrate authentication and authorization with the [Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/) to services written in .NET: on top of ASP.NET Core, ASP.NET OWIN, or just plain .NET framework or .NET Core.
+[Microsoft Identity Web](https://www.nuget.org/packages/Microsoft.Identity.Web) is a library which contains a set of reusable classes that you can use to integrate authentication and authorization with the [Microsoft identity platform](https://learn.microsoft.com/azure/active-directory/develop/) to services written in .NET: on top of ASP.NET Core, ASP.NET OWIN, or just plain .NET framework or .NET Core.
 
 This library is for specific usage with:
 

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -1,6 +1,6 @@
 # Microsoft.Identity.Web
 
-[Microsoft Identity Web](https://www.nuget.org/packages/Microsoft.Identity.Web) is a library which contains a set of reusable classes that you can use to integrate authentication and authorization with the [Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/) to services written in .NET: on top of ASP.NET Core, ASP.NET OWIN, or just plain .NET framework or .NET Core.
+[Microsoft Identity Web](https://www.nuget.org/packages/Microsoft.Identity.Web) is a library which contains a set of reusable classes that you can use to integrate authentication and authorization with the [Microsoft identity platform](https://learn.microsoft.com/azure/active-directory/develop/) to services written in .NET: on top of ASP.NET Core, ASP.NET OWIN, or just plain .NET framework or .NET Core.
 
 This library is for specific usage with:
 

--- a/src/Microsoft.Identity.Web.Certificate/CertificateLoaderHelper.cs
+++ b/src/Microsoft.Identity.Web.Certificate/CertificateLoaderHelper.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Identity.Web
             return X509KeyStorageFlags.MachineKeySet;
 #else
             // This is for app developers using a Mac. MacOS does not support the EphemeralKeySet flag.
-            // See https://learn.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography#write-a-pkcs12pfx
+            // See https://learn.microsoft.com/dotnet/standard/security/cross-platform-cryptography#write-a-pkcs12pfx
             if (OsHelper.IsMacPlatform())
             {
                 return X509KeyStorageFlags.DefaultKeySet;

--- a/src/Microsoft.Identity.Web.Certificate/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web.Certificate/Microsoft.Identity.Web.xml
@@ -157,7 +157,7 @@
         <member name="P:Microsoft.Identity.Web.DefaultCertificateLoader.UserAssignedManagedIdentityClientId">
             <summary>
             User assigned managed identity client ID (as opposed to system assigned managed identity)
-            See https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-portal.
+            See https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-portal.
             </summary>
         </member>
         <member name="M:Microsoft.Identity.Web.DefaultCertificateLoader.LoadIfNeeded(Microsoft.Identity.Web.CertificateDescription)">

--- a/src/Microsoft.Identity.Web.Certificateless/CompatibilitySuppressions.xml
+++ b/src/Microsoft.Identity.Web.Certificateless/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>

--- a/src/Microsoft.Identity.Web.DownstreamApi/CompatibilitySuppressions.xml
+++ b/src/Microsoft.Identity.Web.DownstreamApi/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>

--- a/src/Microsoft.Identity.Web.GraphServiceClient/CompatibilitySuppressions.xml
+++ b/src/Microsoft.Identity.Web.GraphServiceClient/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>

--- a/src/Microsoft.Identity.Web.GraphServiceClient/GraphServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.GraphServiceClient/GraphServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The service collection to chain.</returns>
         public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services, Action<GraphServiceClientOptions> configureMicrosoftGraphOptions)
         {
-            // https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
+            // https://learn.microsoft.com/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
             services.AddOptions<GraphServiceClientOptions>().Configure(configureMicrosoftGraphOptions);
 
             // Add the Graph Service client depending on the lifetime of ITokenAcquisition

--- a/src/Microsoft.Identity.Web.GraphServiceClientBeta/GraphBetaServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.GraphServiceClientBeta/GraphBetaServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The service collection to chain.</returns>
         public static IServiceCollection AddMicrosoftGraphBeta(this IServiceCollection services, Action<GraphServiceClientOptions> configureMicrosoftGraphOptions)
         {
-            // https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
+            // https://learn.microsoft.com/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
             services.AddOptions<GraphServiceClientOptions>().Configure(configureMicrosoftGraphOptions);
 
             // Add the Graph Service client depending on the lifetime of ITokenAcquisition

--- a/src/Microsoft.Identity.Web.MicrosoftGraph/CompatibilitySuppressions.xml
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>

--- a/src/Microsoft.Identity.Web.MicrosoftGraph/GraphServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.MicrosoftGraph/GraphServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Web
         /// <returns>The service collection to chain.</returns>
         public static IServiceCollection AddMicrosoftGraph(this IServiceCollection services, Action<MicrosoftGraphOptions> configureMicrosoftGraphOptions)
         {
-            // https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
+            // https://learn.microsoft.com/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
             services.AddOptions<MicrosoftGraphOptions>().Configure(configureMicrosoftGraphOptions);
 
             services.AddScoped<GraphServiceClient, GraphServiceClient>(serviceProvider =>

--- a/src/Microsoft.Identity.Web.MicrosoftGraphBeta/CompatibilitySuppressions.xml
+++ b/src/Microsoft.Identity.Web.MicrosoftGraphBeta/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/HttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/HttpContextExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Web
         /// it can be used in the actions.</param>
         internal static void StoreTokenUsedToCallWebAPI(this HttpContext httpContext, SecurityToken? token)
         {
-            // lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+            // lock due to https://learn.microsoft.com/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
             lock (httpContext)
             {
                 httpContext.Items[Constants.JwtSecurityTokenUsedToCallWebApi] = token;
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Web
         /// <returns><see cref="SecurityToken"/> used to call the web API.</returns>
         internal static SecurityToken? GetTokenUsedToCallWebAPI(this HttpContext httpContext)
         {
-            // lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+            // lock due to https://learn.microsoft.com/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
             lock (httpContext)
             {
                 return httpContext.Items[Constants.JwtSecurityTokenUsedToCallWebApi] as SecurityToken;

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisition-AspnetCore.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisition-AspnetCore.cs
@@ -131,10 +131,10 @@ namespace Microsoft.Identity.Web
 
         /// <summary>
         /// This handler is executed after the authorization code is received (once the user signs-in and consents) during the
-        /// <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow'>authorization code flow</a> in a web app.
+        /// <a href='https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow'>authorization code flow</a> in a web app.
         /// It uses the code to request an access token from the Microsoft identity platform and caches the tokens and an entry about the signed-in user's account in the MSAL's token cache.
         /// The access token (and refresh token) provided in the <see cref="AuthorizationCodeReceivedContext"/>, once added to the cache, are then used to acquire more tokens using the
-        /// <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a> for the signed-in user's account,
+        /// <a href='https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a> for the signed-in user's account,
         /// in order to call to downstream APIs.
         /// </summary>
         /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisitionAspnetCoreHost.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisitionAspnetCoreHost.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Identity.Web
             MergedOptions mergedOptions)
         {
             // need to lock to avoid threading issues with code outside of this library
-            // https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+            // https://learn.microsoft.com/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
             lock (httpContext)
             {
                 return UriHelper.BuildAbsolute(
@@ -187,7 +187,7 @@ namespace Microsoft.Identity.Web
             var httpContext = CurrentHttpContext;
             if (httpContext != null)
             {
-                // Need to lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+                // Need to lock due to https://learn.microsoft.com/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
                 lock (httpContext)
                 {
                     return httpContext.User;

--- a/src/Microsoft.Identity.Web.TokenAcquisition/CompatibilitySuppressions.xml
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityOptions.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Identity.Web
 
         /// <summary>
         /// Used, when deployed to Azure, to specify explicitly a user assigned managed identity.
-        /// See https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-portal.
+        /// See https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-portal.
         /// </summary>
         public string? UserAssignedManagedIdentityClientId { get; set; }
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Identity.Web
         /// Typically used from a web app or web API controller, this method retrieves an access token
         /// for a downstream API using;
         /// 1) the token cache (for web apps and web APIs) if a token exists in the cache
-        /// 2) or the <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a>
+        /// 2) or the <a href='https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a>
         /// in web APIs, for the user account that is ascertained from claims provided in the current claims principal.
         /// instance of the current HttpContext.
         /// </summary>
@@ -522,7 +522,7 @@ namespace Microsoft.Identity.Web
         /// Typically used from a web app or web API controller, this method retrieves an access token
         /// for a downstream API using;
         /// 1) the token cache (for web apps and web APIs) if a token exists in the cache
-        /// 2) or the <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a>
+        /// 2) or the <a href='https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow'>on-behalf-of flow</a>
         /// in web APIs, for the user account that is ascertained from the claims provided in the current claims principal.
         /// instance of the current HttpContext.
         /// </summary>

--- a/src/Microsoft.Identity.Web.TokenCache/ClaimsPrincipalExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/ClaimsPrincipalExtensions.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Identity.Web
         /// <param name="claimsPrincipal">Claims about the user/account.</param>
         /// <returns>A string containing the display name for the user, as determined by Azure AD (v1.0) and Microsoft identity platform (v2.0) tokens,
         /// or <c>null</c> if the claims cannot be found.</returns>
-        /// <remarks>See https://docs.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims. </remarks>
+        /// <remarks>See https://learn.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims. </remarks>
         public static string? GetDisplayName(this ClaimsPrincipal claimsPrincipal)
         {
             return GetClaimValue(

--- a/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.xml
@@ -608,7 +608,7 @@
             <param name="claimsPrincipal">Claims about the user/account.</param>
             <returns>A string containing the display name for the user, as determined by Azure AD (v1.0) and Microsoft identity platform (v2.0) tokens,
             or <c>null</c> if the claims cannot be found.</returns>
-            <remarks>See https://docs.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims. </remarks>
+            <remarks>See https://learn.microsoft.com/azure/active-directory/develop/id-tokens#payload-claims. </remarks>
         </member>
         <member name="M:Microsoft.Identity.Web.ClaimsPrincipalExtensions.GetUserFlowId(System.Security.Claims.ClaimsPrincipal)">
             <summary>

--- a/src/Microsoft.Identity.Web.UI/CompatibilitySuppressions.xml
+++ b/src/Microsoft.Identity.Web.UI/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>PKV006</DiagnosticId>

--- a/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationTokenAcquisition.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Identity.Web
             string accessToken;
             if (httpContext != null)
             {
-                // Need to lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+                // Need to lock due to https://learn.microsoft.com/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
                 lock (httpContext)
                 {
                     accessToken = GetAccessToken(httpContext.Request.Headers);

--- a/src/Microsoft.Identity.Web/CompatibilitySuppressions.xml
+++ b/src/Microsoft.Identity.Web/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>

--- a/src/Microsoft.Identity.Web/CookiePolicyOptionsExtensions.cs
+++ b/src/Microsoft.Identity.Web/CookiePolicyOptionsExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Web
         private const int Fourteen = 14;
 
         /// <summary>
-        /// Handles SameSite cookie issue according to the https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1.
+        /// Handles SameSite cookies according to the ASP.NET Core documentation at https://learn.microsoft.com/aspnet/core/security/samesite.
         /// The default list of user agents that disallow "SameSite=None",
         /// was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
         /// </summary>
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Handles SameSite cookie issue according to the docs: https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+        /// Handles SameSite cookies according to the ASP.NET Core documentation at https://learn.microsoft.com/aspnet/core/security/samesite.
         /// The default list of user agents that disallow "SameSite=None", was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
         /// </summary>
         /// <param name="options"><see cref="CookiePolicyOptions"/>to update.</param>

--- a/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
+++ b/src/Microsoft.Identity.Web/DownstreamWebApiSupport/DownstreamWebApiExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Web
 
             builder.Services.Configure<DownstreamWebApiOptions>(serviceName, configureOptions);
 
-            // https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
+            // https://learn.microsoft.com/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
             builder.Services.AddHttpClient<IDownstreamWebApi, DownstreamWebApi>();
             builder.Services.Configure(serviceName, configureOptions);
             return builder;

--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.xml
@@ -289,7 +289,7 @@
         </member>
         <member name="M:Microsoft.Identity.Web.CookiePolicyOptionsExtensions.HandleSameSiteCookieCompatibility(Microsoft.AspNetCore.Builder.CookiePolicyOptions)">
             <summary>
-            Handles SameSite cookie issue according to the https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1.
+            Handles SameSite cookies according to the ASP.NET Core documentation at https://learn.microsoft.com/aspnet/core/security/samesite.
             The default list of user agents that disallow "SameSite=None",
             was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
             </summary>
@@ -298,7 +298,7 @@
         </member>
         <member name="M:Microsoft.Identity.Web.CookiePolicyOptionsExtensions.HandleSameSiteCookieCompatibility(Microsoft.AspNetCore.Builder.CookiePolicyOptions,System.Func{System.String,System.Boolean})">
             <summary>
-            Handles SameSite cookie issue according to the docs: https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+            Handles SameSite cookies according to the ASP.NET Core documentation at https://learn.microsoft.com/aspnet/core/security/samesite.
             The default list of user agents that disallow "SameSite=None", was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/.
             </summary>
             <param name="options"><see cref="T:Microsoft.AspNetCore.Builder.CookiePolicyOptions"/>to update.</param>
@@ -1816,7 +1816,7 @@
              </summary>
              <remarks>
              For this session cache to work effectively, the ASP.NET Core session has to be configured properly.
-             The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state
+             The latest guidance is provided at https://learn.microsoft.com/aspnet/core/fundamentals/app-state.
             
              In the method <c>public void ConfigureServices(IServiceCollection services)</c> in Startup.cs, add the following:
              <code>
@@ -1909,7 +1909,7 @@
              </summary>
              <remarks>
              For this session cache to work effectively the ASP.NET Core session has to be configured properly.
-             The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state.
+             The latest guidance is provided at https://learn.microsoft.com/aspnet/core/fundamentals/app-state.
             
              In the method <c>public void ConfigureServices(IServiceCollection services)</c> in Startup.cs, add the following:
              <code>
@@ -1933,7 +1933,7 @@
              </summary>
              <remarks>
              For this session cache to work effectively the ASP.NET Core session has to be configured properly.
-             The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state.
+             The latest guidance is provided at https://learn.microsoft.com/aspnet/core/fundamentals/app-state.
             
              In the method <c>public void ConfigureServices(IServiceCollection services)</c> in Startup.cs, add the following:
              <code>

--- a/src/Microsoft.Identity.Web/Resource/RolesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/RolesRequiredHttpContextExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Web.Resource
             IEnumerable<Claim> userClaims;
             ClaimsPrincipal user;
 
-            // Need to lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+            // Need to lock due to https://learn.microsoft.com/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
             lock (context)
             {
                 user = context.User;

--- a/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
+++ b/src/Microsoft.Identity.Web/Resource/ScopesRequiredHttpContextExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Web.Resource
             IEnumerable<Claim> userClaims;
             ClaimsPrincipal user;
 
-            // Need to lock due to https://docs.microsoft.com/en-us/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
+            // Need to lock due to https://learn.microsoft.com/aspnet/core/performance/performance-best-practices?#do-not-access-httpcontext-from-multiple-threads
             lock (context)
             {
                 user = context.User;

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/MsalSessionTokenCacheProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
     /// </summary>
     /// <remarks>
     /// For this session cache to work effectively, the ASP.NET Core session has to be configured properly.
-    /// The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state
+    /// The latest guidance is provided at https://learn.microsoft.com/aspnet/core/fundamentals/app-state.
     ///
     /// In the method <c>public void ConfigureServices(IServiceCollection services)</c> in Startup.cs, add the following:
     /// <code>

--- a/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
+++ b/src/Microsoft.Identity.Web/TokenCacheProviders/Session/SessionTokenCacheProviderExtension.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         /// </summary>
         /// <remarks>
         /// For this session cache to work effectively the ASP.NET Core session has to be configured properly.
-        /// The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state.
+        /// The latest guidance is provided at https://learn.microsoft.com/aspnet/core/fundamentals/app-state.
         ///
         /// In the method <c>public void ConfigureServices(IServiceCollection services)</c> in Startup.cs, add the following:
         /// <code>
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Session
         /// </summary>
         /// <remarks>
         /// For this session cache to work effectively the ASP.NET Core session has to be configured properly.
-        /// The latest guidance is provided at https://docs.microsoft.com/aspnet/core/fundamentals/app-state.
+        /// The latest guidance is provided at https://learn.microsoft.com/aspnet/core/fundamentals/app-state.
         ///
         /// In the method <c>public void ConfigureServices(IServiceCollection services)</c> in Startup.cs, add the following:
         /// <code>

--- a/tests/DevApps/AjaxCallActionsWithDynamicConsent/Views/Home/Index.cshtml
+++ b/tests/DevApps/AjaxCallActionsWithDynamicConsent/Views/Home/Index.cshtml
@@ -4,7 +4,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>
 <div id="idajx"></div>
 @section Scripts {

--- a/tests/DevApps/AjaxCallActionsWithDynamicConsent/wwwroot/css/site.css
+++ b/tests/DevApps/AjaxCallActionsWithDynamicConsent/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 a.navbar-brand {

--- a/tests/DevApps/AjaxCallActionsWithDynamicConsent/wwwroot/js/site.js
+++ b/tests/DevApps/AjaxCallActionsWithDynamicConsent/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.

--- a/tests/DevApps/B2CWebAppCallsWebApi/Client/Startup.cs
+++ b/tests/DevApps/B2CWebAppCallsWebApi/Client/Startup.cs
@@ -34,7 +34,7 @@ namespace WebApp_OpenIDConnect_DotNet
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
                 options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
-                // Handling SameSite cookie according to https://learn.microsoft.com/aspnet/core/security/samesite
+                // Handles SameSite cookies according to https://learn.microsoft.com/aspnet/core/security/samesite.
                 options.HandleSameSiteCookieCompatibility();
             });
 

--- a/tests/DevApps/B2CWebAppCallsWebApi/Client/Startup.cs
+++ b/tests/DevApps/B2CWebAppCallsWebApi/Client/Startup.cs
@@ -34,7 +34,7 @@ namespace WebApp_OpenIDConnect_DotNet
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
                 options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
-                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                // Handling SameSite cookie according to https://learn.microsoft.com/aspnet/core/security/samesite
                 options.HandleSameSiteCookieCompatibility();
             });
 

--- a/tests/DevApps/B2CWebAppCallsWebApi/Client/wwwroot/css/site.css
+++ b/tests/DevApps/B2CWebAppCallsWebApi/Client/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification\ 
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 body {
     padding-top: 50px;

--- a/tests/DevApps/B2CWebAppCallsWebApi/Client/wwwroot/js/site.js
+++ b/tests/DevApps/B2CWebAppCallsWebApi/Client/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.

--- a/tests/DevApps/B2CWebAppCallsWebApi/README-incremental-instructions.md
+++ b/tests/DevApps/B2CWebAppCallsWebApi/README-incremental-instructions.md
@@ -16,7 +16,7 @@ endpoint: Microsoft identity platform
 
 ## About this sample
 
-This sample has a web api and a client web app, both built using the asp.net core platform. The client app signs in users using the [OpenID Connect protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc) flow and in this process obtains (and caches) an [access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens) for the web api. The client app has a ToDo list that the web app users can work with. This ToDo list is maintained in an in-memory list on the Web API. The client app calls the webApi for all operations on the ToDo list.
+This sample has a web api and a client web app, both built using the asp.net core platform. The client app signs in users using the [OpenID Connect protocol](https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc) flow and in this process obtains (and caches) an [access token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens) for the web api. The client app has a ToDo list that the web app users can work with. This ToDo list is maintained in an in-memory list on the Web API. The client app calls the webApi for all operations on the ToDo list.
 
 ### Scenario
 
@@ -25,7 +25,7 @@ to use your Web API. Your API calls a downstream API (Microsoft Graph) to provid
 
 ### Overview
 
-This sample presents a Web API running on ASP.NET Core, protected by [Azure AD OAuth Bearer](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols) Authentication. The client application uses [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) library to obtain a JWT access token through using the [OAuth 2.0](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow) protocol flow.
+This sample presents a Web API running on ASP.NET Core, protected by [Azure AD OAuth Bearer](https://learn.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols) Authentication. The client application uses [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) library to obtain a JWT access token through using the [OAuth 2.0](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) protocol flow.
 
 The client web application essentially takes the following steps to sign-in the user and obtain a bearer token for the Web API:
 
@@ -304,15 +304,15 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information, visit the following links:
 
 - Articles about the new Microsoft identity platform are at [http://aka.ms/aaddevv2](http://aka.ms/aaddevv2), with a focus on:
-  - [Azure AD OAuth Bearer protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols)
-  - [The OAuth 2.0 protocol in Azure AD](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)
-  - [Access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens)
-  - [The OpenID Connect protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
+  - [Azure AD OAuth Bearer protocol](https://learn.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols)
+  - [The OAuth 2.0 protocol in Azure AD](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+  - [Access token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens)
+  - [The OpenID Connect protocol](https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc)
 
 - To lean more about the application registration, visit:
-  - [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
-  - [Quickstart: Configure a client application to access web APIs (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
-  - [Quickstart: Configure an application to expose web APIs (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
+  - [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app)
+  - [Quickstart: Configure a client application to access web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
+  - [Quickstart: Configure an application to expose web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
 
 - To learn more about the code, visit:
   - [Conceptual documentation for MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki#conceptual-documentation) and in particular:
@@ -320,6 +320,6 @@ For more information, visit the following links:
   - [Customizing Token cache serialization](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization)
 
 - To learn more about security in aspnetcore,
-  - [Introduction to Identity on ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?view=aspnetcore-2.1&tabs=visual-studio%2Caspnetcore2x)
-  - [AuthenticationBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder?view=aspnetcore-2.0)
-  - [Azure Active Directory with ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/azure-active-directory/?view=aspnetcore-2.1)
+  - [Introduction to Identity on ASP.NET Core](https://learn.microsoft.com/aspnet/core/security/authentication/identity/)
+  - [AuthenticationBuilder](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder)
+  - [Azure Active Directory with ASP.NET Core](https://learn.microsoft.com/aspnet/core/security/authentication/azure-active-directory/)

--- a/tests/DevApps/B2CWebAppCallsWebApi/README.md
+++ b/tests/DevApps/B2CWebAppCallsWebApi/README.md
@@ -52,7 +52,7 @@ The client web application (TodoListClient) enables a user to:
 
 - Install .NET Core for Windows by following the instructions at [dot.net/core](https://dot.net/core), which will include [Visual Studio 2017](https://aka.ms/vsdownload).
 - An Internet connection
-- An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/)
+- An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, see [How to get an Azure AD tenant](https://learn.microsoft.com/entra/identity-platform/quickstart-create-new-tenant)
 - A user account in your Azure AD tenant.
 
 ### Step 1:  Clone or download this repository

--- a/tests/DevApps/B2CWebAppCallsWebApi/README.md
+++ b/tests/DevApps/B2CWebAppCallsWebApi/README.md
@@ -22,11 +22,11 @@ This sample is essentially a guide for developers who want to secure their Web A
 
 ### Scenario
 
-This sample has a web api and a client web app, both built using the asp.net core platform. The client app signs in users using the [OpenID Connect protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc) flow and in this process obtains (and caches) an [access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens) for the web api. The client app has a ToDo list that the web app users can work with. This ToDo list is maintained in an in-memory list on the Web API. The client app calls the webApi for all operations on the ToDo list.
+This sample has a web api and a client web app, both built using the asp.net core platform. The client app signs in users using the [OpenID Connect protocol](https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc) flow and in this process obtains (and caches) an [access token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens) for the web api. The client app has a ToDo list that the web app users can work with. This ToDo list is maintained in an in-memory list on the Web API. The client app calls the webApi for all operations on the ToDo list.
 
 ### Overview
 
-This sample presents a Web API running on ASP.NET Core, protected by [Azure AD OAuth Bearer](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols) Authentication. The client application uses [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) library to obtain a JWT access token through using the [OAuth 2.0](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow) protocol flow.
+This sample presents a Web API running on ASP.NET Core, protected by [Azure AD OAuth Bearer](https://learn.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols) Authentication. The client application uses [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) library to obtain a JWT access token through using the [OAuth 2.0](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) protocol flow.
 
 The client web application essentially takes the following steps to sign-in the user and obtain a bearer token for the Web API:
 
@@ -94,7 +94,7 @@ Copy this policy name, so you can use it in step 5.
 
 ### Step 4: Create your own Web app
 
-Now you need to [register your web app in your B2C tenant](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-application), so that it has its own Application ID.
+Now you need to [register your web app in your B2C tenant](https://learn.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-application), so that it has its own Application ID.
 
 Your web application registration should include the following information:
 
@@ -377,15 +377,15 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information, visit the following links:
 
 - Articles about the Microsoft identity platform are at [http://aka.ms/aaddevv2](http://aka.ms/aaddevv2), with a focus on:
-  - [Azure AD OAuth Bearer protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols)
-  - [The OAuth 2.0 protocol in Azure AD](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)
-  - [Access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens)
-  - [The OpenID Connect protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
+  - [Azure AD OAuth Bearer protocol](https://learn.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols)
+  - [The OAuth 2.0 protocol in Azure AD](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+  - [Access token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens)
+  - [The OpenID Connect protocol](https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc)
 
 - To lean more about the application registration, visit:
-  - [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
-  - [Quickstart: Configure a client application to access web APIs (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
-  - [Quickstart: Configure an application to expose web APIs (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
+  - [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app)
+  - [Quickstart: Configure a client application to access web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
+  - [Quickstart: Configure an application to expose web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
 
 - To learn more about the code, visit:
   - [Conceptual documentation for MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki#conceptual-documentation) and in particular:
@@ -393,6 +393,6 @@ For more information, visit the following links:
   - [Customizing Token cache serialization](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization)
 
 - To learn more about security in aspnetcore,
-  - [Introduction to Identity on ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?view=aspnetcore-2.1&tabs=visual-studio%2Caspnetcore2x)
-  - [AuthenticationBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder?view=aspnetcore-2.0)
-  - [Azure Active Directory with ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/azure-active-directory/?view=aspnetcore-2.1)
+  - [Introduction to Identity on ASP.NET Core](https://learn.microsoft.com/aspnet/core/security/authentication/identity/)
+  - [AuthenticationBuilder](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder)
+  - [Azure Active Directory with ASP.NET Core](https://learn.microsoft.com/aspnet/core/security/authentication/azure-active-directory/)

--- a/tests/DevApps/MultipleAuthSchemes/Views/Home/Index.cshtml
+++ b/tests/DevApps/MultipleAuthSchemes/Views/Home/Index.cshtml
@@ -4,7 +4,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>
 
 <div>Api result</div>

--- a/tests/DevApps/MultipleAuthSchemes/Views/HomeB2C/Index.cshtml
+++ b/tests/DevApps/MultipleAuthSchemes/Views/HomeB2C/Index.cshtml
@@ -4,7 +4,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core and AAD B2C</a>.</p>
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core and AAD B2C</a>.</p>
 </div>
 
 <div>Api result</div>

--- a/tests/DevApps/MultipleAuthSchemes/wwwroot/css/site.css
+++ b/tests/DevApps/MultipleAuthSchemes/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 a.navbar-brand {

--- a/tests/DevApps/MultipleAuthSchemes/wwwroot/js/site.js
+++ b/tests/DevApps/MultipleAuthSchemes/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.

--- a/tests/DevApps/WebAppCallsMicrosoftGraph/Pages/Index.cshtml
+++ b/tests/DevApps/WebAppCallsMicrosoftGraph/Pages/Index.cshtml
@@ -8,7 +8,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>@name, Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>@name, Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
      result = @json
     <table class="table table-striped table-condensed" style="font-family: monospace">
         <tr>

--- a/tests/DevApps/WebAppCallsMicrosoftGraph/wwwroot/css/site.css
+++ b/tests/DevApps/WebAppCallsMicrosoftGraph/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 a.navbar-brand {

--- a/tests/DevApps/WebAppCallsMicrosoftGraph/wwwroot/js/site.js
+++ b/tests/DevApps/WebAppCallsMicrosoftGraph/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Startup.cs
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Startup.cs
@@ -37,7 +37,7 @@ namespace WebApp_OpenIDConnect_DotNet
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
                 options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
-                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                // Handling SameSite cookie according to https://learn.microsoft.com/aspnet/core/security/samesite
                 options.HandleSameSiteCookieCompatibility();
             });
 

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Startup.cs
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Startup.cs
@@ -37,7 +37,7 @@ namespace WebApp_OpenIDConnect_DotNet
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
                 options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
-                // Handling SameSite cookie according to https://learn.microsoft.com/aspnet/core/security/samesite
+                // Handles SameSite cookies according to https://learn.microsoft.com/aspnet/core/security/samesite.
                 options.HandleSameSiteCookieCompatibility();
             });
 

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/wwwroot/css/site.css
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification\ 
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification\ 
 for details on configuring this project to bundle and minify static web assets. */
 body {
     padding-top: 50px;

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/wwwroot/js/site.js
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/README-incremental-instructions.md
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/README-incremental-instructions.md
@@ -16,7 +16,7 @@ endpoint: Microsoft identity platform
 
 ## About this sample
 
-This sample has a web api and a client web app, both built using the asp.net core platform. The client app signs in users using the [OpenID Connect protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc) flow and in this process obtains (and caches) an [access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens) for the web api. The client app has a ToDo list that the web app users can work with. This ToDo list is maintained in an in-memory list on the Web API. The client app calls the webApi for all operations on the ToDo list.
+This sample has a web api and a client web app, both built using the asp.net core platform. The client app signs in users using the [OpenID Connect protocol](https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc) flow and in this process obtains (and caches) an [access token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens) for the web api. The client app has a ToDo list that the web app users can work with. This ToDo list is maintained in an in-memory list on the Web API. The client app calls the webApi for all operations on the ToDo list.
 
 ### Scenario
 
@@ -25,7 +25,7 @@ to use your Web API. Your API calls a downstream API (Microsoft Graph) to provid
 
 ### Overview
 
-This sample presents a Web API running on ASP.NET Core, protected by [Azure AD OAuth Bearer](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols) Authentication. The client application uses [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) library to obtain a JWT access token through using the [OAuth 2.0](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow) protocol flow.
+This sample presents a Web API running on ASP.NET Core, protected by [Azure AD OAuth Bearer](https://learn.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols) Authentication. The client application uses [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) library to obtain a JWT access token through using the [OAuth 2.0](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) protocol flow.
 
 The client web application essentially takes the following steps to sign-in the user and obtain a bearer token for the Web API:
 
@@ -304,15 +304,15 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information, visit the following links:
 
 - Articles about the new Microsoft identity platform are at [http://aka.ms/aaddevv2](http://aka.ms/aaddevv2), with a focus on:
-  - [Azure AD OAuth Bearer protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols)
-  - [The OAuth 2.0 protocol in Azure AD](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)
-  - [Access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens)
-  - [The OpenID Connect protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
+  - [Azure AD OAuth Bearer protocol](https://learn.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols)
+  - [The OAuth 2.0 protocol in Azure AD](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+  - [Access token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens)
+  - [The OpenID Connect protocol](https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc)
 
 - To lean more about the application registration, visit:
-  - [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
-  - [Quickstart: Configure a client application to access web APIs (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
-  - [Quickstart: Configure an application to expose web APIs (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
+  - [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app)
+  - [Quickstart: Configure a client application to access web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
+  - [Quickstart: Configure an application to expose web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
 
 - To learn more about the code, visit:
   - [Conceptual documentation for MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki#conceptual-documentation) and in particular:
@@ -320,6 +320,6 @@ For more information, visit the following links:
   - [Customizing Token cache serialization](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization)
 
 - To learn more about security in aspnetcore,
-  - [Introduction to Identity on ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?view=aspnetcore-2.1&tabs=visual-studio%2Caspnetcore2x)
-  - [AuthenticationBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder?view=aspnetcore-2.0)
-  - [Azure Active Directory with ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/azure-active-directory/?view=aspnetcore-2.1)
+  - [Introduction to Identity on ASP.NET Core](https://learn.microsoft.com/aspnet/core/security/authentication/identity/)
+  - [AuthenticationBuilder](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder)
+  - [Azure Active Directory with ASP.NET Core](https://learn.microsoft.com/aspnet/core/security/authentication/azure-active-directory/)

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/README.md
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/README.md
@@ -52,7 +52,7 @@ The client web application (TodoListClient) enables a user to:
 
 - Install .NET Core for Windows by following the instructions at [dot.net/core](https://dot.net/core), which will include [Visual Studio 2017](https://aka.ms/vsdownload).
 - An Internet connection
-- An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/)
+- An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, see [How to get an Azure AD tenant](https://azure.microsoft.com/documentation/articles/active-directory-howto-tenant/)
 - A user account in your Azure AD tenant.
 
 ### Step 1:  Clone or download this repository

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/README.md
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/README.md
@@ -22,11 +22,11 @@ This sample is essentially a guide for developers who want to secure their Web A
 
 ### Scenario
 
-This sample has a web api and a client web app, both built using the asp.net core platform. The client app signs in users using the [OpenID Connect protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc) flow and in this process obtains (and caches) an [access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens) for the web api. The client app has a ToDo list that the web app users can work with. This ToDo list is maintained in an in-memory list on the Web API. The client app calls the webApi for all operations on the ToDo list.
+This sample has a web api and a client web app, both built using the asp.net core platform. The client app signs in users using the [OpenID Connect protocol](https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc) flow and in this process obtains (and caches) an [access token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens) for the web api. The client app has a ToDo list that the web app users can work with. This ToDo list is maintained in an in-memory list on the Web API. The client app calls the webApi for all operations on the ToDo list.
 
 ### Overview
 
-This sample presents a Web API running on ASP.NET Core, protected by [Azure AD OAuth Bearer](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols) Authentication. The client application uses [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) library to obtain a JWT access token through using the [OAuth 2.0](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow) protocol flow. 
+This sample presents a Web API running on ASP.NET Core, protected by [Azure AD OAuth Bearer](https://learn.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols) Authentication. The client application uses [MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) library to obtain a JWT access token through using the [OAuth 2.0](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) protocol flow. 
 
 The client web application essentially takes the following steps to sign-in the user and obtain a bearer token for the Web API:
 
@@ -148,7 +148,7 @@ As a first step you'll need to:
        - `https://localhost:44321/signin-oidc`
    - In the **Advanced settings** section set **Logout URL** to `https://localhost:44321/signout-oidc`
    - In the **Advanced settings** | **Implicit grant** section, check **ID tokens** as this sample requires
-     the [Implicit grant flow](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow) to be enabled to
+     the [Implicit grant flow](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-implicit-grant-flow) to be enabled to
      sign-in the user, and call an API.
 1. Select **Save**.
 1. From the **Certificates & secrets** page, in the **Client secrets** section, choose **New client secret**:
@@ -443,15 +443,15 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information, visit the following links:
 
 - Articles about the Microsoft identity platform are at [http://aka.ms/aaddevv2](http://aka.ms/aaddevv2), with a focus on:
-  - [Azure AD OAuth Bearer protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols)
-  - [The OAuth 2.0 protocol in Azure AD](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)
-  - [Access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens)
-  - [The OpenID Connect protocol](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
+  - [Azure AD OAuth Bearer protocol](https://learn.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols)
+  - [The OAuth 2.0 protocol in Azure AD](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+  - [Access token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens)
+  - [The OpenID Connect protocol](https://learn.microsoft.com/azure/active-directory/develop/v2-protocols-oidc)
 
 - To lean more about the application registration, visit:
-  - [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
-  - [Quickstart: Configure a client application to access web APIs (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
-  - [Quickstart: Configure an application to expose web APIs (Preview)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
+  - [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app)
+  - [Quickstart: Configure a client application to access web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
+  - [Quickstart: Configure an application to expose web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
 
 - To learn more about the code, visit:
   - [Conceptual documentation for MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki#conceptual-documentation) and in particular:
@@ -459,6 +459,6 @@ For more information, visit the following links:
   - [Customizing Token cache serialization](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization)
 
 - To learn more about security in aspnetcore,
-  - [Introduction to Identity on ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?view=aspnetcore-2.1&tabs=visual-studio%2Caspnetcore2x)
-  - [AuthenticationBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder?view=aspnetcore-2.0)
-  - [Azure Active Directory with ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/azure-active-directory/?view=aspnetcore-2.1)
+  - [Introduction to Identity on ASP.NET Core](https://learn.microsoft.com/aspnet/core/security/authentication/identity/)
+  - [AuthenticationBuilder](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder)
+  - [Azure Active Directory with ASP.NET Core](https://learn.microsoft.com/aspnet/core/security/authentication/azure-active-directory/)

--- a/tests/DevApps/blazorserver-calls-api/README-Incremental.md
+++ b/tests/DevApps/blazorserver-calls-api/README-Incremental.md
@@ -66,10 +66,10 @@ cd ms-identity-blazor-server\WebApp-your-API\MyOrg
 1. In the app's registration screen, find and note the **Application (client) ID**. You use this value in your app's configuration file(s) later in your code.
 1. Select **Save** to save your changes.
 1. In the app's registration screen, select the **Expose an API** blade to the left to open the page where you can declare the parameters to expose this app as an Api for which client applications can obtain [access tokens](https://aka.ms/access-tokens) for.
-The first thing that we need to do is to declare the unique [resource](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) URI that the clients will be using to obtain access tokens for this Api. To declare an resource URI, follow the following steps:
+The first thing that we need to do is to declare the unique [resource](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) URI that the clients will be using to obtain access tokens for this Api. To declare an resource URI, follow the following steps:
    - Select `Set` next to the **Application ID URI** to generate a URI that is unique for this app.
    - For this sample, accept the proposed Application ID URI (api://{clientId}) by selecting **Save**.
-1. All Apis have to publish a minimum of one [scope](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code) for the client's to obtain an access token successfully. To publish a scope, follow the following steps:
+1. All Apis have to publish a minimum of one [scope](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code) for the client's to obtain an access token successfully. To publish a scope, follow the following steps:
    - Select **Add a scope** button open the **Add a scope** screen and Enter the values as indicated below:
         - For **Scope name**, use `access_as_user`.
         - Select **Admins and users** options for **Who can consent?**
@@ -161,7 +161,7 @@ dotnet dev-certs https --clean
 dotnet dev-certs https --trust
 ```
 
-Learn more about [HTTPS in .NET Core](https://docs.microsoft.com/aspnet/core/security/enforcing-ssl).
+Learn more about [HTTPS in .NET Core](https://learn.microsoft.com/aspnet/core/security/enforcing-ssl).
 
 #### Step 3. Run the applications
 
@@ -272,12 +272,12 @@ Refer to the [Azure deployment guide](../../Deploy-to-Azure/README.md) to deploy
 
 ## More information
 
-- [Microsoft identity platform (Azure Active Directory for developers)](https://docs.microsoft.com/azure/active-directory/develop/)
-- [Overview of Microsoft Authentication Library (MSAL)](https://docs.microsoft.com/azure/active-directory/develop/msal-overview)
-- [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app)
-- [Quickstart: Configure a client application to access web APIs (Preview)](https://docs.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
+- [Microsoft identity platform (Azure Active Directory for developers)](https://learn.microsoft.com/azure/active-directory/develop/)
+- [Overview of Microsoft Authentication Library (MSAL)](https://learn.microsoft.com/azure/active-directory/develop/msal-overview)
+- [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app)
+- [Quickstart: Configure a client application to access web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
 
-For more information about how OAuth 2.0 protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](https://docs.microsoft.com/azure/active-directory/develop/authentication-flows-app-scenarios).
+For more information about how OAuth 2.0 protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](https://learn.microsoft.com/azure/active-directory/develop/authentication-flows-app-scenarios).
 
 ## Community Help and Support
 

--- a/tests/DevApps/blazorserver-calls-api/README.md
+++ b/tests/DevApps/blazorserver-calls-api/README.md
@@ -46,7 +46,7 @@ This sample demonstrates an ASP.NET Core Blazor Server application calling an AS
 ## Prerequisites
 
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/)
-- An **Azure AD** tenant. For more information see: [How to get an Azure AD tenant](https://docs.microsoft.com/azure/active-directory/develop/quickstart-create-new-tenant)
+- An **Azure AD** tenant. For more information see: [How to get an Azure AD tenant](https://learn.microsoft.com/azure/active-directory/develop/quickstart-create-new-tenant)
 - A user account in your **Azure AD** tenant. This sample will not work with a **personal Microsoft account**. Therefore, if you signed in to the [Azure portal](https://portal.azure.com) with a personal account and have never created a user account in your directory before, you need to do that now.
 
 ## Setup
@@ -114,10 +114,10 @@ As a first step you'll need to:
 1. In the app's registration screen, find and note the **Application (client) ID**. You use this value in your app's configuration file(s) later in your code.
 1. Select **Save** to save your changes.
 1. In the app's registration screen, select the **Expose an API** blade to the left to open the page where you can declare the parameters to expose this app as an Api for which client applications can obtain [access tokens](https://aka.ms/access-tokens) for.
-The first thing that we need to do is to declare the unique [resource](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) URI that the clients will be using to obtain access tokens for this Api. To declare an resource URI, follow the following steps:
+The first thing that we need to do is to declare the unique [resource](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow) URI that the clients will be using to obtain access tokens for this Api. To declare an resource URI, follow the following steps:
    - Select `Set` next to the **Application ID URI** to generate a URI that is unique for this app.
    - For this sample, accept the proposed Application ID URI (api://{clientId}) by selecting **Save**.
-1. All Apis have to publish a minimum of one [scope](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code) for the client's to obtain an access token successfully. To publish a scope, follow the following steps:
+1. All Apis have to publish a minimum of one [scope](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code) for the client's to obtain an access token successfully. To publish a scope, follow the following steps:
    - Select **Add a scope** button open the **Add a scope** screen and Enter the values as indicated below:
         - For **Scope name**, use `access_as_user`.
         - Select **Admins and users** options for **Who can consent?**
@@ -224,7 +224,7 @@ dotnet dev-certs https --clean
 dotnet dev-certs https --trust
 ```
 
-Learn more about [HTTPS in .NET Core](https://docs.microsoft.com/aspnet/core/security/enforcing-ssl).
+Learn more about [HTTPS in .NET Core](https://learn.microsoft.com/aspnet/core/security/enforcing-ssl).
 
 #### Step 3. Run the applications
 
@@ -364,12 +364,12 @@ Refer to the [Azure deployment guide](../../Deploy-to-Azure/README.md) to deploy
 
 ## More information
 
-- [Microsoft identity platform (Azure Active Directory for developers)](https://docs.microsoft.com/azure/active-directory/develop/)
-- [Overview of Microsoft Authentication Library (MSAL)](https://docs.microsoft.com/azure/active-directory/develop/msal-overview)
-- [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app)
-- [Quickstart: Configure a client application to access web APIs (Preview)](https://docs.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
+- [Microsoft identity platform (Azure Active Directory for developers)](https://learn.microsoft.com/azure/active-directory/develop/)
+- [Overview of Microsoft Authentication Library (MSAL)](https://learn.microsoft.com/azure/active-directory/develop/msal-overview)
+- [Quickstart: Register an application with the Microsoft identity platform (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app)
+- [Quickstart: Configure a client application to access web APIs (Preview)](https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
 
-For more information about how OAuth 2.0 protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](https://docs.microsoft.com/azure/active-directory/develop/authentication-flows-app-scenarios).
+For more information about how OAuth 2.0 protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](https://learn.microsoft.com/azure/active-directory/develop/authentication-flows-app-scenarios).
 
 ## Community Help and Support
 

--- a/tests/DevApps/blazorserver2-b2c-callswebapi/Shared/MainLayout.razor
+++ b/tests/DevApps/blazorserver2-b2c-callswebapi/Shared/MainLayout.razor
@@ -7,7 +7,7 @@
 <div class="main">
     <div class="top-row px-4 auth">
         <LoginDisplay />
-        <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
+        <a href="https://learn.microsoft.com/aspnet/" target="_blank">About</a>
     </div>
 
     <div class="content px-4">

--- a/tests/DevApps/blazorwasm-b2c/Shared/MainLayout.razor
+++ b/tests/DevApps/blazorwasm-b2c/Shared/MainLayout.razor
@@ -7,7 +7,7 @@
 <div class="main">
     <div class="top-row px-4 auth">
         <LoginDisplay />
-        <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
+        <a href="https://learn.microsoft.com/aspnet/" target="_blank">About</a>
     </div>
 
     <div class="content px-4">

--- a/tests/DevApps/ciam/myWebApp/Pages/Index.cshtml
+++ b/tests/DevApps/ciam/myWebApp/Pages/Index.cshtml
@@ -6,7 +6,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>
 
 <div>Api result</div>

--- a/tests/DevApps/ciam/myWebApp/Pages/Shared/_Layout.cshtml.css
+++ b/tests/DevApps/ciam/myWebApp/Pages/Shared/_Layout.cshtml.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 a.navbar-brand {

--- a/tests/DevApps/ciam/myWebApp/wwwroot/js/site.js
+++ b/tests/DevApps/ciam/myWebApp/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.

--- a/tools/app-provisioning-tool/README.md
+++ b/tools/app-provisioning-tool/README.md
@@ -55,9 +55,9 @@ dotnet tool uninstall --global msidentity-app-sync
 ## Pre-requisites to using the tool
 
 Have an AAD or B2C tenant (or both). 
-- If you want to add an AAD registration, you are usually already signed-in in Visual Studio in a tenant. If needed you can create your own tenant by following this quickstart [Setup a tenant](https://docs.microsoft.com/azure/active-directory/develop/quickstart-create-new-tenant). But be sure to sign-out and sign-in from Visual Studio or Azure CLI so that this tenant is known in the shared token cache.
+- If you want to add an AAD registration, you are usually already signed-in in Visual Studio in a tenant. If needed you can create your own tenant by following this quickstart [Setup a tenant](https://learn.microsoft.com/azure/active-directory/develop/quickstart-create-new-tenant). But be sure to sign-out and sign-in from Visual Studio or Azure CLI so that this tenant is known in the shared token cache.
 
-- If you want to add an AAD B2C registration you'll need a B2C tenant, and explicity pass it to the `--tenant-id` option of the tool. As well as the sign-up/sign-in policy `--susi-policy-id`. To create a B2C tenant, see [Create a B2C tenant](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-tenant).
+- If you want to add an AAD B2C registration you'll need a B2C tenant, and explicity pass it to the `--tenant-id` option of the tool. As well as the sign-up/sign-in policy `--susi-policy-id`. To create a B2C tenant, see [Create a B2C tenant](https://learn.microsoft.com/azure/active-directory-b2c/tutorial-create-tenant).
 
 ## Using the tool
 

--- a/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/MicrosoftIdentityPlatformApplicationManager.cs
+++ b/tools/app-provisioning-tool/app-provisioning-lib/MicrosoftIdentityPlatformApplication/MicrosoftIdentityPlatformApplicationManager.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Identity.App.MicrosoftIdentityPlatformApplication
             ServicePrincipal servicePrincipal,
             IEnumerable<IGrouping<string, ResourceAndScope>>? scopesPerResource)
         {
-            // Changed: https://learn.microsoft.com/en-us/graph/permissions-grant-via-msgraph?tabs=csharp&pivots=grant-application-permissions#step-2-grant-an-app-role-to-a-client-service-principal
+            // Changed: https://learn.microsoft.com/graph/permissions-grant-via-msgraph?tabs=csharp&pivots=grant-application-permissions#step-2-grant-an-app-role-to-a-client-service-principal
 
             // Consent to the scopes
             if (scopesPerResource != null)

--- a/tools/app-provisioning-tool/vs2019-16.9-how-to-use.md
+++ b/tools/app-provisioning-tool/vs2019-16.9-how-to-use.md
@@ -41,9 +41,9 @@ You can also install it as an external tool in Visual Studio. For details see ht
 
 Next, you need to sign into your Azure subscription. You can sign in with any of the following tools.
 
-- [Visual Studio 2019](https://docs.microsoft.com/en-us/visualstudio/ide/signing-in-to-visual-studio?view=vs-2019#how-to-sign-in-to-visual-studio)
-- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli)
-- [Azure PowerShell](https://docs.microsoft.com/en-us/powershell/azure/authenticate-azureps?view=azps-5.5.0)
+- [Visual Studio 2019](https://learn.microsoft.com/visualstudio/ide/signing-in-to-visual-studio?view=vs-2019#how-to-sign-in-to-visual-studio)
+- [Azure CLI](https://learn.microsoft.com/cli/azure/authenticate-azure-cli)
+- [Azure PowerShell](https://learn.microsoft.com/powershell/azure/authenticate-azureps?view=azps-5.5.0)
 
 Once you sign in with any of these tools, you can start using the identity sync tool. Let's look at how to use the tool to provision a new App Registration and configure the project. To get a list of the available built-in options run: `msidentity-app-sync –help` (or `msidentity-app-sync -h`). The current help output is shown in the image below.
 
@@ -53,7 +53,7 @@ From the help output, you can see that all the options are optional. You'll typi
 
 - The tool will detect what type of asp.net core app the project represents, the supported project types include; web (webapp and mvc templates), web API, Blazor Server and Blazor WebAssembly (hosted or not).
 - The tool will detect which type of auth the project is configured for (Azure AD, Azure AD B2C)
-- A new Azure AD App registration will be created in the [home tenant](https://docs.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) of the signed in user
+- A new Azure AD App registration will be created in the [home tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) of the signed in user
 - The project will be updated to connect the app with the Azure objects created
 
 If you'd like to use an existing Azure AD (or Azure AD B2C) tenant or existing application, you can use the `–-tenant-id` and `–-client-id` parameters respectively. More on this later. For more info on the tool visit the [microsoft-identity-web](https://github.com/AzureAD/microsoft-identity-web/tree/master/tools/app-provisioning-tool) Github repository. Now that we've gone over the basic usage of the tool, let's go ahead and run it.
@@ -86,7 +86,7 @@ By default, the tool will create a new Azure AD or AzureAD B2C application. To u
 
 If you would like to perform all the steps without using the provisioning tool, there are some quick start guides that you can use. The specific steps will be different based on you project type. Use the links below to get started with that.
 
-- Web app [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app - Microsoft identity platform | Microsoft Docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp)
-- Web API [Quickstart: Protect an ASP.NET Core web API with the Microsoft identity platform - Microsoft identity platform | Microsoft Docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-aspnet-core-web-api)
-- Blazor [Tutorial - Create a Blazor Server app that uses the Microsoft identity platform for authentication - Microsoft identity platform | Microsoft Docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-blazor-server)
-- Blazor WASM [Tutorial - Sign in users and call a protected API from a Blazor WebAssembly app - Microsoft identity platform | Microsoft Docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-blazor-webassembly)
+- Web app [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app - Microsoft identity platform | Microsoft Docs](https://learn.microsoft.com/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp)
+- Web API [Quickstart: Protect an ASP.NET Core web API with the Microsoft identity platform - Microsoft identity platform | Microsoft Docs](https://learn.microsoft.com/azure/active-directory/develop/quickstart-v2-aspnet-core-web-api)
+- Blazor [Tutorial - Create a Blazor Server app that uses the Microsoft identity platform for authentication - Microsoft identity platform | Microsoft Docs](https://learn.microsoft.com/azure/active-directory/develop/tutorial-blazor-server)
+- Blazor WASM [Tutorial - Sign in users and call a protected API from a Blazor WebAssembly app - Microsoft identity platform | Microsoft Docs](https://learn.microsoft.com/azure/active-directory/develop/tutorial-blazor-webassembly)


### PR DESCRIPTION
Fixes #3004

The primary goal is to remove the version pinning to ASP.NET Core docs. I also ...

* Changed the site domain (`docs.microsoft.com` :point_right: `learn.microsoft.com`).
* Dropped the culture segments (i.e., `en-us`).

I didn't test all of the links, and I only performed a little work with text around links and link text.