### PR TITLE
Locking Down the TokenAcquirerFactory

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -42,14 +42,14 @@ jobs:
     - name: Build solution
       run: msbuild Microsoft.Identity.Web.sln -r -t:build -verbosity:m -property:Configuration=Release
 
-    - name: Test with .NET 6.0.x
-      run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net6.0 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
-
     - name: Test with .NET 8.0.x
       run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net8.0 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --collect "Xplat Code Coverage" --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
 
     - name: Test with .NET 9.0.x
       run: dotnet test --no-restore --no-build Microsoft.Identity.Web.sln -f net9.0 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --collect "Xplat Code Coverage" --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
+
+    - name: Test with .NET 6.0.x
+      run: dotnet test Microsoft.Identity.Web.sln -f net6.0 -v normal -p:FROM_GITHUB_ACTION=true --configuration Release --filter "(FullyQualifiedName!~Microsoft.Identity.Web.Test.Integration)&(FullyQualifiedName!~WebAppUiTests)&(FullyQualifiedName!~IntegrationTests)&(FullyQualifiedName!~TokenAcquirerTests)"
 
     - name: Create code coverage report
       run: |

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
@@ -110,7 +110,6 @@ namespace Microsoft.Identity.Web
             return (defaultInstance as T)!;
         }
 
-
         /// <summary>
         /// Get the default instance. Use this method to retrieve the instance, optionally add some services to 
         /// the service collection, and build the instance.
@@ -148,7 +147,7 @@ namespace Microsoft.Identity.Web
                         });
                         instance.Services.AddSingleton<ITokenAcquirerFactory, DefaultTokenAcquirerFactoryImplementation>();
                         instance.Services.AddSingleton(defaultInstance.Configuration);
-                     }
+                    }
                 }
             }
             return defaultInstance!;

--- a/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
@@ -58,11 +58,11 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.2" newVersion="6.0.0.2"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -74,7 +74,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.WsFederation" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -82,23 +82,23 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.68.0.0" newVersion="4.68.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.67.2.0" newVersion="4.67.2.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
@@ -59,11 +59,11 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.2" newVersion="6.0.0.2"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -75,7 +75,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.WsFederation" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -83,23 +83,23 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.6.0.0" newVersion="8.6.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.3.1.0" newVersion="8.3.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.68.0.0" newVersion="4.68.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.67.2.0" newVersion="4.67.2.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>

--- a/tests/E2E Tests/CustomSignedAssertionProviderTests/CustomSignedAssertionProviderExtensibilityTests.cs
+++ b/tests/E2E Tests/CustomSignedAssertionProviderTests/CustomSignedAssertionProviderExtensibilityTests.cs
@@ -8,11 +8,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.Test.Common;
 using Xunit.Sdk;
 
 
 namespace CustomSignedAssertionProviderTests
 {
+    [Collection(nameof(TokenAcquirerFactorySingletonProtection))]
     public class CustomSignedAssertionProviderExtensibilityTests
     {
         [Fact]

--- a/tests/E2E Tests/CustomSignedAssertionProviderTests/CustomSignedAssertionProviderTests.csproj
+++ b/tests/E2E Tests/CustomSignedAssertionProviderTests/CustomSignedAssertionProviderTests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.Certificate\Microsoft.Identity.Web.Certificate.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.Certificateless\Microsoft.Identity.Web.Certificateless.csproj" />
+    <ProjectReference Include="..\..\Microsoft.Identity.Web.Test.Common\Microsoft.Identity.Web.Test.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/E2E Tests/TokenAcquirerTests/CertificateRotationTest.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/CertificateRotationTest.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace TokenAcquirerTests
 {
+    [Collection(nameof(TokenAcquirerFactorySingletonProtection))]
     public sealed class CertificateRotationTest : ICertificatesObserver
     {
         const string MicrosoftGraphAppId = "00000003-0000-0000-c000-000000000000";

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -23,6 +23,7 @@ using TaskStatus = System.Threading.Tasks.TaskStatus;
 
 namespace TokenAcquirerTests
 {
+    [CollectionDefinition(nameof(TokenAcquirerFactorySingletonProtection))]
 #if !FROM_GITHUB_ACTION
     public class TokenAcquirer
     {

--- a/tests/Microsoft.Identity.Web.Test.Common/Microsoft.Identity.Web.Test.Common.csproj
+++ b/tests/Microsoft.Identity.Web.Test.Common/Microsoft.Identity.Web.Test.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net462; net472; net6.0; net8.0; net9.0</TargetFrameworks>
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.Identity.Lab.Api" Version="$(MicrosoftIdentityLabApiVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.assert" Version="$(XunitAssertVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)" />

--- a/tests/Microsoft.Identity.Web.Test.Common/TokenAcquirerFactorySingletonProtection.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TokenAcquirerFactorySingletonProtection.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test.Common
+{
+    [CollectionDefinition(nameof(TokenAcquirerFactorySingletonProtection))]
+    public class TokenAcquirerFactorySingletonProtection
+    {
+        // This class has no code, and is never created. Its purpose is to prevent test classes using the
+        // static singleton DefaultTokenAcquirerFactory from running in parallel as some tests modify this singleton.
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/BaseAuthorizationHeaderProviderTest.cs
+++ b/tests/Microsoft.Identity.Web.Test/BaseAuthorizationHeaderProviderTest.cs
@@ -10,11 +10,13 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Web.Test.Common;
 using Microsoft.Identity.Web.Extensibility;
 using Xunit;
 
 namespace Microsoft.Identity.Web.Test
 {
+    [Collection(nameof(TokenAcquirerFactorySingletonProtection))]
     public class BaseAuthorizationHeaderProviderTest
     {
         public BaseAuthorizationHeaderProviderTest()

--- a/tests/Microsoft.Identity.Web.Test/TestTokenAcquisitionHost.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestTokenAcquisitionHost.cs
@@ -4,10 +4,12 @@
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web.Test.Common;
 using Xunit;
 
 namespace Microsoft.Identity.Web.Test
 {
+    [Collection(nameof(TokenAcquirerFactorySingletonProtection))]
     public class TestTokenAcquisitionHost
     {
         [Fact]

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquirerFactoryTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquirerFactoryTests.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Identity.Web.Test.Common;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    [Collection(nameof(TokenAcquirerFactorySingletonProtection))]
+    public class TokenAcquirerFactoryTests
+    {
+        private readonly int numberOfIterations = 5;
+
+        [Fact]
+        public void Build_ThrowsInvalidOperationException_WhenCalledTwiceConcurrently()
+        {
+            // Locally this test failed appropriately on the first run every time when the relevant locks were removed.
+            // However, for robustness, we run it multiple times to protect against false positives in the future.
+            for (int i = 0; i < numberOfIterations; i++)
+            {
+                // Arrange
+                TokenAcquirerFactory.ResetDefaultInstance();
+                var testFactory = TokenAcquirerFactory.GetDefaultInstance();
+
+                // Act & Assert
+                try
+                {
+                    var exception = Assert.Throws<AggregateException>(() =>
+                    {
+                        Parallel.Invoke(
+                            () => testFactory.Build(),
+                            () => testFactory.Build()
+                        );
+                    });
+                    Assert.Single(exception.InnerExceptions);
+                    Assert.All(exception.InnerExceptions, ex => Assert.IsType<InvalidOperationException>(ex));
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"Test failed on iteration {i}", ex);
+                }
+            }
+        }
+
+        [Fact]
+        public void GetDefaultInstance_ParallelExecutionGeneric()
+        {
+            // Locally this test failed appropriately on the first run every time when the relevant locks were removed.
+            // However, for robustness, we run it multiple times to protect against false positives in the future.
+            for (int i = 0; i < numberOfIterations; i++)
+            {
+                // Arrange
+                TokenAcquirerFactoryWithCounter.ResetDefaultInstance();
+                // Act
+                Parallel.Invoke(
+                    () => TokenAcquirerFactoryWithCounter.GetDefaultInstance<TokenAcquirerFactoryWithCounter>(),
+                    () => TokenAcquirerFactoryWithCounter.GetDefaultInstance<TokenAcquirerFactoryWithCounter>(),
+                    () => TokenAcquirerFactoryWithCounter.GetDefaultInstance<TokenAcquirerFactoryWithCounter>(),
+                    () => TokenAcquirerFactoryWithCounter.GetDefaultInstance<TokenAcquirerFactoryWithCounter>()
+                );
+                // Assert
+                Assert.Equal(1, TokenAcquirerFactoryWithCounter.InstanceCount);
+            }
+        }
+
+        /// <summary>
+        /// Due to how the non-Generic GetDefaultInstance method creates a new TokenAcquirerFactory instance immediately, it is not easy to 
+        /// test concurrent access without adding a counter to the TokenAcquirerFactory class. This test is for manual testing only to avoid 
+        /// adding a counter to the class and method permanently so to use this test uncomment the lines using s_defaultInstanceCounter, make
+        /// the member inside the TokenAcquirerFactory class, and increment in the constructor. Don't forget to reset it between tests.
+        /// The current lock implementation as of March 2025 has been tested to work correctly.
+        /// </summary>
+        [Fact(Skip = "Requires manual testing")]
+        public void GetDefaultInstance_ParallelExecutionNonGeneric()
+        {
+            // Arrange
+            TokenAcquirerFactory.ResetDefaultInstance();
+            //TokenAcquirerFactory.s_defaultInstanceCounter = 0;
+
+            // Act
+            Parallel.Invoke(
+                () => TokenAcquirerFactory.GetDefaultInstance(),
+                () => TokenAcquirerFactory.GetDefaultInstance(),
+                () => TokenAcquirerFactory.GetDefaultInstance(),
+                () => TokenAcquirerFactory.GetDefaultInstance()
+            );
+
+            // Assert
+            //Assert.Equal(1, TokenAcquirerFactory.s_defaultInstanceCounter);
+        }
+    }
+
+    public class TokenAcquirerFactoryWithCounter : TokenAcquirerFactory
+    {
+        public static int InstanceCount { get; private set; } = 0;
+
+        public TokenAcquirerFactoryWithCounter()
+        {
+            InstanceCount++;
+        }
+
+        public static new void ResetDefaultInstance()
+        {
+            TokenAcquirerFactory.ResetDefaultInstance();
+            InstanceCount = 0;
+        }
+    }
+}


### PR DESCRIPTION
As demonstrated by the unit tests in this PR failing when the locks (also added here) are removed, it is possible in the currently released version to get multiple threads of execution through the `TokenAcquirerFactory.GetDefaultInstance` and `TokenAcquirerFactory.Build` methods when called concurrently. 

These methods perform setup of services critical to the library's functionality so protecting them from concurrent access is essential to avoiding unexpected behavior.

Additionally, due to the static, singleton nature of GetDefaultInstance this PR adds all test classes using the method to a collection to prevent them from being run in parallel. 