### PR TITLE
Add retry logic to stabilize flaky UI tests

### DIFF
--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Versioning;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Identity;
 using Microsoft.Identity.Lab.Api;
@@ -77,9 +76,9 @@ namespace WebAppUiTests
             {
                 // Start the web app and api processes.
                 // The delay before starting client prevents transient devbox issue where the client fails to load the first time after rebuilding.
-                serviceProcess = UiTestHelpers.StartProcessLocally(_testAssemblyPath, _devAppPath + TC.s_todoListServicePath, TC.s_todoListServiceExe, serviceEnvVars);
+                serviceProcess = UiTestHelpers.StartProcessLocally(_testAssemblyPath, _devAppPath + TC.s_todoListServicePath, TC.s_todoListServiceExe, _output, serviceEnvVars);
                 await Task.Delay(3000);
-                clientProcess = UiTestHelpers.StartProcessLocally(_testAssemblyPath, _devAppPath + TC.s_todoListClientPath, TC.s_todoListClientExe, clientEnvVars, 5);
+                clientProcess = UiTestHelpers.StartProcessLocally(_testAssemblyPath, _devAppPath + TC.s_todoListClientPath, TC.s_todoListClientExe, _output, clientEnvVars, 5);
 
                 if (!UiTestHelpers.ProcessesAreAlive([clientProcess, serviceProcess]))
                 {

--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -42,7 +42,7 @@ namespace WebAppUiTests
 
         [Fact]
         [SupportedOSPlatform("windows")]
-        public async Task Susi_B2C_LocalAccount_TodoAppFucntionsCorrectlyAsync()
+        public async Task Susi_B2C_LocalAccount_TodoAppFunctionsCorrectlyAsync()
         {
             // Web app and api environmental variable setup.
             DefaultAzureCredential azureCred = new();
@@ -79,9 +79,9 @@ namespace WebAppUiTests
                 // The delay before starting client prevents transient devbox issue where the client fails to load the first time after rebuilding.
                 serviceProcess = UiTestHelpers.StartProcessLocally(_testAssemblyPath, _devAppPath + TC.s_todoListServicePath, TC.s_todoListServiceExe, serviceEnvVars);
                 await Task.Delay(3000);
-                clientProcess = UiTestHelpers.StartProcessLocally(_testAssemblyPath, _devAppPath + TC.s_todoListClientPath, TC.s_todoListClientExe, clientEnvVars);
+                clientProcess = UiTestHelpers.StartProcessLocally(_testAssemblyPath, _devAppPath + TC.s_todoListClientPath, TC.s_todoListClientExe, clientEnvVars, 5);
 
-                if (!UiTestHelpers.ProcessesAreAlive(new List<Process>() { clientProcess, serviceProcess }))
+                if (!UiTestHelpers.ProcessesAreAlive([clientProcess, serviceProcess]))
                 {
                     Assert.Fail(TC.WebAppCrashedString);
                 }

--- a/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
@@ -76,7 +76,7 @@ public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixtur
 
         try
         {
-            process = UiTestHelpers.StartProcessLocally(_uiTestAssemblyLocation, _devAppPath, _devAppExecutable, clientEnvVars);
+            process = UiTestHelpers.StartProcessLocally(_uiTestAssemblyLocation, _devAppPath, _devAppExecutable, _output, clientEnvVars);
 
             if (!UiTestHelpers.ProcessIsAlive(process))
             { Assert.Fail(TC.WebAppCrashedString); }

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -170,6 +170,7 @@ namespace WebAppUiTests
             Process? process;
             do
             {
+                Thread.Sleep(1000 * currentAttempt++); // Exponential backoff
                 process = Process.Start(processStartInfo);
             } while (currentAttempt++ <= maxRetries && ProcessIsAlive(process));
 
@@ -179,6 +180,13 @@ namespace WebAppUiTests
             }
             else
             {
+                // Log the output and error streams
+                process.OutputDataReceived += (sender, e) => Console.WriteLine(e.Data);
+                process.ErrorDataReceived += (sender, e) => Console.Error.WriteLine(e.Data);
+
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
                 return process;
             }
         }

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -146,7 +146,8 @@ namespace WebAppUiTests
         /// <returns>The started process.</returns>
         public static Process StartProcessLocally(
             string testAssemblyLocation,
-            string appLocation, string executableName,
+            string appLocation,
+            string executableName,
             Dictionary<string, string>? environmentVariables = null,
             int maxRetries = 0)
         {

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -331,8 +331,7 @@ namespace WebAppUiTests
                                                 processDataEntry.TestAssemblyLocation,
                                                 processDataEntry.AppLocation,
                                                 processDataEntry.ExecutableName,
-                                                processDataEntry.EnvironmentVariables,
-                                                5);
+                                                processDataEntry.EnvironmentVariables);
 
                 processes.Add(processDataEntry.ExecutableName, process);
                 Thread.Sleep(5000);

--- a/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
@@ -5,16 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Versioning;
-using System.Threading;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Lab.Api;
-using TC = Microsoft.Identity.Web.Test.Common.TestConstants;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;
 using Process = System.Diagnostics.Process;
-using System.Linq;
-using System.Text;
+using TC = Microsoft.Identity.Web.Test.Common.TestConstants;
 
 namespace WebAppUiTests
 #if !FROM_GITHUB_ACTION
@@ -82,7 +80,7 @@ namespace WebAppUiTests
                 var serviceProcessOptions = new ProcessStartOptions(_testAssemblyLocation, _devAppPath + TC.s_todoListServicePath, TC.s_todoListServiceExe, serviceEnvVars);
                 var clientProcessOptions = new ProcessStartOptions(_testAssemblyLocation, _devAppPath + TC.s_todoListClientPath, TC.s_todoListClientExe, clientEnvVars);
 
-                bool areProcessesRunning = UiTestHelpers.StartAndVerifyProcessesAreRunning(new List<ProcessStartOptions> { /*grpcProcessOptions,*/ serviceProcessOptions, clientProcessOptions }, out processes);
+                bool areProcessesRunning = UiTestHelpers.StartAndVerifyProcessesAreRunning(new List<ProcessStartOptions> { /*grpcProcessOptions,*/ serviceProcessOptions, clientProcessOptions }, _output, out processes);
 
                 if (!areProcessesRunning)
                 {
@@ -219,7 +217,7 @@ namespace WebAppUiTests
                 // The delay before starting client prevents transient devbox issue where the client fails to load the first time after rebuilding.
                 var serviceProcessOptions = new ProcessStartOptions(_testAssemblyLocation, _devAppPathCiam + TC.s_myWebApiPath, TC.s_myWebApiExe, serviceEnvVars);
                 var clientProcessOptions = new ProcessStartOptions(_testAssemblyLocation, _devAppPathCiam + TC.s_myWebAppPath, TC.s_myWebAppExe, clientEnvVars);
-                bool areProcessesRunning = UiTestHelpers.StartAndVerifyProcessesAreRunning(new List<ProcessStartOptions> { serviceProcessOptions, clientProcessOptions }, out processes);
+                bool areProcessesRunning = UiTestHelpers.StartAndVerifyProcessesAreRunning(new List<ProcessStartOptions> { serviceProcessOptions, clientProcessOptions }, _output, out processes);
 
                 if (!areProcessesRunning)
                 {


### PR DESCRIPTION
Added optional retry logic for the test failures related to the client process start failures.

Addresses #3179