### PR TITLE
Remove step for installing wasm-tools in the build

### DIFF
--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -6,6 +6,7 @@ parameters:
   BuildConfiguration: 'debug'
   MicrosoftIdentityWebVersion: '1.0.0-devopsbuild'
 
+steps:
 - powershell: |
     Push-Location $(IdWebSourceDir)
     $nugetSourceIsExternal = (dotnet nuget list source --format Short).Contains("https://api.nuget.org/v3/index.json")

--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -6,11 +6,6 @@ parameters:
   BuildConfiguration: 'debug'
   MicrosoftIdentityWebVersion: '1.0.0-devopsbuild'
 
-steps:
-- script: |
-    dotnet workload restore $(IdWebSourceDir)tests\DevApps\blazorwasm-b2c\blazorwasm2-b2c.csproj
-  displayName: 'Install wasm-tools'
-
 - powershell: |
     Push-Location $(IdWebSourceDir)
     $nugetSourceIsExternal = (dotnet nuget list source --format Short).Contains("https://api.nuget.org/v3/index.json")


### PR DESCRIPTION
# {Remove step for installing wasm-tools in the build}
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request includes a change to the `build/template-restore-build-MSIdentityWeb.yaml` file. The most important change involves removing a script step that was used to install wasm-tools.

* Removed script step for installing wasm-tools in `build/template-restore-build-MSIdentityWeb.yaml`.

Fixes https://github.com/AzureAD/microsoft-identity-web/issues/3260 
