### PR TITLE
Fix authority parsing logic

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -442,9 +442,10 @@ namespace Microsoft.Identity.Web
         {
             if (string.IsNullOrEmpty(mergedOptions.TenantId) && string.IsNullOrEmpty(mergedOptions.Instance) && !string.IsNullOrEmpty(mergedOptions.Authority))
             {
-                ReadOnlySpan<char> httpsPrefix = "https://".AsSpan();
+                ReadOnlySpan<char> doubleSlash = "//".AsSpan();
                 ReadOnlySpan<char> authoritySpan = mergedOptions.Authority.AsSpan().TrimEnd('/');
-                int startingIndex = authoritySpan.StartsWith(httpsPrefix) ? httpsPrefix.Length : 0;
+                int doubleSlashIndex = authoritySpan.IndexOf(doubleSlash);
+                int startingIndex = doubleSlashIndex == -1 ? 0 : doubleSlashIndex + doubleSlash.Length;
 
                 // Gets position of first '/' after the "https://" prefix, will return -1 if not found, this checks for presence of instance/tenantId
                 int indexTenant = authoritySpan.Slice(startingIndex).IndexOf('/') + startingIndex;

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -442,11 +442,13 @@ namespace Microsoft.Identity.Web
         {
             if (string.IsNullOrEmpty(mergedOptions.TenantId) && string.IsNullOrEmpty(mergedOptions.Instance) && !string.IsNullOrEmpty(mergedOptions.Authority))
             {
-                const int StartingIndex = 8; // length of "https://"
+                ReadOnlySpan<char> httpsPrefix = "https://".AsSpan();
                 ReadOnlySpan<char> authoritySpan = mergedOptions.Authority.AsSpan().TrimEnd('/');
+                int startingIndex = authoritySpan.StartsWith(httpsPrefix) ? httpsPrefix.Length : 0;
 
-                int indexTenant = authoritySpan.Slice(StartingIndex).IndexOf('/') + StartingIndex;
-                if (indexTenant >= 0)
+                // Gets position of first '/' after the "https://" prefix, will return -1 if not found, this checks for presence of instance/tenantId
+                int indexTenant = authoritySpan.Slice(startingIndex).IndexOf('/') + startingIndex;
+                if (indexTenant >= startingIndex)
                 {
                     int indexVersion = authoritySpan.Slice(indexTenant + 1).IndexOf('/');
                     int indexEndOfTenant = indexVersion == -1 ? authoritySpan.Length : indexVersion + indexTenant + 1;

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -320,6 +320,45 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
+        public void TestParseAuthorityIfNecessary_NoUriScheme()
+        {
+            var tenantId = TC.TenantIdAsGuid.ToString();
+            var instance = "myauthorityisbetter.fyi";
+            var authority = $"{instance}/{tenantId}/v2.0";
+
+            MergedOptions mergedOptions = new()
+            {
+                Authority = authority,
+                PreserveAuthority = false
+            };
+
+            MergedOptions.ParseAuthorityIfNecessary(mergedOptions);
+
+            Assert.Equal(authority, mergedOptions.Authority);
+            Assert.Equal(tenantId, mergedOptions.TenantId);
+            Assert.Equal(instance, mergedOptions.Instance);
+        }
+
+        [Fact]
+        public void TestParseAuthorityIfNecessary_NoTenantId()
+        {
+            var instance = "myauthorityisbetter.fyi";
+            var authority = $"https://{instance}";
+
+            MergedOptions mergedOptions = new()
+            {
+                Authority = authority,
+                PreserveAuthority = false
+            };
+
+            MergedOptions.ParseAuthorityIfNecessary(mergedOptions);
+
+            Assert.Equal(authority, mergedOptions.Authority);
+            Assert.Null(mergedOptions.TenantId);
+            Assert.Null(mergedOptions.Instance);
+        }
+
+        [Fact]
         public void MergeExtraQueryParametersTest()
         {
             // Arrange


### PR DESCRIPTION
This pull request changes logic in the `ParseAuthorityIfNecessary` method in the `MergedOptions` class to fix a bug where the check on the `indexTenant` always evaluates to true.

Originally, there had been a bug here because the '/' chars in the scheme prefix of the URI were not taken into account leading to false positives when checking for the presence of the instance/tenantId

[This PR](https://github.com/AzureAD/microsoft-identity-web/commit/0fdfc96216cb6828f462b85bca21842fc9664915) went into Id Web in 3.1.0 and attempted to address the above bug but accidentally created another where the `indexTenant` >=0 condition always evaluated to true as its min possible value was 7.

The current PR fixes this by making the starting index of the authority URI scheme-agnostic and uses that dynamic value to compare against the `indexTenant` variable.