### PR TITLE
Fix CS8602 Warnings in Weather.razor (BlazorApp) – Handle Nullable forecasts and user.Identity

### DIFF
--- a/tests/DevApps/blazor/BlazorApp/Components/Pages/Weather.razor
+++ b/tests/DevApps/blazor/BlazorApp/Components/Pages/Weather.razor
@@ -39,7 +39,7 @@
 }
 else
 {
-    <p>Signed in user is @user.Identity.Name</p>
+    <p>Signed in user is @user?.Identity?.Name</p>
     <table class="table">
         <thead>
             <tr>
@@ -64,7 +64,7 @@ else
 }
 
 @code {
-    private WeatherForecast[]? forecasts;
+    private WeatherForecast[] forecasts = Array.Empty<WeatherForecast>();
     private ClaimsPrincipal? user;
 
     protected override async Task OnInitializedAsync()


### PR DESCRIPTION
# Fix CS8602 Warnings in Weather.razor (BlazorApp) – Handle Nullable forecasts and user.Identity

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description
This pull request includes changes to the `Weather.razor` component in the Blazor application to handle potential null values and initialize arrays properly.

Improvements and code safety enhancements:

* [`tests/DevApps/blazor/BlazorApp/Components/Pages/Weather.razor`](diffhunk://#diff-58ceb5c06c54f7e79b6bb515ae433344bc88de5721583b0e11cf787ca36cd0d5L42-R42): Modified the user identity display to use null-conditional operators to prevent potential null reference exceptions.
* [`tests/DevApps/blazor/BlazorApp/Components/Pages/Weather.razor`](diffhunk://#diff-58ceb5c06c54f7e79b6bb515ae433344bc88de5721583b0e11cf787ca36cd0d5L67-R67): Initialized the `forecasts` array to an empty array using `Array.Empty<WeatherForecast>()` to avoid null-related issues.

Fixes [#3265](https://github.com/AzureAD/microsoft-identity-web)
