### PR TITLE
Fixing TokenAcquireTest (missing reset TokenAcquirerFactory)

### DIFF
--- a/tests/E2E Tests/TokenAcquirerTests/CertificateRotationTest.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/CertificateRotationTest.cs
@@ -40,7 +40,7 @@ namespace TokenAcquirerTests
             _graphServiceClient = new GraphServiceClient(credential);
         }
 
-        [IgnoreOnAzureDevopsFact]
+        [IgnoreOnAzureDevopsFact(Skip = "Can't run in MSIT. Requires ephemeral tenant")]
         public async Task TestCertificateRotationAsync()
         {
             // Prepare the environment

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -487,6 +487,7 @@ namespace TokenAcquirerTests
             const string scope = "https://vault.azure.net/.default";
             const string baseUrl = "https://vault.azure.net";
             const string clientId = "5bcd1685-b002-4fd1-8ebd-1ec3e1e4ca4d";
+            TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest();
             TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
             IServiceProvider serviceProvider = tokenAcquirerFactory.Build();
 


### PR DESCRIPTION

# Fixing TokenAcquireTest (missing reset TokenAcquirerFactory) and Disable Cert rotation test as it can't run in that tenant.
