### PR TITLE
Suppress TFM Build Warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,10 @@
     <LangVersion>13</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+    <!-- Suppress the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0/net7.0 and has not been tested with it" warning -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,6 @@
     <PackageTags>Microsoft Identity Web UI;Microsoft identity platform;Microsoft Identity Web;.NET;ASP.NET Core;Web App;Web API;B2C;Azure Active Directory;AAD;Identity;Authentication;Authorization</PackageTags>
     <DefineConstants>$(DefineConstants);WEB</DefineConstants>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -38,6 +37,7 @@
     <LangVersion>13</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'NET6_0_OR_GREATER'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,7 @@
     <PackageTags>Microsoft Identity Web UI;Microsoft identity platform;Microsoft Identity Web;.NET;ASP.NET Core;Web App;Web API;B2C;Azure Active Directory;AAD;Identity;Authentication;Authorization</PackageTags>
     <DefineConstants>$(DefineConstants);WEB</DefineConstants>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/benchmark/Directory.Build.props
+++ b/benchmark/Directory.Build.props
@@ -9,6 +9,7 @@
     <AssemblyOriginatorKeyFile>../build/MSAL.snk</AssemblyOriginatorKeyFile>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <PropertyGroup Label="Common dependency versions">

--- a/benchmark/Directory.Build.props
+++ b/benchmark/Directory.Build.props
@@ -9,6 +9,10 @@
     <AssemblyOriginatorKeyFile>../build/MSAL.snk</AssemblyOriginatorKeyFile>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+    <!-- Suppress the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0/net7.0 and has not been tested with it" warning -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/tests/DevApps/Directory.Build.props
+++ b/tests/DevApps/Directory.Build.props
@@ -6,6 +6,10 @@
     <UseWip>true</UseWip>
     <IsPackable>false</IsPackable>
     <LangVersion>13</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+    <!-- Suppress the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0/net7.0 and has not been tested with it" warning -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/tests/DevApps/Directory.Build.props
+++ b/tests/DevApps/Directory.Build.props
@@ -6,6 +6,7 @@
     <UseWip>true</UseWip>
     <IsPackable>false</IsPackable>
     <LangVersion>13</LangVersion>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/tests/DevApps/aspnet-mvc/Directory.Build.props
+++ b/tests/DevApps/aspnet-mvc/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
     <LangVersion>13</LangVersion>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 </Project>

--- a/tests/DevApps/aspnet-mvc/Directory.Build.props
+++ b/tests/DevApps/aspnet-mvc/Directory.Build.props
@@ -1,6 +1,10 @@
 <Project>
   <PropertyGroup>
     <LangVersion>13</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+    <!-- Suppress the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0/net7.0 and has not been tested with it" warning -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,6 +8,10 @@
     <IsPackable>false</IsPackable>
     <EnablePackageValidation>false</EnablePackageValidation>
     <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+    <!-- Suppress the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0/net7.0 and has not been tested with it" warning -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,6 +8,7 @@
     <IsPackable>false</IsPackable>
     <EnablePackageValidation>false</EnablePackageValidation>
     <AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <PropertyGroup Label="Common dependency versions">

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/Directory.Build.props
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+        <!-- Suppress the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0/net7.0 and has not been tested with it" warning -->
         <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     </PropertyGroup>
 </Project>

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/Directory.Build.props
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/Directory.Build.props
@@ -1,1 +1,5 @@
-<Project></Project>
+<Project>
+    <PropertyGroup>
+        <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    </PropertyGroup>
+</Project>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -4,5 +4,6 @@
     <EnablePackageValidation>false</EnablePackageValidation>
     <!--RS0016: Add public types and members to the declared API-->
     <NoWarn>RS0016</NoWarn>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 </Project>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -4,6 +4,10 @@
     <EnablePackageValidation>false</EnablePackageValidation>
     <!--RS0016: Add public types and members to the declared API-->
     <NoWarn>RS0016</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+    <!-- Suppress the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0/net7.0 and has not been tested with it" warning -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 </Project>

--- a/tools/app-provisioning-tool/Directory.Build.props
+++ b/tools/app-provisioning-tool/Directory.Build.props
@@ -8,7 +8,11 @@
      <AssemblyOriginatorKeyFile>../../../build/MSAL.snk</AssemblyOriginatorKeyFile>
      <EnablePackageValidation>false</EnablePackageValidation>
      <RootNamespace>Microsoft.Identity.App</RootNamespace>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+     <!-- Suppress the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0/net7.0 and has not been tested with it" warning -->
+     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
  <ItemGroup>

--- a/tools/app-provisioning-tool/Directory.Build.props
+++ b/tools/app-provisioning-tool/Directory.Build.props
@@ -8,6 +8,7 @@
      <AssemblyOriginatorKeyFile>../../../build/MSAL.snk</AssemblyOriginatorKeyFile>
      <EnablePackageValidation>false</EnablePackageValidation>
      <RootNamespace>Microsoft.Identity.App</RootNamespace>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
  <ItemGroup>


### PR DESCRIPTION
Passing on https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1417266&view=results

I had to add suppressions to additional dir.build.props files as the setting is not propagating from the top level .props.