### PR TITLE
Add singleton protection for test class using TokenAcquirerFactory

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
@@ -215,11 +215,14 @@ namespace Microsoft.Identity.Web
         /// </summary>
         internal /* for unit tests */ static void ResetDefaultInstance()
         {
-            if (defaultInstance?.ServiceProvider != null)
+            lock (s_defaultInstanceLock)
             {
-                (defaultInstance.ServiceProvider as IDisposable)?.Dispose();
+                if (defaultInstance?.ServiceProvider != null)
+                {
+                    (defaultInstance.ServiceProvider as IDisposable)?.Dispose();
+                }
+                defaultInstance = null;
             }
-            defaultInstance = null;
         }
 
         // Move to a derived class?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirerFactory.cs
@@ -217,10 +217,10 @@ namespace Microsoft.Identity.Web
         {
             lock (s_defaultInstanceLock)
             {
-                if (defaultInstance?.ServiceProvider != null)
+/*                if (defaultInstance?.ServiceProvider != null)
                 {
                     (defaultInstance.ServiceProvider as IDisposable)?.Dispose();
-                }
+                }*/
                 defaultInstance = null;
             }
         }

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -23,7 +23,7 @@ using TaskStatus = System.Threading.Tasks.TaskStatus;
 
 namespace TokenAcquirerTests
 {
-    [CollectionDefinition(nameof(TokenAcquirerFactorySingletonProtection))]
+    [CollectionDefinition(nameof(TokenAcquirerFactorySingletonProtection), DisableParallelization = true)]
 #if !FROM_GITHUB_ACTION
     public class TokenAcquirer
     {
@@ -477,7 +477,7 @@ namespace TokenAcquirerTests
         }
     }
 
-    [CollectionDefinition(nameof(TokenAcquirerFactorySingletonProtection))]
+    [CollectionDefinition(nameof(TokenAcquirerFactorySingletonProtection), DisableParallelization = true)]
     public class AcquireTokenManagedIdentity
     {
         [OnlyOnAzureDevopsFact]

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -477,6 +477,7 @@ namespace TokenAcquirerTests
         }
     }
 
+    [CollectionDefinition(nameof(TokenAcquirerFactorySingletonProtection))]
     public class AcquireTokenManagedIdentity
     {
         [OnlyOnAzureDevopsFact]
@@ -487,6 +488,7 @@ namespace TokenAcquirerTests
             const string scope = "https://vault.azure.net/.default";
             const string baseUrl = "https://vault.azure.net";
             const string clientId = "5bcd1685-b002-4fd1-8ebd-1ec3e1e4ca4d";
+            TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest();
             TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
             IServiceProvider serviceProvider = tokenAcquirerFactory.Build();
 


### PR DESCRIPTION
Since there was a second class in this test file it was missed when adding the singleton protection collection definition. Added the definition and also the call to reset the TokenAcquirerFactory's default instance in the test itself.
