### PR TITLE
Revert: Warning Quality Check Build Task

### DIFF
--- a/build/template-publish-and-cleanup.yaml
+++ b/build/template-publish-and-cleanup.yaml
@@ -50,12 +50,5 @@ steps:
     GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/tsaConfig.json'
   continueOnError: true
 
-- task: BuildQualityChecks@9
-  displayName: 'Check Warnings'
-  inputs:
-    checkWarnings: true
-    warningFailOption: 'build'
-    showStatistics: true
-
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
   displayName: 'Clean Agent Directories'


### PR DESCRIPTION
since these changes cause errors in the pipeline it was decided to roll them back temporarily