### PR TITLE
Lozensky/add fmi path

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -86,10 +86,8 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Common dependency versions">
-
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.5.0</MicrosoftIdentityModelVersion>
     <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.68.0</MicrosoftIdentityClientVersion>
-
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,7 +87,7 @@
 
   <PropertyGroup Label="Common dependency versions">
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.4.0</MicrosoftIdentityModelVersion>
-    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.67.2</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.68.0</MicrosoftIdentityClientVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>
@@ -96,7 +96,7 @@
     <MicrosoftGraphVersion>4.36.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
     <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
-    <MicrosoftIdentityAbstractionsVersion>8.1.1</MicrosoftIdentityAbstractionsVersion>
+    <MicrosoftIdentityAbstractionsVersion>8.2.0</MicrosoftIdentityAbstractionsVersion>
     <!--CVE-2024-43485-->
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
     <!--CVE-2023-29331-->

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -553,6 +553,10 @@ namespace Microsoft.Identity.Web
                     builder.WithCorrelationId(tokenAcquisitionOptions.CorrelationId.Value);
                 }
                 builder.WithForceRefresh(tokenAcquisitionOptions.ForceRefresh);
+                if (!string.IsNullOrEmpty(tokenAcquisitionOptions.FmiPath))
+                {
+                    builder.WithFmiPath(tokenAcquisitionOptions.FmiPath);
+                }
                 builder.WithClaims(tokenAcquisitionOptions.Claims);
                 if (tokenAcquisitionOptions.PoPConfiguration != null)
                 {

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -553,11 +553,11 @@ namespace Microsoft.Identity.Web
                     builder.WithCorrelationId(tokenAcquisitionOptions.CorrelationId.Value);
                 }
                 builder.WithForceRefresh(tokenAcquisitionOptions.ForceRefresh);
+                builder.WithClaims(tokenAcquisitionOptions.Claims);
                 if (!string.IsNullOrEmpty(tokenAcquisitionOptions.FmiPath))
                 {
                     builder.WithFmiPath(tokenAcquisitionOptions.FmiPath);
                 }
-                builder.WithClaims(tokenAcquisitionOptions.Claims);
                 if (tokenAcquisitionOptions.PoPConfiguration != null)
                 {
                     builder.WithSignedHttpRequestProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);


### PR DESCRIPTION
For testing, will be working with Bogdan/Travis on E2E testing as this isn't really approachable via unit tests.

Since MSAL made `AcquireTokenForClient.WithFmiPath()` available, in the one place we use the AcquireTokenForClient method, adding a check for and insertion of the FMI Path so Id Web customers can make use of this new functionality. Addresses issue #3240 