### PR TITLE
Ensure Singleton registration for TokenAcquisition Services when TokenAcquirerFactory is null

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Web
             ServiceDescriptor? tokenAcquisitionhost = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquisitionHost));
             ServiceDescriptor? authenticationHeaderCreator = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthorizationHeaderProvider));
             ServiceDescriptor? tokenAcquirerFactory = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquirerFactory));
-            if (tokenAcquisitionService != null && tokenAcquisitionInternalService != null && tokenAcquisitionhost != null && authenticationHeaderCreator != null && tokenAcquirerFactory != null)
+            if (tokenAcquisitionService != null && tokenAcquisitionInternalService != null && tokenAcquisitionhost != null && authenticationHeaderCreator != null)
             {
                 if (isTokenAcquisitionSingleton ^ (tokenAcquisitionService.Lifetime == ServiceLifetime.Singleton))
                 {
@@ -77,8 +77,13 @@ namespace Microsoft.Identity.Web
                     services.Remove(tokenAcquisitionInternalService);
                     services.Remove(tokenAcquisitionhost);
                     services.Remove(authenticationHeaderCreator);
-                    services.Remove(tokenAcquirerFactory);
-                    tokenAcquirerFactory = null;
+
+                    // To support ASP.NET Core 2.x on .NET FW. It won't use the TokenAcquirerFactory.GetDefaultInstance()
+                    if (tokenAcquirerFactory != null)
+                    {
+                        services.Remove(tokenAcquirerFactory);
+                        tokenAcquirerFactory = null;
+                    }
                 }
                 else
                 {

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
@@ -139,6 +138,111 @@ namespace Microsoft.Identity.Web.Test
         public void AddHttpContextAccessor_ThrowsWithoutServices()
         {
             Assert.Throws<ArgumentNullException>("services", () => ServiceCollectionExtensions.AddTokenAcquisition(null!));
+        }
+
+        [Fact]
+        public void AddTokenAcquisitionCalledTwice_RegistersTokenAcquisitionOnlyAsSingleton_WhenFlagIsTrue()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            // Token acquisition services were originally registered as scoped
+            services.AddTokenAcquisition();
+
+            // Token acquisition services should now be registered as singleton
+            services.AddTokenAcquisition(isTokenAcquisitionSingleton: true);
+
+            // Assert
+            var orderedServices = services.OrderBy(s => s.ServiceType.FullName).ToList();
+
+            // Check that the first service is registered as singleton
+            Assert.Collection(
+                orderedServices,
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IPostConfigureOptions<MicrosoftIdentityApplicationOptions>), actual.ServiceType);
+                    Assert.Equal(typeof(MicrosoftIdentityApplicationOptionsMerger), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                }, actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IPostConfigureOptions<ConfidentialClientApplicationOptions>), actual.ServiceType);
+                    Assert.Equal(typeof(ConfidentialClientApplicationOptionsMerger), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IPostConfigureOptions<MicrosoftIdentityOptions>), actual.ServiceType);
+                    Assert.Equal(typeof(MicrosoftIdentityOptionsMerger), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IAuthorizationHeaderProvider), actual.ServiceType);
+                    Assert.Equal(typeof(DefaultAuthorizationHeaderProvider), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(typeof(ICredentialsLoader), actual.ServiceType);
+                    Assert.Equal(typeof(DefaultCertificateLoader), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(ITokenAcquirerFactory), actual.ServiceType);
+                    Assert.Equal(typeof(DefaultTokenAcquirerFactoryImplementation), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IMergedOptionsStore), actual.ServiceType);
+                    Assert.Equal(typeof(MergedOptionsStore), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IMergedOptionsStore), actual.ServiceType);
+                    Assert.Equal(typeof(MergedOptionsStore), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(ITokenAcquisition), actual.ServiceType);
+                    Assert.Equal(typeof(TokenAcquisitionAspNetCore), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(ITokenAcquisitionHost), actual.ServiceType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(ITokenAcquisitionInternal), actual.ServiceType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.NotNull(actual.ImplementationFactory);
+                });
         }
     }
 


### PR DESCRIPTION
Why?
This PR ensures TokenAcquisition services are registered only as singletons if the `isTokenAcquisitionSingleton` flag is true and removes any previously added scoped TokenAcquisition services when TokenAcquirerFactory is not used.
 
# {PR title}
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

#3157 
