### PR TITLE
Revert WaitForProcess in UI Tests

### DIFF
--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -167,7 +167,7 @@ namespace WebAppUiTests
                 Queue<Process> processes = new Queue<Process>();
                 if (serviceProcess != null) { processes.Enqueue(serviceProcess); }
                 if (clientProcess != null) { processes.Enqueue(clientProcess); }
-                await UiTestHelpers.KillProcessTreesAsync(processes);
+                UiTestHelpers.KillProcessTrees(processes);
 
                 // Stop tracing and export it into a zip archive.
                 string path = UiTestHelpers.GetTracePath(_testAssemblyPath, TraceFileName);

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -245,7 +245,7 @@ namespace WebAppUiTests
         /// </summary>
         /// <param name="processQueue">queue of parent processes</param>
         [SupportedOSPlatform("windows")]
-        public static async Task KillProcessTreesAsync(Queue<Process> processQueue)
+        public static void KillProcessTrees(Queue<Process> processQueue)
         {
             Process currentProcess;
             while (processQueue.Count > 0)
@@ -258,7 +258,9 @@ namespace WebAppUiTests
                 {
                     processQueue.Enqueue(child);
                 }
-                await currentProcess.WaitForExitAsync();
+                // Do not call "await currentProcess.WaitForExitAsync();"
+                // as the web APIs never terminate by themselves (they are a loop
+                // that serves requests until the process is killed).
                 currentProcess.StandardOutput.Close();
                 currentProcess.StandardError.Close();
 


### PR DESCRIPTION
# Revert WaitForProcess in UI Tests

Removes the call to "await currentProcess.WaitForExitAsync();" as the web APIs never terminate by themselves (they are a loop
that serves requests until the process is killed).