### PR TITLE
use only src files and re-add comments

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,11 +26,6 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x      
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,11 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
+    - name: Setup .NET 8.0.x
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.x
+        
     - name: Setup .NET 9.0.x
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,11 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x      
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -54,28 +54,27 @@ jobs:
     - name: Create code coverage report
       run: |
         dotnet tool install -g dotnet-reportgenerator-globaltool --version 5.4.1
-        reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:CodeCoverage -reporttypes:'MarkdownSummaryGithub;Cobertura'
+        reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:CodeCoverage -reporttypes:'MarkdownSummaryGithub;Cobertura' -filefilters:'+src/**/*.cs'
 
     - name: Write coverage to job summary
       shell: bash
       run: |
         cat CodeCoverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
-    # Temporarily disable commenting the coverage report
-    #     echo "COMMENT_CONTENT_ENV_VAR<<EOF" >> $GITHUB_ENV
-    #     echo $(cat CodeCoverage/SummaryGithub.md) >> $GITHUB_ENV
-    #     echo "EOF" >> $GITHUB_ENV
+        echo "COMMENT_CONTENT_ENV_VAR<<EOF" >> $GITHUB_ENV
+        echo $(cat CodeCoverage/SummaryGithub.md) >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
 
-    # - name: Comment coverage in PR
-    #   uses: actions/github-script@v7
-    #   id: comment
-    #   with:
-    #     script: |
-    #       github.rest.issues.createComment({
-    #         issue_number: context.issue.number,
-    #         owner: context.repo.owner,
-    #         repo: context.repo.repo,
-    #         body: process.env.COMMENT_CONTENT_ENV_VAR
-    #       })
+    - name: Comment coverage in PR
+      uses: actions/github-script@v7
+      id: comment
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: process.env.COMMENT_CONTENT_ENV_VAR
+          })
 
     - name: Test with .NET 462
       run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net462 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)"


### PR DESCRIPTION
Update code coverage report to include only `src` files and re-add comments to the workflow see https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2983

#3177