### PR TITLE
Use AppHomeTenantId for acquiring app token when TenantId is not tenant

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,7 +91,7 @@
     <MicrosoftGraphVersion>4.36.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
     <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
-    <MicrosoftIdentityAbstractionsVersion>7.1.0</MicrosoftIdentityAbstractionsVersion>
+    <MicrosoftIdentityAbstractionsVersion>7.2.0</MicrosoftIdentityAbstractionsVersion>
     <NetNineRuntimeVersion>9.0.0-rc.2.24473.5</NetNineRuntimeVersion>
     <AspNetCoreNineRuntimeVersion>9.0.0-rc.2.24474.3</AspNetCoreNineRuntimeVersion>
     <!--CVE-2024-43485-->

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Identity.Web
 
         // Properties of ConfidentialClientApplication which are not in MicrosoftIdentityOptions
         public AadAuthorityAudience AadAuthorityAudience { get; set; }
+        public string? AppHomeTenantId { get; set; }
         public AzureCloudInstance AzureCloudInstance { get; set; }
         public string? AzureRegion { get; set; }
         public IEnumerable<string>? ClientCapabilities { get; set; }
@@ -536,6 +537,8 @@ namespace Microsoft.Identity.Web
             {
                 mergedOptions.TenantId = microsoftIdentityApplicationOptions.TenantId;
             }
+
+            mergedOptions.AppHomeTenantId = microsoftIdentityApplicationOptions.AppHomeTenantId;
 
             mergedOptions.WithSpaAuthCode |= microsoftIdentityApplicationOptions.WithSpaAuthCode;
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/InternalAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 #nullable enable
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?
+static Microsoft.Identity.Web.TokenAcquisition.ResolveTenant(string? tenant, Microsoft.Identity.Web.MergedOptions! mergedOptions) -> string?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/InternalAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?
-
+static Microsoft.Identity.Web.TokenAcquisition.ResolveTenant(string? tenant, Microsoft.Identity.Web.MergedOptions! mergedOptions) -> string?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/InternalAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 #nullable enable
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?
+static Microsoft.Identity.Web.TokenAcquisition.ResolveTenant(string? tenant, Microsoft.Identity.Web.MergedOptions! mergedOptions) -> string?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/InternalAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 #nullable enable
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?
+static Microsoft.Identity.Web.TokenAcquisition.ResolveTenant(string? tenant, Microsoft.Identity.Web.MergedOptions! mergedOptions) -> string?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/InternalAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 #nullable enable
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?
+static Microsoft.Identity.Web.TokenAcquisition.ResolveTenant(string? tenant, Microsoft.Identity.Web.MergedOptions! mergedOptions) -> string?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 #nullable enable
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?
+static Microsoft.Identity.Web.TokenAcquisition.ResolveTenant(string? tenant, Microsoft.Identity.Web.MergedOptions! mergedOptions) -> string?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 #nullable enable
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?
+static Microsoft.Identity.Web.TokenAcquisition.ResolveTenant(string? tenant, Microsoft.Identity.Web.MergedOptions! mergedOptions) -> string?

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    public class TokenAcquisitionTests
+    {
+        private const string Tenant = "tenant";
+        private const string TenantId = "tenant-id";
+        private const string AppHomeTenantId = "app-home-tenant-id";
+
+        [Theory]
+        [InlineData(null, null, null, null)]
+        [InlineData(null, null, AppHomeTenantId, null)]
+        [InlineData(Tenant, null, null, Tenant)]
+        [InlineData(Tenant, TenantId, null, Tenant)]
+        [InlineData(Tenant, null, AppHomeTenantId, Tenant)]
+        [InlineData(Tenant, TenantId, AppHomeTenantId, Tenant)]
+        [InlineData(null, TenantId, null, TenantId)]
+        [InlineData(null, TenantId, AppHomeTenantId, TenantId)]
+        [InlineData(null, Constants.Common, AppHomeTenantId, AppHomeTenantId)]
+        [InlineData(null, Constants.Organizations, AppHomeTenantId, AppHomeTenantId)]
+        public void TestResolveTenantReturnsCorrectTenant(string? tenant, string? tenantId, string? appHomeTenantId, string? expectedValue)
+        {
+            string? resolvedTenant = TokenAcquisition.ResolveTenant(tenant, new MergedOptions { TenantId = tenantId, AppHomeTenantId = appHomeTenantId });
+            Assert.Equal(expectedValue, resolvedTenant);
+        }
+
+        [Theory]
+        [InlineData(Constants.Common, null)]
+        [InlineData(Constants.Organizations, null)]
+        [InlineData(Constants.Common, TenantId)]
+        [InlineData(Constants.Organizations, TenantId)]
+        [InlineData(Constants.Common, Constants.Common)]
+        [InlineData(Constants.Common, Constants.Organizations)]
+        [InlineData(Constants.Organizations, Constants.Organizations)]
+        [InlineData(Constants.Organizations, Constants.Common)]
+        [InlineData(null, Constants.Common)]
+        [InlineData(null, Constants.Organizations)]
+        public void TestResolveTenantThrowsWhenMetaTenant(string? tenant, string? tenantId)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => TokenAcquisition.ResolveTenant(tenant, new MergedOptions { TenantId = tenantId }));
+            Assert.StartsWith(IDWebErrorMessage.ClientCredentialTenantShouldBeTenanted, exception.Message, StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
Use `AppHomeTenantId` for acquiring app token when `TenantId` is not tenant. https://github.com/AzureAD/microsoft-identity-web/issues/3121