### PR TITLE
Dont modify the merged options when building the confidential client

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -6,10 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Identity.Abstractions;
 
-#if !NETSTANDARD2_0 && !NETFRAMEWORK
+#if !NETSTANDARD2_0 && !NET462 && !NET472
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 #endif
 using Microsoft.Identity.Client;
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Identity.Abstractions;
-#if !NETSTANDARD2_0 && !NET462 && !NET472
+
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 #endif
 using Microsoft.Identity.Client;
 
@@ -52,6 +54,12 @@ namespace Microsoft.Identity.Web
         internal bool MergedWithCca { get; set; }
         // This is for supporting for CIAM authorities including custom url domains, see https://github.com/AzureAD/microsoft-identity-web/issues/2690
         internal bool PreserveAuthority { get; set; }
+
+        /// <summary>
+        /// Id Web will modify the instance so that it can be used by MSAL.
+        /// This modifies this property so that the original value is not changed.
+        /// </summary>
+        internal string? PreparedInstance { get; set; }
 
         internal static void UpdateMergedOptionsFromMicrosoftIdentityOptions(MicrosoftIdentityOptions microsoftIdentityOptions, MergedOptions mergedOptions)
         {
@@ -466,14 +474,14 @@ namespace Microsoft.Identity.Web
             if (IsB2C && Instance.EndsWith("/tfp/", StringComparison.OrdinalIgnoreCase))
             {
 #if !NETSTANDARD2_0 && !NET462 && !NET472
-                Instance = Instance.Replace("/tfp/", string.Empty, StringComparison.OrdinalIgnoreCase).TrimEnd('/') + "/";
+                PreparedInstance = Instance.Replace("/tfp/", string.Empty, StringComparison.OrdinalIgnoreCase).TrimEnd('/') + "/";
 #else
-                Instance = Instance.Replace("/tfp/", string.Empty).TrimEnd('/') + "/";
+                PreparedInstance = Instance.Replace("/tfp/", string.Empty).TrimEnd('/') + "/";
 #endif
             }
             else
             {
-                Instance = Instance.TrimEnd('/') + "/";
+                PreparedInstance = Instance.TrimEnd('/') + "/";
             }
         }
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/InternalAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
+Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForTestUser(Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions, System.Security.Claims.ClaimsPrincipal! user) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/InternalAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
-Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/InternalAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
+Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForTestUser(Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions, System.Security.Claims.ClaimsPrincipal! user) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/InternalAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
-Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/InternalAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
+Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForTestUser(Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions, System.Security.Claims.ClaimsPrincipal! user) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/InternalAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
-Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/InternalAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
+Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForTestUser(Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions, System.Security.Claims.ClaimsPrincipal! user) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/InternalAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
-Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/InternalAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
+Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForTestUser(Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions, System.Security.Claims.ClaimsPrincipal! user) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/InternalAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
-Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
+Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForTestUser(Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions, System.Security.Claims.ClaimsPrincipal! user) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
-Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
+Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
+Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForTestUser(Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions, System.Security.Claims.ClaimsPrincipal! user) -> void
 readonly Microsoft.Identity.Web.TokenAcquisition.tokenAcquisitionExtensionOptionsMonitor -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Web.TokenAcquisitionExtensionOptions!>?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Web.MergedOptions.AppHomeTenantId.set -> void
-Microsoft.Identity.Web.MergedOptions.MergedOptions(Microsoft.Identity.Web.MergedOptions! other) -> void
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.get -> string?
 Microsoft.Identity.Web.MergedOptions.PreparedInstance.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.InvokeOnBeforeTokenAcquisitionForApp(Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder! builder, Microsoft.Identity.Abstractions.AcquireTokenOptions? acquireTokenOptions) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Identity.Web
                 if (mergedOptions.IsB2C)
                 {
 
-                    var authority = $"{mergedOptions.Instance}{ClaimConstants.Tfp}/{mergedOptions.Domain}/{authCodeRedemptionParameters.UserFlow ?? mergedOptions.DefaultUserFlow}";
+                    var authority = $"{mergedOptions.PreparedInstance}{ClaimConstants.Tfp}/{mergedOptions.Domain}/{authCodeRedemptionParameters.UserFlow ?? mergedOptions.DefaultUserFlow}";
                     builder.WithB2CAuthority(authority);
                 }
 
@@ -754,7 +754,6 @@ namespace Microsoft.Identity.Web
         /// </summary>
         private async Task<IConfidentialClientApplication> BuildConfidentialClientApplicationAsync(MergedOptions mergedOptions)
         {
-            string? currentUri = _tokenAcquisitionHost.GetCurrentRedirectUri(mergedOptions);
             mergedOptions.PrepareAuthorityInstanceForMsal();
 
             try
@@ -773,6 +772,8 @@ namespace Microsoft.Identity.Web
                     builder.WithCacheOptions(CacheOptions.EnableSharedCacheOptions);
                 }
 
+                string? currentUri = _tokenAcquisitionHost.GetCurrentRedirectUri(mergedOptions);
+
                 // The redirect URI is not needed for OBO
                 if (!string.IsNullOrEmpty(currentUri))
                 {
@@ -788,12 +789,12 @@ namespace Microsoft.Identity.Web
                 }
                 else if (mergedOptions.IsB2C)
                 {
-                    authority = $"{mergedOptions.Instance}{ClaimConstants.Tfp}/{mergedOptions.Domain}/{mergedOptions.DefaultUserFlow}";
+                    authority = $"{mergedOptions.PreparedInstance}{ClaimConstants.Tfp}/{mergedOptions.Domain}/{mergedOptions.DefaultUserFlow}";
                     builder.WithB2CAuthority(authority);
                 }
                 else
                 {
-                    authority = $"{mergedOptions.Instance}{mergedOptions.TenantId}/";
+                    authority = $"{mergedOptions.PreparedInstance}{mergedOptions.TenantId}/";
                     builder.WithAuthority(authority);
                 }
 


### PR DESCRIPTION
# Don't mutate options

## Description

PrepareAuthorityInstanceForMsal modifies a shared options object, we shouldn't do that.
