### PR TITLE
Grouping Dependabot Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,20 @@ updates:
     labels:
       - "dependabot"
       - "dependencies"
+    groups:
+      # Groups all recommended minor and patch updates with a security designation into a single PR
+      security:
+        applies-to: security-updates
+        patterns:
+        - "*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Groups all minor and patch non-security designated version updates into a single PR
+      notsecurity:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "minor"
+        - "patch"


### PR DESCRIPTION
Added grouping to dependabot config so PRs can contain multiple suggestions. The groupings are minor and patch updates with a security designation and minor and patch updates without a security designation. Major version updates will all still get their own PRs

Additionally, it will label grouped PRs with whether the updates are security-related or not based on the group names of security and notsecurity
