### PR TITLE
Fix E2E tests persistent flakiness + build hanging

### DIFF
--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -167,7 +167,7 @@ namespace WebAppUiTests
                 Queue<Process> processes = new Queue<Process>();
                 if (serviceProcess != null) { processes.Enqueue(serviceProcess); }
                 if (clientProcess != null) { processes.Enqueue(clientProcess); }
-                UiTestHelpers.KillProcessTrees(processes);
+                await UiTestHelpers.KillProcessTreesAsync(processes);
 
                 // Stop tracing and export it into a zip archive.
                 string path = UiTestHelpers.GetTracePath(_testAssemblyPath, TraceFileName);

--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -55,7 +55,7 @@ namespace WebAppUiTests
             {
                 {"ASPNETCORE_ENVIRONMENT", "Development"},
                 {"AzureAdB2C__ClientSecret", clientSecret},
-                {TC.KestrelEndpointEnvVar, TC.HttpsStarColon + TodoListClientPort}
+                {TC.KestrelEndpointEnvVar, TC.HttpStarColon + TodoListClientPort}
             };
 
             // Get email and password from keyvault.
@@ -92,7 +92,7 @@ namespace WebAppUiTests
                 {
                     try
                     {
-                        await page.GotoAsync(TC.LocalhostUrl + TodoListClientPort);
+                        await page.GotoAsync(TC.LocalhostHttpUrl + TodoListClientPort);
                         break;
                     }
                     catch (PlaywrightException ex)

--- a/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
@@ -21,7 +21,7 @@ namespace WebAppUiTests;
 [CollectionDefinition(nameof(UiTestNoParallelization), DisableParallelization = true)]
 public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixture>
 {
-    private const string UrlString = "http://localhost:5001/MicrosoftIdentity/Account/signin";
+    private const string UrlString = "https://localhost:5001/MicrosoftIdentity/Account/signin";
     private const string TraceFileClassName = "TestingWebAppLocally";
     private const string TraceFileClassNameCiam = "TestingWebAppLocallyCiam";
     private readonly ITestOutputHelper _output;
@@ -47,8 +47,8 @@ public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixtur
     }
 
     [Theory]
-    [InlineData("http://MSIDLABCIAM6.ciamlogin.com")] // CIAM authority
-    [InlineData("http://login.msidlabsciam.com/fe362aec-5d43-45d1-b730-9755e60dc3b9/v2.0/")] // CIAM CUD Authority
+    [InlineData("https://MSIDLABCIAM6.ciamlogin.com")] // CIAM authority
+    [InlineData("https://login.msidlabsciam.com/fe362aec-5d43-45d1-b730-9755e60dc3b9/v2.0/")] // CIAM CUD Authority
     [SupportedOSPlatform("windows")]
     public async Task ChallengeUser_MicrosoftIdFlow_LocalApp_ValidEmailWithCiamPasswordAsync(string authority)
     {

--- a/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
@@ -21,7 +21,7 @@ namespace WebAppUiTests;
 [CollectionDefinition(nameof(UiTestNoParallelization), DisableParallelization = true)]
 public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixture>
 {
-    private const string UrlString = "https://localhost:5001/MicrosoftIdentity/Account/signin";
+    private const string UrlString = "http://localhost:5001/MicrosoftIdentity/Account/signin";
     private const string TraceFileClassName = "TestingWebAppLocally";
     private const string TraceFileClassNameCiam = "TestingWebAppLocallyCiam";
     private readonly ITestOutputHelper _output;
@@ -47,8 +47,8 @@ public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixtur
     }
 
     [Theory]
-    [InlineData("https://MSIDLABCIAM6.ciamlogin.com")] // CIAM authority
-    [InlineData("https://login.msidlabsciam.com/fe362aec-5d43-45d1-b730-9755e60dc3b9/v2.0/")] // CIAM CUD Authority
+    [InlineData("http://MSIDLABCIAM6.ciamlogin.com")] // CIAM authority
+    [InlineData("http://login.msidlabsciam.com/fe362aec-5d43-45d1-b730-9755e60dc3b9/v2.0/")] // CIAM CUD Authority
     [SupportedOSPlatform("windows")]
     public async Task ChallengeUser_MicrosoftIdFlow_LocalApp_ValidEmailWithCiamPasswordAsync(string authority)
     {

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -173,7 +173,7 @@ namespace WebAppUiTests
             {
                 Thread.Sleep(1000 * currentAttempt++); // linear backoff
                 process = Process.Start(processStartInfo);
-            } while (currentAttempt++ <= maxRetries && ProcessIsAlive(process));
+            } while (currentAttempt++ <= maxRetries && !ProcessIsAlive(process));
 
             if (process == null)
             {
@@ -181,30 +181,17 @@ namespace WebAppUiTests
             }
             else
             {
-                LogOutputErrorStreams(process, output);
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    output.WriteLine(e?.Data == null ? "null output data received." : $"{process.Id} {e.Data}");
+                };
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    output.WriteLine(e?.Data == null ? "null output data received." : $"{process.Id} {e.Data}");
+                };
 
                 return process;
             }
-        }
-
-        /// <summary>
-        /// Logs the output and error streams of a process.
-        /// </summary>
-        /// <param name="process"></param>
-        /// <param name="output"></param>
-        private static void LogOutputErrorStreams(Process process, ITestOutputHelper output)
-        {
-            process.OutputDataReceived += (sender, e) =>
-            {
-                output.WriteLine(e?.Data == null ? "null output data received." : $"{process.Id} {e.Data}");
-            };
-            process.ErrorDataReceived += (sender, e) =>
-            {
-                output.WriteLine(e?.Data == null ? "null output data received." : $"{process.Id} {e.Data}");
-            };
-
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
         }
 
         /// <summary>
@@ -271,6 +258,10 @@ namespace WebAppUiTests
                 {
                     processQueue.Enqueue(child);
                 }
+                _ = currentProcess.WaitForExitAsync();
+                currentProcess.StandardOutput.Close();
+                currentProcess.StandardError.Close();
+
                 currentProcess.Kill();
                 currentProcess.Close();
             }

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -245,7 +245,7 @@ namespace WebAppUiTests
         /// </summary>
         /// <param name="processQueue">queue of parent processes</param>
         [SupportedOSPlatform("windows")]
-        public static void KillProcessTrees(Queue<Process> processQueue)
+        public static async Task KillProcessTreesAsync(Queue<Process> processQueue)
         {
             Process currentProcess;
             while (processQueue.Count > 0)
@@ -258,7 +258,7 @@ namespace WebAppUiTests
                 {
                     processQueue.Enqueue(child);
                 }
-                _ = currentProcess.WaitForExitAsync();
+                await currentProcess.WaitForExitAsync();
                 currentProcess.StandardOutput.Close();
                 currentProcess.StandardError.Close();
 

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -181,24 +181,30 @@ namespace WebAppUiTests
             }
             else
             {
-                // Log the output and error streams
-                process.OutputDataReceived += (sender, e) =>
-                {
-                    output.WriteLine($"{process.Id} ");
-                    output.WriteLine(e?.Data ?? "null output data received.");
-                };
-
-                process.ErrorDataReceived += (sender, e) =>
-                {
-                    output.WriteLine($"{process.Id} ");
-                    output.WriteLine(e?.Data ?? "null error data received.");
-                };
-
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
+                LogOutputErrorStreams(process, output);
 
                 return process;
             }
+        }
+
+        /// <summary>
+        /// Logs the output and error streams of a process.
+        /// </summary>
+        /// <param name="process"></param>
+        /// <param name="output"></param>
+        private static void LogOutputErrorStreams(Process process, ITestOutputHelper output)
+        {
+            process.OutputDataReceived += (sender, e) =>
+            {
+                output.WriteLine(e?.Data == null ? "null output data received." : $"{process.Id} {e.Data}");
+            };
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                output.WriteLine(e?.Data == null ? "null output data received." : $"{process.Id} {e.Data}");
+            };
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
         }
 
         /// <summary>

--- a/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
@@ -233,7 +233,6 @@ namespace WebAppUiTests
                 }
 
                 page = await NavigateToWebAppAsync(context, WebAppCiamPort);
-                 _output.WriteLine("WebApp HTML: " + await page.InnerHTMLAsync("html"));
 
                 // Initial sign in
                 _output.WriteLine("Starting web app sign-in flow.");

--- a/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
@@ -179,8 +179,8 @@ namespace WebAppUiTests
         }
 
         [Theory]
-        [InlineData("http://MSIDLABCIAM6.ciamlogin.com")] // CIAM authority
-        [InlineData("http://login.msidlabsciam.com/fe362aec-5d43-45d1-b730-9755e60dc3b9/v2.0/")] // CIAM CUD Authority
+        [InlineData("https://MSIDLABCIAM6.ciamlogin.com")] // CIAM authority
+        [InlineData("https://login.msidlabsciam.com/fe362aec-5d43-45d1-b730-9755e60dc3b9/v2.0/")] // CIAM CUD Authority
         [SupportedOSPlatform("windows")]
         public async Task ChallengeUser_MicrosoftIdFlow_LocalApp_ValidEmailPasswordCreds_CallsDownStreamApiWithCiamAsync(string authority)
         {
@@ -233,6 +233,7 @@ namespace WebAppUiTests
                 }
 
                 page = await NavigateToWebAppAsync(context, WebAppCiamPort);
+                 _output.WriteLine("WebApp HTML: " + await page.InnerHTMLAsync("html"));
 
                 // Initial sign in
                 _output.WriteLine("Starting web app sign-in flow.");
@@ -258,7 +259,7 @@ namespace WebAppUiTests
             }
             catch (Exception ex)
             {
-                //Adding guid incase of multiple test runs. This will allow screenshots to be matched to their appropriet test runs.
+                //Adding guid incase of multiple test runs. This will allow screenshots to be matched to their appropriate test runs.
                 var guid = Guid.NewGuid().ToString();
                 try
                 {

--- a/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
@@ -49,7 +49,7 @@ namespace WebAppUiTests
             var grpcEnvVars = new Dictionary<string, string>
             {
                 {"ASPNETCORE_ENVIRONMENT", "Development"},
-                {TC.KestrelEndpointEnvVar, TC.HttpsStarColon + GrpcPort}
+                {TC.KestrelEndpointEnvVar, TC.HttpStarColon + GrpcPort}
             };
             var serviceEnvVars = new Dictionary<string, string>
             {
@@ -59,7 +59,7 @@ namespace WebAppUiTests
             var clientEnvVars = new Dictionary<string, string>
             {
                 {"ASPNETCORE_ENVIRONMENT", "Development"},
-                {TC.KestrelEndpointEnvVar, TC.HttpsStarColon + TodoListClientPort}
+                {TC.KestrelEndpointEnvVar, TC.HttpStarColon + TodoListClientPort}
             };
 
             Dictionary<string, Process>? processes = null;
@@ -109,7 +109,7 @@ namespace WebAppUiTests
                 // Sign out
                 _output.WriteLine("Starting web app sign-out flow.");
                 await page.GetByRole(AriaRole.Link, new() { Name = "Sign out" }).ClickAsync();
-                await UiTestHelpers.PerformSignOut_MicrosoftIdFlowAsync(page, email, TC.LocalhostUrl + TodoListClientPort + SignOutPageUriPath, _output);
+                await UiTestHelpers.PerformSignOut_MicrosoftIdFlowAsync(page, email, TC.LocalhostHttpUrl + TodoListClientPort + SignOutPageUriPath, _output);
                 _output.WriteLine("Web app sign out successful.");
 
                 // Sign in again using Todo List button
@@ -179,8 +179,8 @@ namespace WebAppUiTests
         }
 
         [Theory]
-        [InlineData("https://MSIDLABCIAM6.ciamlogin.com")] // CIAM authority
-        [InlineData("https://login.msidlabsciam.com/fe362aec-5d43-45d1-b730-9755e60dc3b9/v2.0/")] // CIAM CUD Authority
+        [InlineData("http://MSIDLABCIAM6.ciamlogin.com")] // CIAM authority
+        [InlineData("http://login.msidlabsciam.com/fe362aec-5d43-45d1-b730-9755e60dc3b9/v2.0/")] // CIAM CUD Authority
         [SupportedOSPlatform("windows")]
         public async Task ChallengeUser_MicrosoftIdFlow_LocalApp_ValidEmailPasswordCreds_CallsDownStreamApiWithCiamAsync(string authority)
         {
@@ -198,7 +198,7 @@ namespace WebAppUiTests
                 {"AzureAd__ClientId", "b244c86f-ed88-45bf-abda-6b37aa482c79"},
                 {"AzureAd__Authority", authority},
                 {"DownstreamApi__Scopes__0", "api://634de702-3173-4a71-b336-a4fab786a479/.default"},
-                {TC.KestrelEndpointEnvVar, TC.HttpsStarColon + WebAppCiamPort}
+                {TC.KestrelEndpointEnvVar, TC.HttpStarColon + WebAppCiamPort}
             };
 
             Dictionary<string, Process>? processes = null;
@@ -245,7 +245,7 @@ namespace WebAppUiTests
                 // Sign out
                 _output.WriteLine("Starting web app sign-out flow.");
                 await page.GetByRole(AriaRole.Link, new() { Name = "Sign out" }).ClickAsync();
-                await UiTestHelpers.PerformSignOut_MicrosoftIdFlowAsync(page, email, TC.LocalhostUrl + WebAppCiamPort + SignOutPageUriPath, _output);
+                await UiTestHelpers.PerformSignOut_MicrosoftIdFlowAsync(page, email, TC.LocalhostHttpUrl + WebAppCiamPort + SignOutPageUriPath, _output);
                 _output.WriteLine("Web app sign out successful.");
 
                 // Sign in again using Todo List button
@@ -341,7 +341,7 @@ namespace WebAppUiTests
             {
                 try
                 {
-                    await page.GotoAsync(TC.LocalhostUrl + port);
+                    await page.GotoAsync(TC.LocalhostHttpUrl + port);
                     break;
                 }
                 catch (PlaywrightException ex)

--- a/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
@@ -175,7 +175,8 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string PasswordText = "Password";
         public const string TodoTitle1 = "Testing create todo item";
         public const string TodoTitle2 = "Testing edit todo item";
-        public const string LocalhostUrl = @"https://localhost:";
+        public const string LocalhostHttpsUrl = @"https://localhost:";
+        public const string LocalhostHttpUrl = @"http://localhost:";
         public const string KestrelEndpointEnvVar = "Kestrel:Endpoints:Http:Url";
         public const string HttpStarColon = "http://*:";
         public const string HttpsStarColon = "https://*:";


### PR DESCRIPTION
Issue 1: The persistent flakiness 🥐 
After enabling output and error logs, we see [this ](https://identitydivision.visualstudio.com/DevEx/_build/results?buildId=1411321&view=logs&j=f3712adf-8b8e-52fd-13d9-df53740e9087&t=80606c5c-301e-53cc-a2ac-c3815e4eca23&l=833)in a build with failing E2E tests.
![image](https://github.com/user-attachments/assets/fbb2bf30-922f-4dde-af4a-d668bc69f45e)
We can't replicate this locally as we have the certs configured locally. Moving to HTTP from HTTPS should resolve this for our builds.

Issue 2: Build Hanging
Adding logging from the output/error streams on the processes mean that we need to close them. 🤦‍♀️ Interestingly, the IdWeb build didn't fail on this, but the Unified build did. 