### PR TITLE
- Fixes 3181

### DIFF
--- a/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
+++ b/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
@@ -162,10 +162,11 @@ namespace Microsoft.Identity.Web
                         context.ProtocolMessage.SetParameter(ClaimConstants.ClientInfo, Constants.One);
                         context.ProtocolMessage.SetParameter(Constants.TelemetryHeaderKey, IdHelper.CreateTelemetryInfo());
 
-                        if (context.ProtocolMessage.IssuerAddress!=null && context.ProtocolMessage.IssuerAddress.EndsWith("/authorize", StringComparison.OrdinalIgnoreCase))
+                        if (context.ProtocolMessage.IssuerAddress != null && context.ProtocolMessage.IssuerAddress.EndsWith("/authorize", StringComparison.OrdinalIgnoreCase))
                         {
                             context.ProtocolMessage.RedirectUri = context.Request.Uri.ToString();
                         }
+
                         return Task.CompletedTask;
                     },
 

--- a/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
+++ b/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
@@ -161,6 +161,11 @@ namespace Microsoft.Identity.Web
                         }
                         context.ProtocolMessage.SetParameter(ClaimConstants.ClientInfo, Constants.One);
                         context.ProtocolMessage.SetParameter(Constants.TelemetryHeaderKey, IdHelper.CreateTelemetryInfo());
+
+                        if (context.ProtocolMessage.IssuerAddress!=null && context.ProtocolMessage.IssuerAddress.EndsWith("/authorize", StringComparison.OrdinalIgnoreCase))
+                        {
+                            context.ProtocolMessage.RedirectUri = context.Request.Uri.ToString();
+                        }
                         return Task.CompletedTask;
                     },
 

--- a/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.xml
+++ b/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.xml
@@ -57,11 +57,14 @@
         </member>
         <member name="M:Microsoft.Identity.Web.AppBuilderExtension.RejectInternalClaims(System.Security.Claims.ClaimsIdentity,System.String,System.String)">
             <summary>
-            Rejects the internal claims, if present.
+            The SDK injects 2 claims named uuid and utid into the ClaimsPrincipal, from ESTS's client_info. These represent 
+            the home oid and home tid and together they form the AccountId, which MSAL uses as cache key for web site 
+            scenarios. In case the app owner defines claims with the same name to be added to the ID Token, this creates 
+            a conflict with the reserved claims Id.Web injects, and it is better to throw a meaningful error. See issue 2968 for details.
             </summary>
             <param name="identity">The <see cref="T:System.Security.Claims.ClaimsIdentity"/> associated to the logged-in user</param>
-            <param name="uniqueTenantIdentifier">The tenant identifier (i.e. <see cref="F:Microsoft.Identity.Web.ClaimConstants.UniqueTenantIdentifier"/>>)</param>
-            <param name="uniqueObjectIdentifier">The object identifier (i.e. <see cref="F:Microsoft.Identity.Web.ClaimConstants.UniqueObjectIdentifier"/>>)</param>
+            <param name="claimType">The claim type</param>
+            <param name="claimValue">The claim value</param>
             <exception cref="T:System.Security.Authentication.AuthenticationException">The <see cref="T:System.Security.Claims.ClaimsIdentity"/> contains internal claims that are used internal use by this library</exception>
         </member>
         <member name="T:Microsoft.Identity.Web.ControllerBaseExtensions">

--- a/src/Microsoft.Identity.Web.OWIN/OwinTokenAcquirerFactory.cs
+++ b/src/Microsoft.Identity.Web.OWIN/OwinTokenAcquirerFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using System.Web;
+using System.Web.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Web.Hosts;
@@ -34,7 +35,8 @@ namespace Microsoft.Identity.Web.OWIN
                 ["AzureAd:SignedOutCallbackPath"] = ConfigurationManager.AppSettings["ida:PostLogoutRedirectUri"],
                 ["AzureAd:RedirectUri"] = ConfigurationManager.AppSettings["ida:RedirectUri"],
             });
-            return HttpContext.Current.Request.PhysicalApplicationPath;
+
+            return HostingEnvironment.MapPath("~/");
         }
 
         /// <summary>

--- a/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
@@ -25,10 +25,6 @@
 				<bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
 			</dependentAssembly>
@@ -180,7 +176,6 @@
 				<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
 			</dependentAssembly>
-	
     </assemblyBinding>
   </runtime>
   <system.codedom>

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/App_Start/Startup.Auth.cs
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/App_Start/Startup.Auth.cs
@@ -21,24 +21,10 @@ namespace OwinWebApp
 
             app.AddMicrosoftIdentityWebApp(factory);
             factory.Services
-                .Configure<ConfidentialClientApplicationOptions>(options => { options.RedirectUri = "https://localhost:44386/"; })
                 .AddMicrosoftGraph()
                 .AddDownstreamApi("DownstreamAPI1", factory.Configuration.GetSection("DownstreamAPI"))
                 .AddInMemoryTokenCaches();
             factory.Build();
-
-            /*
-            app.AddMicrosoftIdentityWebApp(configureServices: services =>
-            {
-                services
-                .Configure<ConfidentialClientApplicationOptions>(options => { options.RedirectUri = "https://localhost:44386/"; })
-                .AddMicrosoftGraph()
-               // WE cannot do that today: Configuration is not available.
-               // .AddDownstreamApi("CalledApi", null)
-                .AddInMemoryTokenCaches();
-            });
-            */
-
         }
     }
 }

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
@@ -31,7 +31,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.0.0.4" newVersion="8.0.0.4"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -59,7 +59,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.1.0.0" newVersion="8.1.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.0.0" newVersion="8.3.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -75,7 +75,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.1.0.0" newVersion="8.1.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.0.0" newVersion="8.3.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.WsFederation" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -83,23 +83,23 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.1.0.0" newVersion="8.1.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.0.0" newVersion="8.3.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.1.0.0" newVersion="8.1.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.0.0" newVersion="8.3.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.1.0.0" newVersion="8.1.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.0.0" newVersion="8.3.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.1.0.0" newVersion="8.1.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.0.0" newVersion="8.3.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.65.2.0" newVersion="4.65.2.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.66.1.0" newVersion="4.66.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
@@ -169,6 +169,7 @@
 				<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
 			</dependentAssembly>
+			
 			
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
# Fix Null Reference Exception in OwinTokenAcquirerFactory + other OWIN cleanup

This pull request addresses several improvements and bug fixes for the Microsoft.Identity.Web.OWIN package, specifically:

1. Fixes a null reference exception in `OwinTokenAcquirerFactory` (#3181)
2. Removes the need to provide the MSAL redirect URI in web applications.
3. Updates the binding redirect in the OWIN samples.

#3181 



