### PR TITLE
Revert "Treat warnings as errors"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,6 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>13</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'NET6_0_OR_GREATER'">

--- a/src/Microsoft.Identity.Web.Certificate/Base64EncodedCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/Base64EncodedCertificateLoader.cs
@@ -39,22 +39,18 @@ namespace Microsoft.Identity.Web
 
         internal static X509Certificate2 LoadFromBase64Encoded(string certificateBase64, X509KeyStorageFlags x509KeyStorageFlags)
         {
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
             return new X509Certificate2(
                 Convert.FromBase64String(certificateBase64),
                 (string?)null,
                 x509KeyStorageFlags);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
         }
 
         internal static X509Certificate2 LoadFromBase64Encoded(string certificateBase64, string password, X509KeyStorageFlags x509KeyStorageFlags)
         {
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
             return new X509Certificate2(
                 Convert.FromBase64String(certificateBase64),
                 password,
                 x509KeyStorageFlags);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
         }
     }
 }

--- a/src/Microsoft.Identity.Web.Certificate/FromPathCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/FromPathCertificateLoader.cs
@@ -26,12 +26,10 @@ namespace Microsoft.Identity.Web
         {
             X509KeyStorageFlags x509KeyStorageFlags = CertificateLoaderHelper.DetermineX509KeyStorageFlag();
 
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
             return new X509Certificate2(
                 certificateFileName,
                 password,
                 x509KeyStorageFlags);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
         }
     }
 }

--- a/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
@@ -98,12 +98,10 @@ namespace Microsoft.Identity.Web
             // Return a certificate with only the public key if the private key is not exportable.
             if (certificate.Policy?.Exportable != true)
             {
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
                 return new X509Certificate2(
                     certificate.Cer,
                     (string?)null,
                     x509KeyStorageFlags);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
             }
 
             // Parse the secret ID and version to retrieve the private key.

--- a/tests/E2E Tests/TokenAcquirerTests/CertificateRotationTest.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/CertificateRotationTest.cs
@@ -271,9 +271,7 @@ namespace TokenAcquirerTests
             var cert = req.CreateSelfSigned(notBefore.HasValue ? notBefore.Value : DateTimeOffset.Now, expiry);
 
             byte[] bytes = cert.Export(X509ContentType.Pfx, (string?)null);
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
             X509Certificate2 certWithPrivateKey = new(bytes);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
 
             // Add it to the local cert store.
             X509Store x509Store = new(StoreName.My, StoreLocation.CurrentUser);

--- a/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
@@ -78,9 +78,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
         [Fact]
         public void TestFromCertificate()
         {
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
-            using X509Certificate2 certificate2 = new([]);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
+            using X509Certificate2 certificate2 = new X509Certificate2(new byte[0]);
             CertificateDescription certificateDescription =
                 CertificateDescription.FromCertificate(certificate2);
         }

--- a/tests/Microsoft.Identity.Web.Test/MsAuth10AtPopTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MsAuth10AtPopTests.cs
@@ -80,9 +80,7 @@ namespace Microsoft.Identity.Web.Test
         {
             // Arrange
             IConfidentialClientApplication app = CreateBuilder();
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
-            using X509Certificate2 clientCertificate = new([]);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
+            var clientCertificate = new X509Certificate2(new byte[0]);
             var jwkClaim = "jwk_claim";
             var clientId = "client_id";
 
@@ -101,9 +99,7 @@ namespace Microsoft.Identity.Web.Test
         {
             // Arrange
             IConfidentialClientApplication app = CreateBuilder();
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
-            using X509Certificate2 clientCertificate = new([]);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
+            var clientCertificate = new X509Certificate2(new byte[0]);
             var popPublicKey = "pop_key";
             var clientId = "client_id";
 

--- a/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/JwtBearerEventsClaimsValidationTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         [Fact]
         public async Task TokenValidated_MissingScopesAndRoles_AuthenticationFailsAsync()
         {
-            Assert.True(_tokenContext.Result!.Succeeded);
+            Assert.True(_tokenContext.Result.Succeeded);
             await _jwtEvents.TokenValidated(_tokenContext);
             Assert.False(_tokenContext.Result.Succeeded);
         }
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Web.Test.Resource
         [Fact]
         public async Task TokenValidated_WithScopesAndRoles_AuthenticationSucceedsAsync()
         {
-            Assert.True(_tokenContext.Result!.Succeeded);
+            Assert.True(_tokenContext.Result.Succeeded);
             await _jwtEvents.TokenValidated(_tokenContext);
             Assert.True(_tokenContext.Result.Succeeded);
         }


### PR DESCRIPTION
Reverts AzureAD/microsoft-identity-web#3166

This is causing failures in a separate pipeline.