### PR TITLE
Disable Coverage PR comments

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -60,21 +60,22 @@ jobs:
       shell: bash
       run: |
         cat CodeCoverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
-        echo "COMMENT_CONTENT_ENV_VAR<<EOF" >> $GITHUB_ENV
-        echo $(cat CodeCoverage/SummaryGithub.md) >> $GITHUB_ENV
-        echo "EOF" >> $GITHUB_ENV
+    # Temporarily disable commenting the coverage report
+    #     echo "COMMENT_CONTENT_ENV_VAR<<EOF" >> $GITHUB_ENV
+    #     echo $(cat CodeCoverage/SummaryGithub.md) >> $GITHUB_ENV
+    #     echo "EOF" >> $GITHUB_ENV
 
-    - name: Comment coverage in PR
-      uses: actions/github-script@v7
-      id: comment
-      with:
-        script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: process.env.COMMENT_CONTENT_ENV_VAR
-          })
+    # - name: Comment coverage in PR
+    #   uses: actions/github-script@v7
+    #   id: comment
+    #   with:
+    #     script: |
+    #       github.rest.issues.createComment({
+    #         issue_number: context.issue.number,
+    #         owner: context.repo.owner,
+    #         repo: context.repo.repo,
+    #         body: process.env.COMMENT_CONTENT_ENV_VAR
+    #       })
 
     - name: Test with .NET 462
       run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net462 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"


### PR DESCRIPTION
Related to https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2983

Until code coverage report is configured ideally, do not post a comment with the report each time a push is made.

The report is still visible in the summary section of the action that runs unit tests.