### PR TITLE
Lozensky/perf fix graph service client

### DIFF
--- a/src/Microsoft.Identity.Web.GraphServiceClient/GraphAuthenticationProvider.cs
+++ b/src/Microsoft.Identity.Web.GraphServiceClient/GraphAuthenticationProvider.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Identity.Web
         private const string AuthorizationHeaderKey = "Authorization";
         readonly IAuthorizationHeaderProvider _authorizationHeaderProvider;
         readonly GraphServiceClientOptions _defaultAuthenticationOptions;
+        private static readonly AllowedHostsValidator _allowedGraphHostsValidator = new(["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn", "canary.graph.microsoft.com", "graph.microsoft-ppe.com"]);
         private readonly string[] _graphUris = ["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn", "canary.graph.microsoft.com", "graph.microsoft-ppe.com"];
         readonly IEnumerable<string> _defaultGraphScope = ["https://graph.microsoft.com/.default"];
 
@@ -83,9 +84,8 @@ namespace Microsoft.Identity.Web
                 authorizationHeaderProviderOptions = graphServiceClientOptions;
             }
 
-            AllowedHostsValidator allowedHostsValidator = new(_graphUris);
             // Add the authorization header
-            if (allowedHostsValidator.IsUrlHostValid(request.URI) && !request.Headers.ContainsKey(AuthorizationHeaderKey))
+            if (_allowedGraphHostsValidator.IsUrlHostValid(request.URI) && !request.Headers.ContainsKey(AuthorizationHeaderKey))
             {
                 string authorizationHeader = await _authorizationHeaderProvider.CreateAuthorizationHeaderAsync(
                         authorizationHeaderProviderOptions!.RequestAppToken ? _defaultGraphScope : scopes!,

--- a/src/Microsoft.Identity.Web.GraphServiceClient/GraphAuthenticationProvider.cs
+++ b/src/Microsoft.Identity.Web.GraphServiceClient/GraphAuthenticationProvider.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Identity.Web
         readonly IAuthorizationHeaderProvider _authorizationHeaderProvider;
         readonly GraphServiceClientOptions _defaultAuthenticationOptions;
         private static readonly AllowedHostsValidator _allowedGraphHostsValidator = new(["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn", "canary.graph.microsoft.com", "graph.microsoft-ppe.com"]);
-        private readonly string[] _graphUris = ["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn", "canary.graph.microsoft.com", "graph.microsoft-ppe.com"];
         readonly IEnumerable<string> _defaultGraphScope = ["https://graph.microsoft.com/.default"];
 
         /// <summary>

--- a/tests/E2E Tests/GraphServiceClientTests/GraphServiceClientTests.cs
+++ b/tests/E2E Tests/GraphServiceClientTests/GraphServiceClientTests.cs
@@ -66,25 +66,24 @@ namespace Microsoft.Identity.Web.Test.Integration
                     o.RequestAppToken = true;
                 });
             });
-
         }
 
         [Fact]
         public async Task AuthenticateRequestAsync_NonGraphUri_DoesNotSetAuthZHeaderAsync()
         {
-            // arrange
-            RequestInformation request = new()
-            {
-                URI = new Uri("http://www.contoso.com/")
-            };
+                // arrange
+                RequestInformation request = new()
+                {
+                    URI = new Uri("http://www.contoso.com/")
+                };
 
-            GraphAuthenticationProvider graphAuthenticationProvider = new(_authorizationHeaderProvider, new GraphServiceClientOptions());
+                GraphAuthenticationProvider graphAuthenticationProvider = new(_authorizationHeaderProvider, new GraphServiceClientOptions());
 
-            // act
-            await graphAuthenticationProvider.AuthenticateRequestAsync(request);
+                // act
+                await graphAuthenticationProvider.AuthenticateRequestAsync(request);
 
-            // assert
-            Assert.False(request.Headers.ContainsKey("Authorization"));
+                // assert
+                Assert.False(request.Headers.ContainsKey("Authorization"));
         }
     }
 }

--- a/tests/E2E Tests/GraphServiceClientTests/GraphServiceClientTests.cs
+++ b/tests/E2E Tests/GraphServiceClientTests/GraphServiceClientTests.cs
@@ -71,19 +71,19 @@ namespace Microsoft.Identity.Web.Test.Integration
         [Fact]
         public async Task AuthenticateRequestAsync_NonGraphUri_DoesNotSetAuthZHeaderAsync()
         {
-                // arrange
-                RequestInformation request = new()
-                {
-                    URI = new Uri("http://www.contoso.com/")
-                };
+            // arrange
+            RequestInformation request = new()
+            {
+                URI = new Uri("http://www.contoso.com/")
+            };
 
-                GraphAuthenticationProvider graphAuthenticationProvider = new(_authorizationHeaderProvider, new GraphServiceClientOptions());
+            GraphAuthenticationProvider graphAuthenticationProvider = new(_authorizationHeaderProvider, new GraphServiceClientOptions());
 
-                // act
-                await graphAuthenticationProvider.AuthenticateRequestAsync(request);
+            // act
+            await graphAuthenticationProvider.AuthenticateRequestAsync(request);
 
-                // assert
-                Assert.False(request.Headers.ContainsKey("Authorization"));
+            // assert
+            Assert.False(request.Headers.ContainsKey("Authorization"));
         }
     }
 }


### PR DESCRIPTION
Essentially just moving an instantiation of the `AllowedHostsValidator` to a static member to avoid creating a new instance every time the method is called.