### PR TITLE
Implement correct metadata interface for `RequiredScopeOrAppPermission` extension method

### DIFF
--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Web
             return endpointConventionBuilder.WithMetadata(new RequiredScopeOrAppPermissionMetadata(scope, appPermission));
         }
 
-        private sealed class RequiredScopeOrAppPermissionMetadata : IAuthRequiredScopeMetadata
+        private sealed class RequiredScopeOrAppPermissionMetadata : IAuthRequiredScopeOrAppPermissionMetadata
         {
             public RequiredScopeOrAppPermissionMetadata(string[] scope, string[] appPermission)
             {
@@ -57,6 +57,7 @@ namespace Microsoft.Identity.Web
             public string[]? AcceptedAppPermission { get; }
 
             public string? RequiredScopesConfigurationKey { get; }
+            public string? RequiredAppPermissionsConfigurationKey { get; }
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopeOrAppPermissionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Resource/RequiredScopeOrAppPermissionExtensionsTests.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test.Resource
+{
+    public class RequiredScopeOrAppPermissionExtensionsTests
+    {
+        private const string PolicyName = "foo";
+        private const string AppPermission = "access_as_app";
+        private const string Scope = "user.read";
+
+        [Fact]
+        public async Task RequireScopeOrAppPermission_WithAppPermission_SucceedsAsync()
+        {
+            // Arrange
+            var authorizationService = BuildAuthorizationService(PolicyName, null, Scope);
+
+            var user = new ClaimsPrincipal(
+                new CaseSensitiveClaimsIdentity([new Claim(ClaimConstants.Role, AppPermission)]));
+
+            var testBuilder = new TestEndpointConventionBuilder()
+                .RequireScopeOrAppPermission([], [AppPermission]);
+
+            var convention = Assert.Single(testBuilder.Conventions);
+
+            var endpointModel = new RouteEndpointBuilder((context) => Task.CompletedTask, RoutePatternFactory.Parse("/"), 0);
+            convention(endpointModel);
+            var endpoint = endpointModel.Build();
+
+            // Act
+            var allowed = await authorizationService.AuthorizeAsync(user, endpoint, PolicyName);
+
+            // Assert
+            Assert.True(allowed.Succeeded);
+        }
+
+        private static IAuthorizationService BuildAuthorizationService(string policy, string? appPermission, string? scope)
+        {
+            IHostBuilder hostBuilder = Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddAuthorization(options =>
+                    {
+                        options.AddPolicy(policy, policyBuilder =>
+                        {
+                            policyBuilder.RequireScopeOrAppPermission(scope?.Split(' ')!, appPermission?.Split(' ')!);
+                        });
+                    });
+                    services.AddLogging();
+                    services.AddOptions();
+                    services.AddRequiredScopeOrAppPermissionAuthorization();
+                });
+
+            var provider = hostBuilder.Build().Services;
+            return provider.GetRequiredService<IAuthorizationService>();
+        }
+
+        private class TestEndpointConventionBuilder : IEndpointConventionBuilder
+        {
+            public List<Action<EndpointBuilder>> Conventions { get; } = [];
+
+            public void Add(Action<EndpointBuilder> convention)
+            {
+                Conventions.Add(convention);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Updates the `RequiredScopeOrAppPermissionMetadata` class to implement `IAuthRequiredScopeOrAppPermissionMetadata` rather than `IAuthRequiredScopeMetadata`. This makes it conform to the type that the `ScopeOrAppPermissionAuthorizationHandler` looks for in order to determine what scopes and app permissions to check for.

## Description

Also added a new unit test file that tests the extension method by creating an endpoint with the appropriate metadata. This test fails when you swap back to `IAuthRequiredScope`.

Fixes #3323