### PR TITLE
Add Warning Quality Check Build Task 🔨

### DIFF
--- a/build/template-publish-and-cleanup.yaml
+++ b/build/template-publish-and-cleanup.yaml
@@ -51,11 +51,11 @@ steps:
   continueOnError: true
 
 - task: BuildQualityChecks@9
-    displayName: 'Check Warnings'
-    inputs:
-      checkWarnings: true
-      warningFailOption: 'build'
-      showStatistics: true
+  displayName: 'Check Warnings'
+  inputs:
+    checkWarnings: true
+    warningFailOption: 'build'
+    showStatistics: true
 
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
   displayName: 'Clean Agent Directories'

--- a/build/template-publish-and-cleanup.yaml
+++ b/build/template-publish-and-cleanup.yaml
@@ -50,5 +50,12 @@ steps:
     GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/tsaConfig.json'
   continueOnError: true
 
+- task: BuildQualityChecks@9
+    displayName: 'Check Warnings'
+    inputs:
+      checkWarnings: true
+      warningFailOption: 'build'
+      showStatistics: true
+
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
   displayName: 'Clean Agent Directories'


### PR DESCRIPTION
With the new task, I've configured the build to:

- fail if the number of warnings has increased since the previous build - no new warnings!
- show warning statistics to show the changes in number of warnings grouped by task/code file/object

I have not selected this option:
- Force fewer warnings 
- Allow Variance - we don't want the number of warnings to creep up. 

Build Quality Checks Warnings Policy documentation: https://github.com/MicrosoftPremier/VstsExtensions/blob/master/BuildQualityChecks/en-US/WarningsPolicy.md#evaluateTaskWarnings 