### PR TITLE
Pass the assertion options to MSAL for ROPC call

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -335,8 +335,9 @@ namespace Microsoft.Identity.Web
             {
                 string username = user.FindFirst(ClaimConstants.Username)?.Value ?? string.Empty;
                 string password = user.FindFirst(ClaimConstants.Password)?.Value ?? string.Empty;
+                bool forceRefresh = tokenAcquisitionOptions?.ForceRefresh ?? false;
 
-                if (user.GetMsalAccountId() != null)
+                if (!forceRefresh && user.GetMsalAccountId() != null)
                 {
                     try
                     {
@@ -370,6 +371,29 @@ namespace Microsoft.Identity.Web
                 if (addInOptions != null)
                 {
                     addInOptions.InvokeOnBeforeTokenAcquisitionForTestUser(builder, tokenAcquisitionOptions, user);
+                }
+
+                // Pass the token acquisition options to the builder
+                if (tokenAcquisitionOptions != null)
+                {
+                    var dict = MergeExtraQueryParameters(mergedOptions, tokenAcquisitionOptions);
+                    if (dict != null)
+                    {
+                        builder.WithExtraQueryParameters(dict);
+                    }
+                    if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
+                    {
+                        builder.WithExtraHttpHeaders(tokenAcquisitionOptions.ExtraHeadersParameters);
+                    }
+                    if (tokenAcquisitionOptions.CorrelationId != null)
+                    {
+                        builder.WithCorrelationId(tokenAcquisitionOptions.CorrelationId.Value);
+                    }
+                    builder.WithClaims(tokenAcquisitionOptions.Claims);
+                    if (tokenAcquisitionOptions.PoPConfiguration != null)
+                    {
+                        builder.WithSignedHttpRequestProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);
+                    }
                 }
 
                 var authenticationResult = await builder.ExecuteAsync()

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -123,6 +123,37 @@ namespace TokenAcquirerTests
         }
 
         [Fact]
+        public async Task AcquireToken_ROPC_CCA_WithForceRefresh_async()
+        {
+            var tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
+            _ = tokenAcquirerFactory.Build();
+
+            var labResponse = await LabUserHelper.GetDefaultUserAsync();
+
+            ITokenAcquirer tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer(
+               authority: "https://login.microsoftonline.com/organizations",
+               clientId: "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+               clientCredentials: s_clientCredentials);
+
+            var user = ClaimsPrincipalFactory.FromUsernamePassword(labResponse.User.Upn, labResponse.User.GetOrFetchPassword());
+
+            var result = await tokenAcquirer.GetTokenForUserAsync(
+                scopes: new[] { "https://graph.microsoft.com/.default" }, user: user);
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.AccessToken);
+
+            AcquireTokenOptions options = new AcquireTokenOptions { ForceRefresh = true };
+
+            var result2 = await tokenAcquirer.GetTokenForUserAsync(tokenAcquisitionOptions: options,
+                scopes: new[] { "https://graph.microsoft.com/.default" }, user: user);
+
+            Assert.NotNull(result2);
+            Assert.NotNull(result2.AccessToken);
+            Assert.NotEqual(result.AccessToken, result2.AccessToken);
+        }
+
+        [Fact]
         public void AcquireToken_SafeFromMultipleThreads()
         {
             var tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAddInTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAddInTests.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Identity.Web.Tests
             // Arrange
             var options = new TokenAcquisitionExtensionOptions();
             var acquireTokenOptions = new AcquireTokenOptions();
-            acquireTokenOptions.ForceRefresh = true;
 
             //Configure mocks
             using MockHttpClientFactory mockHttpClient = new();


### PR DESCRIPTION
#3207 
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Pass the assertion/ merged options to MSAL for the ROPC flow and make sure if forceRefresh is set the silent flow is skipped

## Description

- Update the TokenAcquisition.cs to pass the ExtraQueryParams, ExtraHttpHeaders etc to MSAL from the mergedOptions and tokenAcquisitionOptions.
- Skip the silent call in case forceRefresh is set to true

Fixes #3207  (in this specific format)
