### PR TITLE
Propose a fix for:

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -751,23 +751,40 @@ namespace Microsoft.Identity.Web
                 || exMsal.Message.Contains(Constants.CertificateHasBeenRevoked)
                 || exMsal.Message.Contains(Constants.CertificateIsOutsideValidityWindow));
 #endif
-        }       
+        }
 
 
         internal /* for testing */ async Task<IConfidentialClientApplication> GetOrBuildConfidentialClientApplicationAsync(
-             MergedOptions mergedOptions)
+            MergedOptions mergedOptions)
         {
             // Use all credentials to compute a credential chain ID. Each individual ID should be unique.
             string credentialId = string.Join("-", mergedOptions.ClientCredentials?.Select(c => c.Id) ?? Enumerable.Empty<string>());
             string key = GetApplicationKey(mergedOptions) + credentialId;
 
             // GetOrAddAsync based on https://github.com/dotnet/runtime/issues/83636#issuecomment-1474998680
-            if (!_applicationsByAuthorityClientId.TryGetValue(key, out IConfidentialClientApplication? application) && application != null)
-                return application;
+            // Fast path: check if already created
+            if (_applicationsByAuthorityClientId.TryGetValue(key, out var existingApp) && existingApp != null)
+                return existingApp;
 
-            application = _applicationsByAuthorityClientId.GetOrAdd(key, await BuildConfidentialClientApplicationAsync(mergedOptions));
+            // Get or create a semaphore for this specific key
+            var semaphore = _appSemaphores.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
 
-            return application!;            
+            await semaphore.WaitAsync();
+            try
+            {
+                // Double-check after acquiring the lock
+                if (_applicationsByAuthorityClientId.TryGetValue(key, out var app) && app != null)
+                    return app;
+
+                // Build and store the application
+                var newApp = await BuildConfidentialClientApplicationAsync(mergedOptions);
+                _applicationsByAuthorityClientId[key] = newApp;
+                return newApp;
+            }
+            finally
+            {
+                semaphore.Release();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Propose a fix for:
 - `GetValue(key, out IConfidentialClientApplication? application) && application != null)` was not right because if `TryGetValue` returns `false`, application will necessarilly be **null**. So the condition `!TryGetValue(...) && application != null` can never be true.
- which implies that we'll have a race condition: `BuildConfidentialClientApplicationAsync to be executed multiple times concurrently for the same key. The pattern used here:`

The proposed code with a semaphore per key released on all cases should prevents multiple concurrent builds while still allowing concurrent access to different applications.

# Productization

## Description


