### PR TITLE
Update changelog.md to fix release 3.2.2 which had a breaking change

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@
 =========
 - Updated to Microsoft.IdentityModel.* 8.1.2
 - **Breaking change** (without major version change. Sorry!) 
-   [ClientAssertionProviderBase.GetSignedAssertion](https://github.com/AzureAD/microsoft-identity-web/blob/195328cc509e3d964bb47f1877a8946b6f136f81/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs#L79) now takes an MSAL.NET AssertionRequestOptions. See:
+   [ClientAssertionProviderBase.GetSignedAssertion](https://github.com/AzureAD/microsoft-identity-web/blob/195328cc509e3d964bb47f1877a8946b6f136f81/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs#L79) now takes an MSAL.NET AssertionRequestOptions and the method name has changed from `GetSignedAssertion` to `GetClientAssertionAsync`:
 
    ```csharp
    var m = new ManagedIdentityClientAssertion("<some client id>");

--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,14 @@
 3.2.2
 =========
 - Updated to Microsoft.IdentityModel.* 8.1.2
+- **Breaking change** (without major version change. Sorry!) 
+   ClientAssertionProviderBase.GetSignedAssertion now takes an MSAL.NET AssertionRequestOptions. See:
 
+   ```csharp
+   var m = new ManagedIdentityClientAssertion("<some client id>");
+   m.GetSignedAssertion(CancellationToken.None); // this method will break on v3.2.2  
+   ```
+   
 3.2.1
 =========
 - Updated to Microsoft.IdentityModel.* 8.1.1

--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@
 =========
 - Updated to Microsoft.IdentityModel.* 8.1.2
 - **Breaking change** (without major version change. Sorry!) 
-   ClientAssertionProviderBase.GetSignedAssertion now takes an MSAL.NET AssertionRequestOptions. See:
+   [ClientAssertionProviderBase.GetSignedAssertion](https://github.com/AzureAD/microsoft-identity-web/blob/195328cc509e3d964bb47f1877a8946b6f136f81/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs#L79) now takes an MSAL.NET AssertionRequestOptions. See:
 
    ```csharp
    var m = new ManagedIdentityClientAssertion("<some client id>");


### PR DESCRIPTION
# Update changelog.md to fix release 3.2.2 which had a breaking change
Update changelog.md to fix release 3.2.2 which had a breaking change
Fixes #3101

This broke a number of partners using FIC+MSI with MSAL.NET
cc: @bgavrilMS 
