### PR TITLE
Add Support for Custom Saml Bearer in HttpRequest Headers

### DIFF
--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -522,7 +522,7 @@ namespace Microsoft.Identity.Web
                        user,
                        cancellationToken).ConfigureAwait(false);
 
-                httpRequestMessage.Headers.Add(Authorization, authorizationHeader);
+                httpRequestMessage.Headers.TryAddWithoutValidation(Authorization, authorizationHeader);
             }
             else
             {

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -522,6 +522,7 @@ namespace Microsoft.Identity.Web
                        user,
                        cancellationToken).ConfigureAwait(false);
 
+                // The TryAddWithoutValidation method is used to bypass the strict checks on format of Authorization header
                 httpRequestMessage.Headers.TryAddWithoutValidation(Authorization, authorizationHeader);
             }
             else

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Identity.Web
         private readonly IOptionsMonitor<DownstreamApiOptions> _namedDownstreamApiOptions;
         private const string Authorization = "Authorization";
         protected readonly ILogger<DownstreamApi> _logger;
+        private const string AuthSchemeDstsSamlBearer = "http://schemas.microsoft.com/dsts/saml2-bearer";
 
         /// <summary>
         /// Constructor.
@@ -522,8 +523,15 @@ namespace Microsoft.Identity.Web
                        user,
                        cancellationToken).ConfigureAwait(false);
 
-                // The TryAddWithoutValidation method is used to bypass the strict checks on format of Authorization header
-                httpRequestMessage.Headers.TryAddWithoutValidation(Authorization, authorizationHeader);
+                if (authorizationHeader.StartsWith(AuthSchemeDstsSamlBearer, StringComparison.OrdinalIgnoreCase))
+                {
+                    // TryAddWithoutValidation method bypasses strict validation, allowing non-standard headers to be added for custom Header schemes that cannot be parsed.
+                    httpRequestMessage.Headers.TryAddWithoutValidation(Authorization, authorizationHeader);
+                }
+                else
+                {
+                    httpRequestMessage.Headers.Add(Authorization, authorizationHeader);
+                }
             }
             else
             {


### PR DESCRIPTION
# Add Support for Saml Authorization Scheme in HttpRequest Headers
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This PR introduces a change to the way authorization headers are added to HTTP requests, specifically to support SAML tokens. The change ensures that custom SAML authorization schemes are correctly added using TryAddWithoutValidation. This approach allows for more flexible handling of SAML tokens, even when they might not pass standard validation.

Changes:

Replaced the below line to improve compatibility with custom SAML authorization schemes.
```csharp 
httpRequestMessage.Headers.Add(Authorization, authorizationHeader);
``` 
with 
```csharp
httpRequestMessage.Headers.TryAddWithoutValidation(Authorization, authorizationHeader);
```
 
Added unit tests to validate the new behavior and ensure headers are correctly added in various scenarios.

Fixes #3269 
