### PR TITLE
Fix for Remove NuGet Source steps (now with enhanced logging)

### DIFF
--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -9,12 +9,39 @@ parameters:
 steps:
 - powershell: |
     Push-Location $(IdWebSourceDir)
-    $nugetSourceIsExternal = (dotnet nuget list source --format Short).Contains("https://api.nuget.org/v3/index.json")
+
+    Write-Host "🟢 Listing existing NuGet sources..."
+    dotnet nuget list source
+
+    Write-Host "🟢 Checking if the external NuGet source exists..."
+    $nugetSources = dotnet nuget list source --format Short
+    $nugetSourceIsExternal = $nugetSources -match "https://api.nuget.org/v3/index.json"
+
     if ($nugetSourceIsExternal) {
-        dotnet nuget remove source NuGet
-        dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
-        dotnet nuget list source
+        Write-Host "🟢 Removing external NuGet source..."
+        dotnet nuget remove source NuGet --configfile $(IdWebSourceDir)\nuget.config
+        if ($?) { 
+            Write-Host "✅ Successfully removed external NuGet source." 
+        } else { 
+            Write-Host "❌ Failed to remove external NuGet source." 
+            exit 1
+        }
+    } else {
+        Write-Host "⚠️ External NuGet source not found. Skipping removal."
     }
+
+    Write-Host "🟢 Adding IDDP NuGet source..."
+    dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP --configfile $(IdWebSourceDir)\nuget.config
+    if ($?) { 
+        Write-Host "✅ Successfully added IDDP NuGet source." 
+    } else { 
+        Write-Host "❌ Failed to add IDDP NuGet source." 
+        exit 1
+    }
+
+    Write-Host "🟢 Final NuGet sources list:"
+    dotnet nuget list source --configfile $(IdWebSourceDir)\nuget.config
+
     Pop-Location
   displayName: 'Remove external "NuGet" Source and add "IDDP artifacts" as a NuGet Source, if needed.'
 

--- a/build/template-restore-build-MSIdentityWeb.yaml
+++ b/build/template-restore-build-MSIdentityWeb.yaml
@@ -10,37 +10,56 @@ steps:
 - powershell: |
     Push-Location $(IdWebSourceDir)
 
-    Write-Host "🟢 Listing existing NuGet sources..."
+    # Check if nuget.config exists
+    $nugetConfigPath = "$(IdWebSourceDir)\nuget.config"
+    if (Test-Path $nugetConfigPath) {
+        Write-Host "Found nuget.config at $nugetConfigPath"
+    } else {
+        Write-Host "Warning: nuget.config file not found at expected path."
+        $nugetConfigPath = ""  # Use default global config
+    }
+
+    Write-Host "Listing existing NuGet sources..."
     dotnet nuget list source
 
-    Write-Host "🟢 Checking if the external NuGet source exists..."
+    Write-Host "Checking if the external NuGet source exists..."
     $nugetSources = dotnet nuget list source --format Short
     $nugetSourceIsExternal = $nugetSources -match "https://api.nuget.org/v3/index.json"
 
     if ($nugetSourceIsExternal) {
-        Write-Host "🟢 Removing external NuGet source..."
-        dotnet nuget remove source NuGet --configfile $(IdWebSourceDir)\nuget.config
+        Write-Host "Removing external NuGet source..."
+        if ($nugetConfigPath -ne "") {
+            dotnet nuget remove source NuGet --configfile $nugetConfigPath
+        } else {
+            dotnet nuget remove source NuGet
+        }
+
         if ($?) { 
-            Write-Host "✅ Successfully removed external NuGet source." 
+            Write-Host "Successfully removed external NuGet source." 
         } else { 
-            Write-Host "❌ Failed to remove external NuGet source." 
+            Write-Host "Failed to remove external NuGet source." 
             exit 1
         }
     } else {
-        Write-Host "⚠️ External NuGet source not found. Skipping removal."
+        Write-Host "External NuGet source not found. Skipping removal."
     }
 
-    Write-Host "🟢 Adding IDDP NuGet source..."
-    dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP --configfile $(IdWebSourceDir)\nuget.config
+    Write-Host "Adding IDDP NuGet source..."
+    if ($nugetConfigPath -ne "") {
+        dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP --configfile $nugetConfigPath
+    } else {
+        dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
+    }
+
     if ($?) { 
-        Write-Host "✅ Successfully added IDDP NuGet source." 
+        Write-Host "Successfully added IDDP NuGet source." 
     } else { 
-        Write-Host "❌ Failed to add IDDP NuGet source." 
+        Write-Host "Failed to add IDDP NuGet source." 
         exit 1
     }
 
-    Write-Host "🟢 Final NuGet sources list:"
-    dotnet nuget list source --configfile $(IdWebSourceDir)\nuget.config
+    Write-Host "Final NuGet sources list:"
+    dotnet nuget list source
 
     Pop-Location
   displayName: 'Remove external "NuGet" Source and add "IDDP artifacts" as a NuGet Source, if needed.'


### PR DESCRIPTION
# Fix for Remove NuGet Source steps (now with enhanced logging)

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

**Fix -** 
- The updated script checked if nuget.config exists before using it.
- If it was missing, it used the global NuGet config instead.

This pull request includes changes to the `build/template-restore-build-MSIdentityWeb.yaml` file to improve the handling of NuGet sources in the build process. The key changes focus on adding checks for the existence of a `nuget.config` file, enhancing logging, and ensuring robust handling of NuGet source addition and removal.

Improvements to NuGet source handling:

* Added a check for the existence of `nuget.config` and appropriate logging messages to inform whether the file was found or not.
* Enhanced logging to list existing NuGet sources before making any changes, and to confirm the successful addition or removal of NuGet sources.
* Implemented conditional logic to use `nuget.config` if it exists for adding and removing NuGet sources, ensuring the correct configuration file is used.
* Added error handling to exit the script if the removal or addition of a NuGet source fails, ensuring the build process does not proceed with incorrect configurations.


Fixes #3264
