### PR TITLE
Reload certificates for all client credential based issues

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -812,18 +812,7 @@ namespace Microsoft.Identity.Web
         private bool IsInvalidClientCertificateOrSignedAssertionError(MsalServiceException exMsal)
         {
             return !_retryClientCertificate &&
-                string.Equals(exMsal.ErrorCode, Constants.InvalidClient, StringComparison.OrdinalIgnoreCase) &&
-#if !NETSTANDARD2_0 && !NET462 && !NET472
-                (exMsal.Message.Contains(Constants.InvalidKeyError, StringComparison.OrdinalIgnoreCase)
-                || exMsal.Message.Contains(Constants.SignedAssertionInvalidTimeRange, StringComparison.OrdinalIgnoreCase)
-                || exMsal.Message.Contains(Constants.CertificateHasBeenRevoked, StringComparison.OrdinalIgnoreCase)
-                || exMsal.Message.Contains(Constants.CertificateIsOutsideValidityWindow, StringComparison.OrdinalIgnoreCase));
-#else
-                (exMsal.Message.Contains(Constants.InvalidKeyError)
-                || exMsal.Message.Contains(Constants.SignedAssertionInvalidTimeRange)
-                || exMsal.Message.Contains(Constants.CertificateHasBeenRevoked)
-                || exMsal.Message.Contains(Constants.CertificateIsOutsideValidityWindow));
-#endif
+                string.Equals(exMsal.ErrorCode, Constants.InvalidClient, StringComparison.OrdinalIgnoreCase);
         }
 
 


### PR DESCRIPTION
# Reload certificates for all client credential based issues

- [ ] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Change retry logic to reload certificates on all credential issues, not just revocation/expiration.

## Description

The current behavior of the library is to reload and retry certificates in the event that the certificate fails for one of the following two issues:

* The certificate has been revoked.
* The certificate has expired.

There is a [great many](https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes#aadsts-error-codes) other reasons that authentication can fail that fall outside of these two scenarios. If any of those additional scenarios occur the certificate will never be reloaded.

As a result, if a bad certificate is installed on the machine and picked up, and subsequently rotated, a service restart is needed for the new certificate to be used.

Fixes #3429
