### PR TITLE
Fixing 3212 and cleaning-up technical debt

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -96,7 +96,7 @@
     <MicrosoftGraphVersion>4.36.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
     <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
-    <MicrosoftIdentityAbstractionsVersion>7.2.1</MicrosoftIdentityAbstractionsVersion>
+    <MicrosoftIdentityAbstractionsVersion>8.0.0</MicrosoftIdentityAbstractionsVersion>
     <!--CVE-2024-43485-->
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
     <!--CVE-2023-29331-->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!--This should be passed from the VSTS build-->
     <!-- This needs to be greater than or equal to the validation baseline version -->
-    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">3.2.3</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">3.6.2</MicrosoftIdentityWebVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MicrosoftIdentityWebVersion)</Version>
 

--- a/src/Microsoft.Identity.Web.Certificate/CertificateDescription.cs
+++ b/src/Microsoft.Identity.Web.Certificate/CertificateDescription.cs
@@ -24,14 +24,12 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="credentialDescription"></param>
         public CertificateDescription(CredentialDescription credentialDescription)
+            : base(credentialDescription)
         {
             _ = Throws.IfNull(credentialDescription);
 
             // TODO: Check credentialDescription is really a cert
             SourceType = (CertificateSource)credentialDescription.SourceType;
-            Container = credentialDescription.Container;
-            Certificate = credentialDescription.Certificate;
-            ReferenceOrValue = credentialDescription.ReferenceOrValue;
         }
 
         /// <summary>
@@ -160,26 +158,6 @@ namespace Microsoft.Identity.Web
 
         // Should Container and ReferenceOrValue be moved to
         // the tests (As extension methods)
-
-        #region Backwards compatibilty with 1.x
-        /// <summary>
-        /// <inheritdoc/>.
-        /// </summary>
-        internal new string? Container
-        {
-            get { return base.Container; }
-            set { base.Container = value; }
-        }
-
-        /// <summary>
-        /// <inheritdoc/>.
-        /// </summary>
-        internal new string? ReferenceOrValue
-        {
-            get { return base.ReferenceOrValue; }
-            set { base.ReferenceOrValue = value; }
-        }
-
         /// <summary>
         /// <inheritdoc/>.
         /// </summary>
@@ -197,6 +175,5 @@ namespace Microsoft.Identity.Web
             get { return (CertificateSource)base.SourceType; }
             set { base.SourceType = (CredentialSource)value; }
         }
-        #endregion
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
         {
             CertificateDescription certificateDescription = CertificateDescription.FromKeyVault(keyVaultUrl, certificateName);
             Assert.Equal(CertificateSource.KeyVault, certificateDescription.SourceType);
-            Assert.Equal(keyVaultUrl, certificateDescription.Container);
-            Assert.Equal(certificateName, certificateDescription.ReferenceOrValue);
+            Assert.Equal(keyVaultUrl, certificateDescription.KeyVaultUrl);
             Assert.Equal(certificateName, certificateDescription.KeyVaultCertificateName);
             Assert.Equal(keyVaultUrl, certificateDescription.KeyVaultUrl);
 #if NET462
@@ -33,11 +32,9 @@ namespace Microsoft.Identity.Web.Test.Certificates
         {
             CertificateDescription certificateDescription = CertificateDescription.FromPath(certificatePath, password);
             Assert.Equal(CertificateSource.Path, certificateDescription.SourceType);
-            Assert.Equal(certificatePath, certificateDescription.Container);
-            Assert.Equal(password, certificateDescription.ReferenceOrValue);
             Assert.Equal(certificatePath, certificateDescription.CertificateDiskPath);
             Assert.Equal(password, certificateDescription.CertificatePassword);
-        }
+         }
 
         [Theory]
         [InlineData("440A5BE6C4BE2FF02A0ADBED1AAA43D6CF12E269")]
@@ -45,7 +42,6 @@ namespace Microsoft.Identity.Web.Test.Certificates
         {
             CertificateDescription certificateDescription = CertificateDescription.FromBase64Encoded(base64Encoded);
             Assert.Equal(CertificateSource.Base64Encoded, certificateDescription.SourceType);
-            Assert.Equal(base64Encoded, certificateDescription.ReferenceOrValue);
             Assert.Equal(base64Encoded, certificateDescription.Base64EncodedValue);
         }
 
@@ -56,8 +52,6 @@ namespace Microsoft.Identity.Web.Test.Certificates
             CertificateDescription certificateDescription =
                 CertificateDescription.FromStoreWithDistinguishedName(certificateDistinguishedName, storeLocation, storeName);
             Assert.Equal(CertificateSource.StoreWithDistinguishedName, certificateDescription.SourceType);
-            Assert.Equal($"{storeLocation}/{storeName}", certificateDescription.Container);
-            Assert.Equal(certificateDistinguishedName, certificateDescription.ReferenceOrValue);
             Assert.Equal(certificateDistinguishedName, certificateDescription.CertificateDistinguishedName);
             Assert.Equal($"{storeLocation}/{storeName}", certificateDescription.CertificateStorePath);
         }
@@ -69,8 +63,6 @@ namespace Microsoft.Identity.Web.Test.Certificates
             CertificateDescription certificateDescription =
                 CertificateDescription.FromStoreWithThumbprint(certificateThumbprint, storeLocation, storeName);
             Assert.Equal(CertificateSource.StoreWithThumbprint, certificateDescription.SourceType);
-            Assert.Equal($"{storeLocation}/{storeName}", certificateDescription.Container);
-            Assert.Equal(certificateThumbprint, certificateDescription.ReferenceOrValue);
             Assert.Equal($"{storeLocation}/{storeName}", certificateDescription.CertificateStorePath);
             Assert.Equal(certificateThumbprint, certificateDescription.CertificateThumbprint);
         }

--- a/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/CertificateDescriptionTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
             Assert.Equal(CertificateSource.Path, certificateDescription.SourceType);
             Assert.Equal(certificatePath, certificateDescription.CertificateDiskPath);
             Assert.Equal(password, certificateDescription.CertificatePassword);
-         }
+        }
 
         [Theory]
         [InlineData("440A5BE6C4BE2FF02A0ADBED1AAA43D6CF12E269")]

--- a/tests/Microsoft.Identity.Web.Test/Certificates/DefaultCertificateLoaderTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/DefaultCertificateLoaderTests.cs
@@ -55,47 +55,22 @@ namespace Microsoft.Identity.Web.Test.Certificates
             Assert.NotNull(certificateDescription.Certificate);
         }
 
-#pragma warning disable xUnit1012 // Null should only be used for nullable parameters
-        [InlineData(CertificateSource.Base64Encoded, null, TestConstants.CertificateX5c)]
-#pragma warning restore xUnit1012 // Null should only be used for nullable parameters
-        [Theory]
-        public void TestLoadFirstCertificate(
-            CertificateSource certificateSource,
-            string container,
-            string referenceOrValue)
+        [Fact]
+        public void TestLoadFirstCertificate()
         {
-            IEnumerable<CertificateDescription> certDescriptions = CreateCertificateDescriptions(
-                certificateSource,
-                container,
-                referenceOrValue);
-
+            IEnumerable<CertificateDescription> certDescriptions = [CertificateDescription.FromBase64Encoded(TestConstants.CertificateX5c)];
             X509Certificate2? certificate = DefaultCertificateLoader.LoadFirstCertificate(certDescriptions);
 
             Assert.NotNull(certificate);
             Assert.Equal("CN=ACS2ClientCertificate", certificate.Issuer);
         }
 
-#pragma warning disable xUnit1012 // Null should only be used for nullable parameters
-        [InlineData(CertificateSource.Base64Encoded, null, TestConstants.CertificateX5c)]
-#pragma warning restore xUnit1012 // Null should only be used for nullable parameters
-        [Theory]
-        public void TestLoadAllCertificates(
-           CertificateSource certificateSource,
-           string container,
-           string referenceOrValue)
+        [Fact]
+        public void TestLoadAllCertificates()
         {
-            List<CertificateDescription> certDescriptions = CreateCertificateDescriptions(
-                certificateSource,
-                container,
-                referenceOrValue).ToList();
+            List<CertificateDescription> certDescriptions = [CertificateDescription.FromBase64Encoded(TestConstants.CertificateX5c)];
 
-            certDescriptions.Add(new CertificateDescription
-            {
-                SourceType = certificateSource,
-                Container = container,
-                ReferenceOrValue = referenceOrValue,
-            });
-
+            certDescriptions.Add(CertificateDescription.FromBase64Encoded(TestConstants.CertificateX5c));
             certDescriptions.Add(CertificateDescription.FromCertificate(null!));
 
             IEnumerable<X509Certificate2?> certificates = DefaultCertificateLoader.LoadAllCertificates(certDescriptions);
@@ -134,23 +109,6 @@ namespace Microsoft.Identity.Web.Test.Certificates
 
             Assert.NotNull(certificateDescription.Certificate);
             Assert.True(certificateDescription.Certificate.HasPrivateKey);
-        }
-
-        private IEnumerable<CertificateDescription> CreateCertificateDescriptions(
-            CertificateSource certificateSource,
-            string container,
-            string referenceOrValue)
-        {
-            List<CertificateDescription> certificateDescription = new List<CertificateDescription>();
-
-            certificateDescription.Add(new CertificateDescription
-            {
-                SourceType = certificateSource,
-                Container = container,
-                ReferenceOrValue = referenceOrValue,
-            });
-
-            return certificateDescription;
         }
     }
 }


### PR DESCRIPTION
# Fixing 3212 and cleaning-up technical debt

## Description

- Adopts Abstractions 8.0, which removes the public properties Container and ValueOrReference on CredentialDescriptions, that were for compatibility with IdWeb 1.x
- Clean-up the tests that were using these properties instead of using the right properties. Some of these were using theories for one case

Fixes #3212 
