### PR TITLE
Adopting Microsoft.Identity.Abstractions 9.3.0 and using the new IAuthenticationSchemeInformationProvider interface

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!--This should be passed from the VSTS build-->
     <!-- This needs to be greater than or equal to the validation baseline version -->
-    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">3.13.0</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">3.12.1</MicrosoftIdentityWebVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MicrosoftIdentityWebVersion)</Version>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!--This should be passed from the VSTS build-->
     <!-- This needs to be greater than or equal to the validation baseline version -->
-    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">3.12.0</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">3.13.0</MicrosoftIdentityWebVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MicrosoftIdentityWebVersion)</Version>
 
@@ -87,7 +87,7 @@
     <AzureSecurityKeyVaultCertificatesVersion>4.6.0</AzureSecurityKeyVaultCertificatesVersion>
     <MicrosoftGraphVersion>4.36.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
-    <MicrosoftIdentityAbstractionsVersion>9.2.0</MicrosoftIdentityAbstractionsVersion>
+    <MicrosoftIdentityAbstractionsVersion>9.3.0</MicrosoftIdentityAbstractionsVersion>
     <!--CVE-2024-43485-->
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
     <!--CVE-2023-29331-->

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 =======
 ### Dependencies updates
 - Microsoft.IdentityModel updated to version [8.13.1](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases/tag/8.13.1).
+- Microsoft.Abstractons updated to version [9.3.0](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases/tag/9.3.).
 
 ### Bug fixes
 - Fixed an issue with instantiation of TokenAcquirerFactory when AppContext.BaseDirectory is root path. See PR [#3443](https://github.com/AzureAD/microsoft-identity-web/pull/3443) for details.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 =======
 ### Dependencies updates
 - Microsoft.IdentityModel updated to version [8.13.1](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases/tag/8.13.1).
-- Microsoft.Abstractons updated to version [9.3.0](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases/tag/9.3.).
+- Microsoft.Abstractions updated to version [9.3.0](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases/tag/9.3.) and using IAuthenticationSchemeInformationProvider from that library, deprecating the interface of the same name in Microsoft.Identity.Web (introduced in 3.12.0).
 
 ### Bug fixes
 - Fixed an issue with instantiation of TokenAcquirerFactory when AppContext.BaseDirectory is root path. See PR [#3443](https://github.com/AzureAD/microsoft-identity-web/pull/3443) for details.

--- a/src/Microsoft.Identity.Web.AgentIdentities/AgentUserIdentityMsalAddIn.cs
+++ b/src/Microsoft.Identity.Web.AgentIdentities/AgentUserIdentityMsalAddIn.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Identity.Web.AgentIdentities
                     {
                         // Get the services from the service provider.
                         ITokenAcquirerFactory tokenAcquirerFactory = serviceProvider.GetRequiredService<ITokenAcquirerFactory>();
-                        IAuthenticationSchemeInformationProvider authenticationSchemeInformationProvider =
-                            serviceProvider.GetRequiredService<IAuthenticationSchemeInformationProvider>();
+                        Abstractions.IAuthenticationSchemeInformationProvider authenticationSchemeInformationProvider =
+                            serviceProvider.GetRequiredService<Abstractions.IAuthenticationSchemeInformationProvider>();
                         IOptionsMonitor<MicrosoftIdentityApplicationOptions> optionsMonitor =
                             serviceProvider.GetRequiredService<IOptionsMonitor<MicrosoftIdentityApplicationOptions>>();
 

--- a/src/Microsoft.Identity.Web.Azure/MicrosoftIdentityTokenCredential.cs
+++ b/src/Microsoft.Identity.Web.Azure/MicrosoftIdentityTokenCredential.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Identity.Web
 	public class MicrosoftIdentityTokenCredential : TokenCredential
 	{
 		private readonly ITokenAcquirerFactory _tokenAcquirerFactory;
-        private readonly IAuthenticationSchemeInformationProvider _authenticationSchemeInformationProvider;
+        private readonly Abstractions.IAuthenticationSchemeInformationProvider _authenticationSchemeInformationProvider;
 
         /// <summary>
         /// Constructor from an ITokenAcquisition service.
         /// </summary>
         /// <param name="tokenAcquirerFactory">Token acquisition factory</param>
         /// <param name="authenticationSchemeInformationProvider">Host for the token acquisition</param>
-        public MicrosoftIdentityTokenCredential(ITokenAcquirerFactory tokenAcquirerFactory, IAuthenticationSchemeInformationProvider authenticationSchemeInformationProvider)
+        public MicrosoftIdentityTokenCredential(ITokenAcquirerFactory tokenAcquirerFactory, Abstractions.IAuthenticationSchemeInformationProvider authenticationSchemeInformationProvider)
 		{
 			_tokenAcquirerFactory = tokenAcquirerFactory ?? throw new System.ArgumentNullException(nameof(tokenAcquirerFactory));
             _authenticationSchemeInformationProvider = authenticationSchemeInformationProvider ?? throw new System.ArgumentNullException(nameof(authenticationSchemeInformationProvider));

--- a/src/Microsoft.Identity.Web.Azure/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Azure/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.MicrosoftIdentityTokenCredential
-Microsoft.Identity.Web.MicrosoftIdentityTokenCredential.MicrosoftIdentityTokenCredential(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider! authenticationSchemeInformationProvider) -> void
+Microsoft.Identity.Web.MicrosoftIdentityTokenCredential.MicrosoftIdentityTokenCredential(Microsoft.Identity.Abstractions.ITokenAcquirerFactory! tokenAcquirerFactory, Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider! authenticationSchemeInformationProvider) -> void
 Microsoft.Identity.Web.MicrosoftIdentityTokenCredential.Options.get -> Microsoft.Identity.Abstractions.AuthorizationHeaderProviderOptions!
 Microsoft.Identity.Web.ServiceCollectionExtensionForAzureCreds
 override Microsoft.Identity.Web.MicrosoftIdentityTokenCredential.GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) -> Azure.Core.AccessToken

--- a/src/Microsoft.Identity.Web.TokenAcquisition/IAuthenticationSchemeInformationProvider.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/IAuthenticationSchemeInformationProvider.cs
@@ -1,21 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Identity.Web
 {
     /// <summary>
     /// Provides information about the effective authentication scheme. If passing null
     /// or string.Empty, this returns the default authentication scheme.
     /// </summary>
-    public interface IAuthenticationSchemeInformationProvider
+    [Obsolete("This interface is obsolete and will be removed in a future version. Use Microsoft.Identity.Web.Abstractions.IAuthenticationSchemeInformationProvider instead.")]
+    public interface IAuthenticationSchemeInformationProvider : Abstractions.IAuthenticationSchemeInformationProvider
 
     {
-        /// <summary>
-        /// Get the effective authentication scheme based on the provided authentication scheme.
-        /// </summary>
-        /// <param name="authenticationScheme">intended authentication scheme.</param>
-        /// <returns>Effective authentication scheme (default authentication scheme if the intended
-        /// authentication scheme is null or an empty string.</returns>
-        string GetEffectiveAuthenticationScheme(string? authenticationScheme);
     }
 }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ITokenAcquisitionHost.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ITokenAcquisitionHost.cs
@@ -9,7 +9,7 @@ using Microsoft.IdentityModel.Tokens;
 namespace Microsoft.Identity.Web
 {
 
-    internal interface ITokenAcquisitionHost : IAuthenticationSchemeInformationProvider
+    internal interface ITokenAcquisitionHost : Abstractions.IAuthenticationSchemeInformationProvider
     {
         MergedOptions GetOptions(string? authenticationScheme, out string effectiveAuthenticationScheme);
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync
 Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider
-Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!
 Microsoft.Identity.Web.TokenAcquirerExtensions
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForTestUserAsync -> Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync?
 static Microsoft.Identity.Web.TokenAcquirerExtensions.GetFicTokenAsync(this Microsoft.Identity.Abstractions.ITokenAcquirer! tokenAcquirer, Microsoft.Identity.Abstractions.AcquireTokenOptions? options = null, string? clientAssertion = null, string! scope = "api://AzureAdTokenExchange/.default", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Abstractions.AcquireTokenResult!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync
 Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider
-Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!
 Microsoft.Identity.Web.TokenAcquirerExtensions
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForTestUserAsync -> Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync?
 static Microsoft.Identity.Web.TokenAcquirerExtensions.GetFicTokenAsync(this Microsoft.Identity.Abstractions.ITokenAcquirer! tokenAcquirer, Microsoft.Identity.Abstractions.AcquireTokenOptions? options = null, string? clientAssertion = null, string! scope = "api://AzureAdTokenExchange/.default", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Abstractions.AcquireTokenResult!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync
 Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider
-Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!
 Microsoft.Identity.Web.TokenAcquirerExtensions
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForTestUserAsync -> Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync?
 static Microsoft.Identity.Web.TokenAcquirerExtensions.GetFicTokenAsync(this Microsoft.Identity.Abstractions.ITokenAcquirer! tokenAcquirer, Microsoft.Identity.Abstractions.AcquireTokenOptions? options = null, string? clientAssertion = null, string! scope = "api://AzureAdTokenExchange/.default", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Abstractions.AcquireTokenResult!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync
 Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider
-Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!
 Microsoft.Identity.Web.TokenAcquirerExtensions
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForTestUserAsync -> Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync?
 static Microsoft.Identity.Web.TokenAcquirerExtensions.GetFicTokenAsync(this Microsoft.Identity.Abstractions.ITokenAcquirer! tokenAcquirer, Microsoft.Identity.Abstractions.AcquireTokenOptions? options = null, string? clientAssertion = null, string! scope = "api://AzureAdTokenExchange/.default", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Abstractions.AcquireTokenResult!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync
 Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider
-Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!
 Microsoft.Identity.Web.TokenAcquirerExtensions
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForTestUserAsync -> Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync?
 static Microsoft.Identity.Web.TokenAcquirerExtensions.GetFicTokenAsync(this Microsoft.Identity.Abstractions.ITokenAcquirer! tokenAcquirer, Microsoft.Identity.Abstractions.AcquireTokenOptions? options = null, string? clientAssertion = null, string! scope = "api://AzureAdTokenExchange/.default", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Abstractions.AcquireTokenResult!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync
 Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider
-Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!
 Microsoft.Identity.Web.TokenAcquirerExtensions
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForTestUserAsync -> Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync?
 static Microsoft.Identity.Web.TokenAcquirerExtensions.GetFicTokenAsync(this Microsoft.Identity.Abstractions.ITokenAcquirer! tokenAcquirer, Microsoft.Identity.Abstractions.AcquireTokenOptions? options = null, string? clientAssertion = null, string! scope = "api://AzureAdTokenExchange/.default", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Abstractions.AcquireTokenResult!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
 Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync
 Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider
-Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!
 Microsoft.Identity.Web.TokenAcquirerExtensions
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForTestUserAsync -> Microsoft.Identity.Web.BeforeTokenAcquisitionForTestUserAsync?
 static Microsoft.Identity.Web.TokenAcquirerExtensions.GetFicTokenAsync(this Microsoft.Identity.Abstractions.ITokenAcquirer! tokenAcquirer, Microsoft.Identity.Abstractions.AcquireTokenOptions? options = null, string? clientAssertion = null, string! scope = "api://AzureAdTokenExchange/.default", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Abstractions.AcquireTokenResult!>!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Web
             ServiceDescriptor? tokenAcquisitionhost = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquisitionHost));
             ServiceDescriptor? authenticationHeaderCreator = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthorizationHeaderProvider));
             ServiceDescriptor? tokenAcquirerFactory = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquirerFactory));
-            ServiceDescriptor? authSchemeInfoProvider = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthenticationSchemeInformationProvider));
+            ServiceDescriptor? authSchemeInfoProvider = services.FirstOrDefault(s => s.ServiceType == typeof(Abstractions.IAuthenticationSchemeInformationProvider));
             
             if (tokenAcquisitionService != null && tokenAcquisitionInternalService != null && 
                 tokenAcquisitionhost != null && authenticationHeaderCreator != null && authSchemeInfoProvider != null)
@@ -125,7 +125,7 @@ namespace Microsoft.Identity.Web
                 }
 #endif
                 services.AddSingleton(s => (ITokenAcquisitionInternal)s.GetRequiredService<ITokenAcquisition>());
-                services.AddSingleton<IAuthenticationSchemeInformationProvider>(sp =>
+                services.AddSingleton<Abstractions.IAuthenticationSchemeInformationProvider>(sp =>
                     sp.GetRequiredService<ITokenAcquisitionHost>());
                 services.AddSingleton<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
             }
@@ -155,7 +155,7 @@ namespace Microsoft.Identity.Web
                 }
 #endif
                 services.AddScoped(s => (ITokenAcquisitionInternal)s.GetRequiredService<ITokenAcquisition>());
-                services.AddScoped<IAuthenticationSchemeInformationProvider>(sp =>
+                services.AddScoped<Abstractions.IAuthenticationSchemeInformationProvider>(sp =>
                     sp.GetRequiredService<ITokenAcquisitionHost>());
                 services.AddScoped<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
             }

--- a/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApi/Web.config
@@ -21,6 +21,26 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Web.Diagnostics" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Abstractions" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-9.3.0.0" newVersion="9.3.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Web.TokenCache" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Web.Certificate" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Web.Certificateless" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
 			</dependentAssembly>
@@ -98,7 +118,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.73.1.0" newVersion="4.73.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.74.1.0" newVersion="4.74.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
@@ -22,6 +22,26 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Web.Diagnostics" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Abstractions" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-9.3.0.0" newVersion="9.3.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Web.TokenCache" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Web.Certificate" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Web.Certificateless" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
 			</dependentAssembly>
@@ -99,7 +119,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.73.1.0" newVersion="4.73.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.74.1.0" newVersion="4.74.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>

--- a/tests/Microsoft.Identity.Web.Test/AuthenticationSchemeInformationProviderTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AuthenticationSchemeInformationProviderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddTokenAcquisition();
 
             // Assert
-            var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthenticationSchemeInformationProvider));
+            var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(Abstractions.IAuthenticationSchemeInformationProvider));
             Assert.NotNull(descriptor);
             Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
         }
@@ -38,7 +38,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddTokenAcquisition(isTokenAcquisitionSingleton: true);
 
             // Assert
-            var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthenticationSchemeInformationProvider));
+            var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(Abstractions.IAuthenticationSchemeInformationProvider));
             Assert.NotNull(descriptor);
             Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
         }
@@ -54,7 +54,7 @@ namespace Microsoft.Identity.Web.Test
 
             // Act
             var tokenAcquisitionHost = serviceProvider.GetRequiredService<ITokenAcquisitionHost>();
-            var schemeInfoProvider = serviceProvider.GetRequiredService<IAuthenticationSchemeInformationProvider>();
+            var schemeInfoProvider = serviceProvider.GetRequiredService<Abstractions.IAuthenticationSchemeInformationProvider>();
 
             // Assert - they should be the same instance when using factory registration
             Assert.Same(tokenAcquisitionHost, schemeInfoProvider);
@@ -68,12 +68,12 @@ namespace Microsoft.Identity.Web.Test
             builder.Services.AddTokenAcquisition();  // This adds AspNetCore authentication
 
             // Act
-            var descriptor = builder.Services.FirstOrDefault(s => s.ServiceType == typeof(IAuthenticationSchemeInformationProvider));
+            var descriptor = builder.Services.FirstOrDefault(s => s.ServiceType == typeof(Abstractions.IAuthenticationSchemeInformationProvider));
             var descriptorHost = builder.Services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquisitionHost));
 
             var sp = builder.Services.BuildServiceProvider();
             ITokenAcquisitionHost host = sp.GetRequiredService<ITokenAcquisitionHost>();
-            IAuthenticationSchemeInformationProvider authSchemeProvider = sp.GetRequiredService<IAuthenticationSchemeInformationProvider>();
+            Abstractions.IAuthenticationSchemeInformationProvider authSchemeProvider = sp.GetRequiredService<Abstractions.IAuthenticationSchemeInformationProvider>();
 
             // Assert
             Assert.NotNull(host);
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddAuthentication("OpenIdConnect");
             services.AddTokenAcquisition();
             var serviceProvider = services.BuildServiceProvider();
-            var schemeInfoProvider = serviceProvider.GetRequiredService<IAuthenticationSchemeInformationProvider>();
+            var schemeInfoProvider = serviceProvider.GetRequiredService<Abstractions.IAuthenticationSchemeInformationProvider>();
 
             // Act
             var result = schemeInfoProvider.GetEffectiveAuthenticationScheme("TestScheme");
@@ -105,7 +105,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddAuthentication("OpenIdConnect");
             services.AddTokenAcquisition();
             var serviceProvider = services.BuildServiceProvider();
-            var schemeInfoProvider = serviceProvider.GetRequiredService<IAuthenticationSchemeInformationProvider>();
+            var schemeInfoProvider = serviceProvider.GetRequiredService<Abstractions.IAuthenticationSchemeInformationProvider>();
 
             // Act
             var result = schemeInfoProvider.GetEffectiveAuthenticationScheme(string.Empty);
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddAuthentication("OpenIdConnect");
             services.AddTokenAcquisition();
             var serviceProvider = services.BuildServiceProvider();
-            var schemeInfoProvider = serviceProvider.GetRequiredService<IAuthenticationSchemeInformationProvider>();
+            var schemeInfoProvider = serviceProvider.GetRequiredService<Abstractions.IAuthenticationSchemeInformationProvider>();
 
             // Act
             var result = schemeInfoProvider.GetEffectiveAuthenticationScheme(string.Empty);

--- a/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityTokenCredentialTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MicrosoftIdentityTokenCredentialTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Web.Test
     {
         private readonly ITokenAcquirer _tokenAcquirer;
         private readonly ITokenAcquirerFactory _tokenAcquirerFactory;
-        private readonly IAuthenticationSchemeInformationProvider _authenticationSchemeInformationProvider;
+        private readonly Abstractions.IAuthenticationSchemeInformationProvider _authenticationSchemeInformationProvider;
         private readonly string[] _scopes = new[] { "https://graph.microsoft.com/.default" };
         private readonly string _accessToken = "mock_access_token";
         private readonly DateTimeOffset _expiresOn = DateTimeOffset.UtcNow.AddHours(1);
@@ -40,7 +40,7 @@ namespace Microsoft.Identity.Web.Test
             // Setup mock objects
             _tokenAcquirer = Substitute.For<ITokenAcquirer>();
             _tokenAcquirerFactory = Substitute.For<ITokenAcquirerFactory>();
-            _authenticationSchemeInformationProvider = Substitute.For<IAuthenticationSchemeInformationProvider>();
+            _authenticationSchemeInformationProvider = Substitute.For<Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider>();
 
             // Configure mocks
             _authenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(Arg.Any<string>())

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionForAzureCredsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionForAzureCredsTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Web.Test
             
             // Mock the dependencies needed for MicrosoftIdentityTokenCredential
             services.AddScoped<ITokenAcquirerFactory>(sp => Substitute.For<ITokenAcquirerFactory>());
-            services.AddScoped<IAuthenticationSchemeInformationProvider>(sp => Substitute.For<IAuthenticationSchemeInformationProvider>());
+            services.AddScoped<Abstractions.IAuthenticationSchemeInformationProvider>(sp => Substitute.For<Abstractions.IAuthenticationSchemeInformationProvider>());
             
             // Act
             services.AddMicrosoftIdentityAzureTokenCredential();

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.Web.Test
                 actual =>
                 {
                     Assert.Equal(ServiceLifetime.Scoped, actual.Lifetime);
-                    Assert.Equal(typeof(IAuthenticationSchemeInformationProvider), actual.ServiceType);
+                    Assert.Equal(typeof(Abstractions.IAuthenticationSchemeInformationProvider), actual.ServiceType);
                     Assert.Null(actual.ImplementationType);
                     Assert.Null(actual.ImplementationInstance);
                     Assert.NotNull(actual.ImplementationFactory);
@@ -216,7 +216,7 @@ namespace Microsoft.Identity.Web.Test
                 actual =>
                 {
                     Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
-                    Assert.Equal(typeof(IAuthenticationSchemeInformationProvider), actual.ServiceType);
+                    Assert.Equal(typeof(Abstractions.IAuthenticationSchemeInformationProvider), actual.ServiceType);
                     Assert.Null(actual.ImplementationType);
                     Assert.Null(actual.ImplementationInstance);
                     Assert.NotNull(actual.ImplementationFactory);


### PR DESCRIPTION
# Adopting Microsoft.Identity.Abstractions 9.3.0 and using the new IAuthenticationSchemeInformationProvider interface

Replacing the use of Microsoft.Identity.Web.IAuthenticationSchemeInformationProvider by Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider from Microsoft.Identity.Abstractions 9.3.0