### PR TITLE
Update to use MSAL 4.67.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,7 +82,7 @@
 
   <PropertyGroup Label="Common dependency versions">
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.3.0</MicrosoftIdentityModelVersion>
-    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.67.0</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.67.1</MicrosoftIdentityClientVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,7 +82,7 @@
 
   <PropertyGroup Label="Common dependency versions">
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.3.0</MicrosoftIdentityModelVersion>
-    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.66.2</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.67.0</MicrosoftIdentityClientVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Identity.Web
                 builder.WithClaims(tokenAcquisitionOptions.Claims);
                 if (tokenAcquisitionOptions.PoPConfiguration != null)
                 {
-                    builder.WithProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);
+                    builder.WithSignedHttpRequestProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);
                 }
                 if (!string.IsNullOrEmpty(tokenAcquisitionOptions.PopPublicKey))
                 {
@@ -982,7 +982,7 @@ namespace Microsoft.Identity.Web
                         builder.WithClaims(tokenAcquisitionOptions.Claims);
                         if (tokenAcquisitionOptions.PoPConfiguration != null)
                         {
-                            builder.WithProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);
+                            builder.WithSignedHttpRequestProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);
                         }
                     }
 


### PR DESCRIPTION
# Update to use MSAL 4.67.1

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

This pull request includes updates to dependency versions and modifications to the `TokenAcquisition` class methods in the `Microsoft.Identity.Web.TokenAcquisition` project. The most important changes are as follows:

Dependency updates:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL85-R85): Updated `MicrosoftIdentityClientVersion` from `4.66.2` to `4.67.1`.

Method modifications:

* [`src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs`](diffhunk://#diff-3600735102cf2582ea4dc8277f799690b8a8135f4971e0be919fbecd053ae2caL535-R535): Replaced the `WithProofOfPossession` method with `WithSignedHttpRequestProofOfPossession` in the `GetAuthenticationResultForAppAsync` method.
* [`src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs`](diffhunk://#diff-3600735102cf2582ea4dc8277f799690b8a8135f4971e0be919fbecd053ae2caL985-R985): Replaced the `WithProofOfPossession` method with `WithSignedHttpRequestProofOfPossession` in the `NotifyCertificateSelection` method.

{Detail}

Fixes #{bug number} (in this specific format)
