### PR TITLE
Enabling IdWeb to throw an exception if MSAL indicates that it should not configure the distributed cache

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,7 +87,7 @@
 
   <PropertyGroup Label="Common dependency versions">
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.6.1</MicrosoftIdentityModelVersion>
-    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.69.1</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.70.0</MicrosoftIdentityClientVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>

--- a/src/Microsoft.Identity.Web.TokenCache/CacheSerializerHints.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/CacheSerializerHints.cs
@@ -31,6 +31,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// <summary>
         /// Determines if the client application should not use the distributed cache.
         /// </summary>
-        internal bool ShouldNotUseDistributedCache { get; set; }
+        internal string? ShouldNotUseDistributedCache { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web.TokenCache/CacheSerializerHints.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/CacheSerializerHints.cs
@@ -27,5 +27,10 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// Stores details to log to MSAL's telemetry client
         /// </summary>
         internal TelemetryData? TelemetryData { get; set; }
+
+        /// <summary>
+        /// Determines if the client application should not use the distributed cache.
+        /// </summary>
+        internal bool ShouldNotUseDistributedCache { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web.TokenCache/CacheSerializerHints.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/CacheSerializerHints.cs
@@ -31,6 +31,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// <summary>
         /// Error message to display in the cases where the client application should not use the distributed cache (not null or empty means it shouldn't use it)
         /// </summary>
-        internal string? ShouldNotUseDistributedCache { get; set; }
+        internal string? ShouldNotUseDistributedCacheMessage { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web.TokenCache/CacheSerializerHints.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/CacheSerializerHints.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         internal TelemetryData? TelemetryData { get; set; }
 
         /// <summary>
-        /// Determines if the client application should not use the distributed cache.
+        /// Error message to display in the cases where the client application should not use the distributed cache (not null or empty means it shouldn't use it)
         /// </summary>
         internal string? ShouldNotUseDistributedCache { get; set; }
     }

--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -110,9 +110,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         {
             const string remove = "Remove";
 
-            if (cacheSerializerHints.ShouldNotUseDistributedCache)
+            if (!string.IsNullOrEmpty(cacheSerializerHints.ShouldNotUseDistributedCache))
             {
-                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache);
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCache);
             }
 
             if (_memoryCache != null)
@@ -154,9 +154,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             byte[]? result = null;
             var telemetryData = cacheSerializerHints.TelemetryData;
 
-            if (cacheSerializerHints.ShouldNotUseDistributedCache)
+            if (!string.IsNullOrEmpty(cacheSerializerHints.ShouldNotUseDistributedCache))
             {
-                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache);
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCache);
             }
 
             if (_memoryCache != null)
@@ -249,11 +249,10 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             const string write = "Write";
 
             DateTimeOffset? cacheExpiry = cacheSerializerHints?.SuggestedCacheExpiry;
-            bool ShouldNotUseDistributedCache = cacheSerializerHints?.ShouldNotUseDistributedCache ?? false;
 
-            if (ShouldNotUseDistributedCache)
+            if (!string.IsNullOrEmpty(cacheSerializerHints?.ShouldNotUseDistributedCache))
             {
-                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache);
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCache);
             }
 
             if (_memoryCache != null)

--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -110,6 +110,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         {
             const string remove = "Remove";
 
+            if (cacheSerializerHints.ShouldNotUseDistributedCache)
+            {
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache);
+            }
+
             if (_memoryCache != null)
             {
                 _memoryCache.Remove(cacheKey);
@@ -148,6 +153,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             const string read = "Read";
             byte[]? result = null;
             var telemetryData = cacheSerializerHints.TelemetryData;
+
+            if (cacheSerializerHints.ShouldNotUseDistributedCache)
+            {
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache);
+            }
 
             if (_memoryCache != null)
             {
@@ -239,6 +249,12 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             const string write = "Write";
 
             DateTimeOffset? cacheExpiry = cacheSerializerHints?.SuggestedCacheExpiry;
+            bool ShouldNotUseDistributedCache = cacheSerializerHints?.ShouldNotUseDistributedCache ?? false;
+
+            if (ShouldNotUseDistributedCache)
+            {
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache);
+            }
 
             if (_memoryCache != null)
             {

--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -110,9 +110,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         {
             const string remove = "Remove";
 
-            if (!string.IsNullOrEmpty(cacheSerializerHints.ShouldNotUseDistributedCache))
+            if (!string.IsNullOrEmpty(cacheSerializerHints.ShouldNotUseDistributedCacheMessage))
             {
-                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCache);
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCacheMessage);
             }
 
             if (_memoryCache != null)
@@ -154,9 +154,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             byte[]? result = null;
             var telemetryData = cacheSerializerHints.TelemetryData;
 
-            if (!string.IsNullOrEmpty(cacheSerializerHints.ShouldNotUseDistributedCache))
+            if (!string.IsNullOrEmpty(cacheSerializerHints.ShouldNotUseDistributedCacheMessage))
             {
-                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCache);
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCacheMessage);
             }
 
             if (_memoryCache != null)
@@ -250,9 +250,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 
             DateTimeOffset? cacheExpiry = cacheSerializerHints?.SuggestedCacheExpiry;
 
-            if (!string.IsNullOrEmpty(cacheSerializerHints?.ShouldNotUseDistributedCache))
+            if (!string.IsNullOrEmpty(cacheSerializerHints?.ShouldNotUseDistributedCacheMessage))
             {
-                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCache);
+                throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCacheMessage);
             }
 
             if (_memoryCache != null)

--- a/src/Microsoft.Identity.Web.TokenCache/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenCache/InternalAPI.Unshipped.txt
@@ -1,3 +1,3 @@
-const Microsoft.Identity.Web.TokenCacheErrorMessage.CannotUseDistributedCache = "IDW10803: Do not use a distributed cache for the current configuration. Use an in memory cache instead." -> string!
-Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCache.get -> bool
+const Microsoft.Identity.Web.TokenCacheErrorMessage.CannotUseDistributedCache = "IDW10803: Cannot use distributed cache for the current configuration. Use an in memory cache instead." -> string!
+Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCache.get -> string?
 Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCache.set -> void

--- a/src/Microsoft.Identity.Web.TokenCache/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenCache/InternalAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+const Microsoft.Identity.Web.TokenCacheErrorMessage.CannotUseDistributedCache = "IDW10803: Do not use a distributed cache for the current configuration. Use an in memory cache instead." -> string!
+Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCache.get -> bool
+Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCache.set -> void

--- a/src/Microsoft.Identity.Web.TokenCache/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenCache/InternalAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 const Microsoft.Identity.Web.TokenCacheErrorMessage.CannotUseDistributedCache = "IDW10803: Cannot use distributed cache for the current configuration. Use an in memory cache instead." -> string!
-Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCache.get -> string?
-Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCache.set -> void
+Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCacheMessage.get -> string?
+Microsoft.Identity.Web.TokenCacheProviders.CacheSerializerHints.ShouldNotUseDistributedCacheMessage.set -> void

--- a/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         {   CancellationToken = args.CancellationToken,
             SuggestedCacheExpiry = args.SuggestedCacheExpiry,
             TelemetryData = args.TelemetryData,
-            ShouldNotUseDistributedCache = args.NoDistributedCacheUseReason
+            ShouldNotUseDistributedCacheMessage = args.NoDistributedCacheUseReason
         };
 
         private async Task OnBeforeAccessAsync(TokenCacheNotificationArgs args)

--- a/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         {   CancellationToken = args.CancellationToken,
             SuggestedCacheExpiry = args.SuggestedCacheExpiry,
             TelemetryData = args.TelemetryData,
-            ShouldNotUseDistributedCache = args.ShouldNotUseDistributedCache
+            ShouldNotUseDistributedCache = args.NoDistributedCacheUseReason
         };
 
         private async Task OnBeforeAccessAsync(TokenCacheNotificationArgs args)

--- a/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/MsalAbstractTokenCacheProvider.cs
@@ -101,7 +101,11 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         }
 
         private static CacheSerializerHints CreateHintsFromArgs(TokenCacheNotificationArgs args) => new CacheSerializerHints 
-        { CancellationToken = args.CancellationToken, SuggestedCacheExpiry = args.SuggestedCacheExpiry, TelemetryData = args.TelemetryData };
+        {   CancellationToken = args.CancellationToken,
+            SuggestedCacheExpiry = args.SuggestedCacheExpiry,
+            TelemetryData = args.TelemetryData,
+            ShouldNotUseDistributedCache = args.ShouldNotUseDistributedCache
+        };
 
         private async Task OnBeforeAccessAsync(TokenCacheNotificationArgs args)
         {

--- a/src/Microsoft.Identity.Web.TokenCache/TokenCacheErrorMessage.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/TokenCacheErrorMessage.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Identity.Web
     {
         public const string InitializeAsyncIsObsolete = "IDW10801: Use Initialize instead. See https://aka.ms/ms-id-web/1.9.0. ";
         public const string ExceptionDeserializingCache = "IDW10802: Exception occurred while deserializing token cache. See https://aka.ms/msal-net-token-cache-serialization general guidance and https://aka.ms/ms-id-web/token-cache-troubleshooting for token cache troubleshooting information.";
-        public const string CannotUseDistributedCache = "IDW10803: Do not use a distributed cache for the current configuration. Use an in memory cache instead.";
+        public const string CannotUseDistributedCache = "IDW10803: Cannot use distributed cache for the current configuration. Use an in memory cache instead.";
     }
 }

--- a/src/Microsoft.Identity.Web.TokenCache/TokenCacheErrorMessage.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/TokenCacheErrorMessage.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Identity.Web
     {
         public const string InitializeAsyncIsObsolete = "IDW10801: Use Initialize instead. See https://aka.ms/ms-id-web/1.9.0. ";
         public const string ExceptionDeserializingCache = "IDW10802: Exception occurred while deserializing token cache. See https://aka.ms/msal-net-token-cache-serialization general guidance and https://aka.ms/ms-id-web/token-cache-troubleshooting for token cache troubleshooting information.";
+        public const string CannotUseDistributedCache = "IDW10803: Do not use a distributed cache for the current configuration. Use an in memory cache instead.";
     }
 }

--- a/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/TestMsalDistributedTokenCacheAdapter.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestHelpers/TestMsalDistributedTokenCacheAdapter.cs
@@ -34,6 +34,11 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
             await RemoveKeyAsync(cacheKey);
         }
 
+        public async Task TestRemoveKeyAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
+        {
+            await RemoveKeyAsync(cacheKey, cacheSerializerHints?? new CacheSerializerHints());
+        }
+
         public async Task TestWriteCacheBytesAsync(string cacheKey, byte[] bytes, CacheSerializerHints? cacheSerializerHints = null)
         {
             await WriteCacheBytesAsync(cacheKey, bytes, cacheSerializerHints);
@@ -42,6 +47,11 @@ namespace Microsoft.Identity.Web.Test.Common.TestHelpers
         public async Task<byte[]?> TestReadCacheBytesAsync(string cacheKey)
         {
             return await ReadCacheBytesAsync(cacheKey);
+        }
+
+        public async Task<byte[]?> TestReadCacheBytesAsync(string cacheKey, CacheSerializerHints cacheSerializerHints)
+        {
+            return await ReadCacheBytesAsync(cacheKey, cacheSerializerHints?? new CacheSerializerHints());
         }
 
         public async Task<byte[]?> TestReadCacheBytesAsync(string cacheKey, TelemetryData telemetryData)

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -417,9 +417,9 @@ namespace Microsoft.Identity.Web.Test
                 await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey, cacheSerializerHints));
 
             // Assert
-            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex1.Message + "  DoNotUseDistCache");
-            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex2.Message + "  DoNotUseDistCache");
-            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex3.Message + "  DoNotUseDistCache");
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache + " DoNotUseDistCache", ex1.Message);
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache + " DoNotUseDistCache", ex2.Message);
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache + " DoNotUseDistCache", ex3.Message);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
         }
 

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Empty(L2Cache._dict);
             CacheSerializerHints cacheSerializerHints = new CacheSerializerHints();
             cacheSerializerHints.SuggestedCacheExpiry = System.DateTimeOffset.Now - System.TimeSpan.FromHours(1);
-            cacheSerializerHints.ShouldNotUseDistributedCache = "DoNotUseDistCache";
+            cacheSerializerHints.ShouldNotUseDistributedCacheMessage = "DoNotUseDistCache";
 
             // Act
             var ex1 = await Assert.ThrowsAsync<InvalidOperationException>(async () =>

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
@@ -389,6 +390,37 @@ namespace Microsoft.Identity.Web.Test
             await _testCacheAdapter.TestRemoveKeyAsync(AnotherCacheKey);
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
             Assert.Empty(L2Cache._dict);
+        }
+
+
+        [Fact]
+        public async Task SetLCache_ThrowIf_ShouldNotUseDistributedCache_TestAsync()
+        {
+            // Arrange
+            byte[] cache = new byte[3];
+            AssertCacheValues(_testCacheAdapter);
+            Assert.NotNull(_testCacheAdapter._memoryCache);
+            Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
+            Assert.Empty(L2Cache._dict);
+            CacheSerializerHints cacheSerializerHints = new CacheSerializerHints();
+            cacheSerializerHints.SuggestedCacheExpiry = System.DateTimeOffset.Now - System.TimeSpan.FromHours(1);
+            cacheSerializerHints.ShouldNotUseDistributedCache = true;
+
+            // Act
+            var ex1 = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await _testCacheAdapter.TestWriteCacheBytesAsync(DefaultCacheKey, cache, cacheSerializerHints));
+
+            var ex2 = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await _testCacheAdapter.TestReadCacheBytesAsync(DefaultCacheKey, cacheSerializerHints));
+
+            var ex3 = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey, cacheSerializerHints));
+
+            // Assert
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex1.Message);
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex2.Message);
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex3.Message);
+            Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
         }
 
         private static void AssertCacheValues(TestMsalDistributedTokenCacheAdapter testCache)

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Empty(L2Cache._dict);
             CacheSerializerHints cacheSerializerHints = new CacheSerializerHints();
             cacheSerializerHints.SuggestedCacheExpiry = System.DateTimeOffset.Now - System.TimeSpan.FromHours(1);
-            cacheSerializerHints.ShouldNotUseDistributedCache = true;
+            cacheSerializerHints.ShouldNotUseDistributedCache = "DoNotUseDistCache";
 
             // Act
             var ex1 = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -417,9 +417,9 @@ namespace Microsoft.Identity.Web.Test
                 await _testCacheAdapter.TestRemoveKeyAsync(DefaultCacheKey, cacheSerializerHints));
 
             // Assert
-            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex1.Message);
-            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex2.Message);
-            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex3.Message);
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex1.Message + "  DoNotUseDistCache");
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex2.Message + "  DoNotUseDistCache");
+            Assert.Equal(TokenCacheErrorMessage.CannotUseDistributedCache, ex3.Message + "  DoNotUseDistCache");
             Assert.Equal(0, _testCacheAdapter._memoryCache.Count);
         }
 


### PR DESCRIPTION
This PR depends on [this MSAL PR](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5175) and should not be merged until this PR is released.

# Enabling IdWeb to throw an exception if MSAL indicates that it should not configure the distributed cache

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

IdWeb will throw an exception if MSAL `TokenCacheNotificationArgs` indicates that it should not configure the distributed cache and it is configured.

## Description

[Issue 3304](https://github.com/AzureAD/microsoft-identity-web/issues/3304)
