### PR TITLE
Post release cleanup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!--This should be passed from the VSTS build-->
     <!-- This needs to be greater than or equal to the validation baseline version -->
-    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">3.8.0</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">3.8.1</MicrosoftIdentityWebVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MicrosoftIdentityWebVersion)</Version>
 

--- a/src/Microsoft.Identity.Web.OidcFIC/Microsoft.Identity.Web.OidcFIC.csproj
+++ b/src/Microsoft.Identity.Web.OidcFIC/Microsoft.Identity.Web.OidcFIC.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{8DA7A2C6-00D4-4CF1-8145-448D7B7B4E5A}</ProjectGuid>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <!-- Until it releases-->
-    <EnablePackageValidation>false</EnablePackageValidation>
+    <PackageValidationBaselineVersion>3.8.0</PackageValidationBaselineVersion>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net462/InternalAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net462/InternalAPI.Shipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
+override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net462/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net462/InternalAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
-override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
+static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
-static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net472/InternalAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net472/InternalAPI.Shipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
+override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net472/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net472/InternalAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
-override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
+static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
-static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net6.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net6.0/InternalAPI.Shipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
+override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net6.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net6.0/InternalAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
-override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
+static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
-static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net7.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net7.0/InternalAPI.Shipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
+override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net7.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net7.0/InternalAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
-override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net7.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net7.0/PublicAPI.Shipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
+static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
-static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net8.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net8.0/InternalAPI.Shipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
+override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net8.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net8.0/InternalAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
-override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
+static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
-static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net9.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net9.0/InternalAPI.Shipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
+override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
-override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
+static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
-static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/netstandard2.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/netstandard2.0/InternalAPI.Shipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
+Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
+override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.CredentialSource.get -> Microsoft.Identity.Abstractions.CredentialSource
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.LoadIfNeededAsync(Microsoft.Identity.Abstractions.CredentialDescription! credentialDescription, Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters? parameters = null) -> System.Threading.Tasks.Task!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.Name.get -> string!
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader.OidcIdpSignedAssertionLoader(Microsoft.Extensions.Logging.ILogger<Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader!>! logger, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions!>! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory) -> void
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider
-Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.OidcIdpSignedAssertionProvider(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options, string? tokenExchangeUrl) -> void
-override Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionProvider.GetClientAssertionAsync(Microsoft.Identity.Client.AssertionRequestOptions? assertionRequestOptions) -> System.Threading.Tasks.Task<Microsoft.Identity.Web.ClientAssertion!>!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
+static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OidcFIC/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions
-static Microsoft.Extensions.DependencyInjection.OidcFicSignedAssertionProviderExtensions.AddOidcFic(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -124,6 +124,7 @@ Microsoft.Identity.Web.OpenIdConnectOptions.ClientSecret.set -> void
 Microsoft.Identity.Web.OpenIdConnectOptions.OpenIdConnectOptions() -> void
 Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens
 Microsoft.Identity.Web.ServiceCollectionExtensions
+Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
 Microsoft.Identity.Web.TokenAcquirerFactory
 Microsoft.Identity.Web.TokenAcquirerFactory.Build() -> System.IServiceProvider!
 Microsoft.Identity.Web.TokenAcquirerFactory.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration!
@@ -149,6 +150,7 @@ Microsoft.Identity.Web.TokenAcquisitionOptions.TokenAcquisitionOptions() -> void
 static Microsoft.Identity.Web.Internal.WebApiBuilders.EnableTokenAcquisition(System.Action<Microsoft.Identity.Client.ConfidentialClientApplicationOptions!>! configureConfidentialClientApplicationOptions, string! authenticationScheme, Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfigurationSection? configuration) -> Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder!
 static Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens.GetBootstrapToken(this System.Security.Principal.IPrincipal! claimsPrincipal) -> Microsoft.IdentityModel.Tokens.SecurityToken?
 static Microsoft.Identity.Web.ServiceCollectionExtensions.AddTokenAcquisition(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isTokenAcquisitionSingleton = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance(string! configSection = "AzureAd") -> Microsoft.Identity.Web.TokenAcquirerFactory!
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance<T>(string! configSection = "AzureAd") -> T!
 virtual Microsoft.Identity.Web.Extensibility.BaseAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync(System.Collections.Generic.IEnumerable<string!>! scopes, Microsoft.Identity.Abstractions.AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
-static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -124,6 +124,7 @@ Microsoft.Identity.Web.OpenIdConnectOptions.ClientSecret.set -> void
 Microsoft.Identity.Web.OpenIdConnectOptions.OpenIdConnectOptions() -> void
 Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens
 Microsoft.Identity.Web.ServiceCollectionExtensions
+Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
 Microsoft.Identity.Web.TokenAcquirerFactory
 Microsoft.Identity.Web.TokenAcquirerFactory.Build() -> System.IServiceProvider!
 Microsoft.Identity.Web.TokenAcquirerFactory.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration!
@@ -149,6 +150,7 @@ Microsoft.Identity.Web.TokenAcquisitionOptions.TokenAcquisitionOptions() -> void
 static Microsoft.Identity.Web.Internal.WebApiBuilders.EnableTokenAcquisition(System.Action<Microsoft.Identity.Client.ConfidentialClientApplicationOptions!>! configureConfidentialClientApplicationOptions, string! authenticationScheme, Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfigurationSection? configuration) -> Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder!
 static Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens.GetBootstrapToken(this System.Security.Principal.IPrincipal! claimsPrincipal) -> Microsoft.IdentityModel.Tokens.SecurityToken?
 static Microsoft.Identity.Web.ServiceCollectionExtensions.AddTokenAcquisition(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isTokenAcquisitionSingleton = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance(string! configSection = "AzureAd") -> Microsoft.Identity.Web.TokenAcquirerFactory!
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance<T>(string! configSection = "AzureAd") -> T!
 virtual Microsoft.Identity.Web.Extensibility.BaseAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync(System.Collections.Generic.IEnumerable<string!>! scopes, Microsoft.Identity.Abstractions.AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
-static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -124,6 +124,7 @@ Microsoft.Identity.Web.MicrosoftIdentityWebChallengeUserException.Userflow.get -
 Microsoft.Identity.Web.MicrosoftIdentityWebChallengeUserException.Userflow.set -> void
 Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens
 Microsoft.Identity.Web.ServiceCollectionExtensions
+Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
 Microsoft.Identity.Web.TokenAcquirerFactory
 Microsoft.Identity.Web.TokenAcquirerFactory.Build() -> System.IServiceProvider!
 Microsoft.Identity.Web.TokenAcquirerFactory.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration!
@@ -150,6 +151,7 @@ static Microsoft.Identity.Web.ApplicationBuilderExtensions.UseTokenAcquirerFacto
 static Microsoft.Identity.Web.Internal.WebApiBuilders.EnableTokenAcquisition(System.Action<Microsoft.Identity.Client.ConfidentialClientApplicationOptions!>! configureConfidentialClientApplicationOptions, string! authenticationScheme, Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfigurationSection? configuration) -> Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder!
 static Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens.GetBootstrapToken(this System.Security.Principal.IPrincipal! claimsPrincipal) -> Microsoft.IdentityModel.Tokens.SecurityToken?
 static Microsoft.Identity.Web.ServiceCollectionExtensions.AddTokenAcquisition(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isTokenAcquisitionSingleton = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance(string! configSection = "AzureAd") -> Microsoft.Identity.Web.TokenAcquirerFactory!
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance<T>(string! configSection = "AzureAd") -> T!
 virtual Microsoft.Identity.Web.Extensibility.BaseAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync(System.Collections.Generic.IEnumerable<string!>! scopes, Microsoft.Identity.Abstractions.AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
-static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/PublicAPI.Shipped.txt
@@ -124,6 +124,7 @@ Microsoft.Identity.Web.MicrosoftIdentityWebChallengeUserException.Userflow.get -
 Microsoft.Identity.Web.MicrosoftIdentityWebChallengeUserException.Userflow.set -> void
 Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens
 Microsoft.Identity.Web.ServiceCollectionExtensions
+Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
 Microsoft.Identity.Web.TokenAcquirerFactory
 Microsoft.Identity.Web.TokenAcquirerFactory.Build() -> System.IServiceProvider!
 Microsoft.Identity.Web.TokenAcquirerFactory.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration!
@@ -150,6 +151,7 @@ static Microsoft.Identity.Web.ApplicationBuilderExtensions.UseTokenAcquirerFacto
 static Microsoft.Identity.Web.Internal.WebApiBuilders.EnableTokenAcquisition(System.Action<Microsoft.Identity.Client.ConfidentialClientApplicationOptions!>! configureConfidentialClientApplicationOptions, string! authenticationScheme, Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfigurationSection? configuration) -> Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder!
 static Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens.GetBootstrapToken(this System.Security.Principal.IPrincipal! claimsPrincipal) -> Microsoft.IdentityModel.Tokens.SecurityToken?
 static Microsoft.Identity.Web.ServiceCollectionExtensions.AddTokenAcquisition(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isTokenAcquisitionSingleton = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance(string! configSection = "AzureAd") -> Microsoft.Identity.Web.TokenAcquirerFactory!
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance<T>(string! configSection = "AzureAd") -> T!
 virtual Microsoft.Identity.Web.Extensibility.BaseAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync(System.Collections.Generic.IEnumerable<string!>! scopes, Microsoft.Identity.Abstractions.AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
-static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -124,6 +124,7 @@ Microsoft.Identity.Web.MicrosoftIdentityWebChallengeUserException.Userflow.get -
 Microsoft.Identity.Web.MicrosoftIdentityWebChallengeUserException.Userflow.set -> void
 Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens
 Microsoft.Identity.Web.ServiceCollectionExtensions
+Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
 Microsoft.Identity.Web.TokenAcquirerFactory
 Microsoft.Identity.Web.TokenAcquirerFactory.Build() -> System.IServiceProvider!
 Microsoft.Identity.Web.TokenAcquirerFactory.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration!
@@ -150,6 +151,7 @@ static Microsoft.Identity.Web.ApplicationBuilderExtensions.UseTokenAcquirerFacto
 static Microsoft.Identity.Web.Internal.WebApiBuilders.EnableTokenAcquisition(System.Action<Microsoft.Identity.Client.ConfidentialClientApplicationOptions!>! configureConfidentialClientApplicationOptions, string! authenticationScheme, Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfigurationSection? configuration) -> Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder!
 static Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens.GetBootstrapToken(this System.Security.Principal.IPrincipal! claimsPrincipal) -> Microsoft.IdentityModel.Tokens.SecurityToken?
 static Microsoft.Identity.Web.ServiceCollectionExtensions.AddTokenAcquisition(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isTokenAcquisitionSingleton = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance(string! configSection = "AzureAd") -> Microsoft.Identity.Web.TokenAcquirerFactory!
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance<T>(string! configSection = "AzureAd") -> T!
 virtual Microsoft.Identity.Web.Extensibility.BaseAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync(System.Collections.Generic.IEnumerable<string!>! scopes, Microsoft.Identity.Abstractions.AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
-static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -124,6 +124,7 @@ Microsoft.Identity.Web.MicrosoftIdentityWebChallengeUserException.Userflow.get -
 Microsoft.Identity.Web.MicrosoftIdentityWebChallengeUserException.Userflow.set -> void
 Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens
 Microsoft.Identity.Web.ServiceCollectionExtensions
+Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
 Microsoft.Identity.Web.TokenAcquirerFactory
 Microsoft.Identity.Web.TokenAcquirerFactory.Build() -> System.IServiceProvider!
 Microsoft.Identity.Web.TokenAcquirerFactory.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration!
@@ -150,6 +151,7 @@ static Microsoft.Identity.Web.ApplicationBuilderExtensions.UseTokenAcquirerFacto
 static Microsoft.Identity.Web.Internal.WebApiBuilders.EnableTokenAcquisition(System.Action<Microsoft.Identity.Client.ConfidentialClientApplicationOptions!>! configureConfidentialClientApplicationOptions, string! authenticationScheme, Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfigurationSection? configuration) -> Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder!
 static Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens.GetBootstrapToken(this System.Security.Principal.IPrincipal! claimsPrincipal) -> Microsoft.IdentityModel.Tokens.SecurityToken?
 static Microsoft.Identity.Web.ServiceCollectionExtensions.AddTokenAcquisition(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isTokenAcquisitionSingleton = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance(string! configSection = "AzureAd") -> Microsoft.Identity.Web.TokenAcquirerFactory!
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance<T>(string! configSection = "AzureAd") -> T!
 virtual Microsoft.Identity.Web.Extensibility.BaseAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync(System.Collections.Generic.IEnumerable<string!>! scopes, Microsoft.Identity.Abstractions.AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
-static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -124,6 +124,7 @@ Microsoft.Identity.Web.OpenIdConnectOptions.ClientSecret.set -> void
 Microsoft.Identity.Web.OpenIdConnectOptions.OpenIdConnectOptions() -> void
 Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens
 Microsoft.Identity.Web.ServiceCollectionExtensions
+Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
 Microsoft.Identity.Web.TokenAcquirerFactory
 Microsoft.Identity.Web.TokenAcquirerFactory.Build() -> System.IServiceProvider!
 Microsoft.Identity.Web.TokenAcquirerFactory.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration!
@@ -149,6 +150,7 @@ Microsoft.Identity.Web.TokenAcquisitionOptions.TokenAcquisitionOptions() -> void
 static Microsoft.Identity.Web.Internal.WebApiBuilders.EnableTokenAcquisition(System.Action<Microsoft.Identity.Client.ConfidentialClientApplicationOptions!>! configureConfidentialClientApplicationOptions, string! authenticationScheme, Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfigurationSection? configuration) -> Microsoft.Identity.Web.MicrosoftIdentityAppCallsWebApiAuthenticationBuilder!
 static Microsoft.Identity.Web.PrincipalExtensionsForSecurityTokens.GetBootstrapToken(this System.Security.Principal.IPrincipal! claimsPrincipal) -> Microsoft.IdentityModel.Tokens.SecurityToken?
 static Microsoft.Identity.Web.ServiceCollectionExtensions.AddTokenAcquisition(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isTokenAcquisitionSingleton = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance(string! configSection = "AzureAd") -> Microsoft.Identity.Web.TokenAcquirerFactory!
 static Microsoft.Identity.Web.TokenAcquirerFactory.GetDefaultInstance<T>(string! configSection = "AzureAd") -> T!
 virtual Microsoft.Identity.Web.Extensibility.BaseAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync(System.Collections.Generic.IEnumerable<string!>! scopes, Microsoft.Identity.Abstractions.AuthorizationHeaderProviderOptions? authorizationHeaderProviderOptions = null, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting
-static Microsoft.Identity.Web.TestOnly.TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest() -> void


### PR DESCRIPTION
# Post release 3.8.0 cleanup
- Reset the public API Unshipped.txt files, and update the Shipped ones
- Update the IDWeb next version to 3.8.1 for the moment
- Enable Package Validation for the new Microsoft.Identity.Web.FicOidc package and sets its baselineVersion to 3,8,0 as its it's first version.
- 
