### PR TITLE
Remove use of Thread.Sleep

### DIFF
--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -42,7 +42,7 @@ namespace WebAppUiTests
 
         [Fact]
         [SupportedOSPlatform("windows")]
-        public async Task Susi_B2C_LocalAccount_TodoAppFucntionsCorrectlyAsync()
+        public async Task Susi_B2C_LocalAccount_TodoAppFunctionsCorrectlyAsync()
         {
             // Web app and api environmental variable setup.
             DefaultAzureCredential azureCred = new();

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -324,7 +324,6 @@ namespace WebAppUiTests
                                                 processDataEntry.EnvironmentVariables);
 
                 processes.Add(processDataEntry.ExecutableName, process);
-                Thread.Sleep(5000);
             }
 
             //Verify that processes are running
@@ -357,7 +356,6 @@ namespace WebAppUiTests
                                                     processDataEntry.AppLocation,
                                                     processDataEntry.ExecutableName,
                                                     processDataEntry.EnvironmentVariables);
-                    Thread.Sleep(5000);
 
                     //Update process in collection
                     processes[processEntry.Key] = process;


### PR DESCRIPTION
Remove unnecessary usage of `Thread.Sleep` in the `UiTestHelpers` class.