### PR TITLE
Update benchmark-action.yml to use net 9

### DIFF
--- a/.github/workflows/benchmark-action.yml
+++ b/.github/workflows/benchmark-action.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           dotnet-version: '9.x'
       - name: Run benchmark
-        run: cd benchmark && dotnet run -c release -f net8.0 --filter 'Benchmarks.TokenAcquisitionBenchmark.*' --exporters json 
+        run: cd benchmark && dotnet run -c release -f net9.0 --filter 'Benchmarks.TokenAcquisitionBenchmark.*' --exporters json 
 
       - name: Download previous benchmark data
         uses: actions/cache@v4

--- a/.github/workflows/benchmark-action.yml
+++ b/.github/workflows/benchmark-action.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
       - name: Run benchmark
         run: cd benchmark && dotnet run -c release -f net8.0 --filter 'Benchmarks.TokenAcquisitionBenchmark.*' --exporters json 
 

--- a/benchmark/Directory.Build.props
+++ b/benchmark/Directory.Build.props
@@ -2,12 +2,11 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <EnablePackageValidation>false</EnablePackageValidation>
-    <SignAssembly>True</SignAssembly>
-    <DelaySign>True</DelaySign>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\build\msal.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>False</SignAssembly>
+    <DelaySign>False</DelaySign>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
# Update benchmark-action.yml to use net 9

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description
This pull request includes updates to the .NET version used in the benchmarking process and changes to the build properties for the benchmark project. The most important changes are as follows:

### .NET Version Update:

* Updated the .NET version from 8.x to 9.x in the GitHub Actions workflow file `.github/workflows/benchmark-action.yml` to ensure the benchmarks run with the latest version.

### Build Properties Update:

* Changed the target framework from `net8.0` to `net9.0` in `benchmark/Directory.Build.props` to align with the updated .NET version.
* Modified the signing properties in `benchmark/Directory.Build.props` to disable assembly signing by setting `SignAssembly` and `DelaySign` to `False`.

Fixes #3270
