### PR TITLE
Support multi-tenant agent user identities

### DIFF
--- a/src/Microsoft.Identity.Web.AgentIdentities/AgentUserIdentityMsalAddIn.cs
+++ b/src/Microsoft.Identity.Web.AgentIdentities/AgentUserIdentityMsalAddIn.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Web.AgentIdentities
                         string authenticationScheme = authenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(options.AuthenticationOptionsName);
                         ITokenAcquirer tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer(authenticationScheme);
                         ITokenAcquirer agentApplicationTokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer();
-                        AcquireTokenResult aaFic = await agentApplicationTokenAcquirer.GetFicTokenAsync(new() { FmiPath = agentIdentity }); // Uses the regular client credentials
+                        AcquireTokenResult aaFic = await agentApplicationTokenAcquirer.GetFicTokenAsync(new() { Tenant = options.Tenant, FmiPath = agentIdentity }); // Uses the regular client credentials
                         string? clientAssertion = aaFic.AccessToken;
 
                         // Get the FIC token for the agent identity.
@@ -54,9 +54,9 @@ namespace Microsoft.Identity.Web.AgentIdentities
                             ClientId = agentIdentity,
                             Instance = microsoftIdentityApplicationOptions.Instance,
                             Authority = microsoftIdentityApplicationOptions.Authority,
-                            TenantId = microsoftIdentityApplicationOptions.TenantId
+                            TenantId = options.Tenant ?? microsoftIdentityApplicationOptions.TenantId
                         });
-                        AcquireTokenResult aidFic = await agentIdentityTokenAcquirer.GetFicTokenAsync(clientAssertion: clientAssertion); // Uses the agent identity
+                        AcquireTokenResult aidFic = await agentIdentityTokenAcquirer.GetFicTokenAsync(options: new() { Tenant = options.Tenant }, clientAssertion: clientAssertion); // Uses the agent identity
                         string? userFicAssertion = aidFic.AccessToken;
 
                         // Already in the request:

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -267,6 +267,7 @@ namespace Microsoft.Identity.Web
                 // If the user is not null and has claims xms-username and xms-password, perform ROPC for CCA
                 authenticationResult = await TryGetAuthenticationResultForConfidentialClientUsingRopcAsync(
                     application,
+                    tenantId,
                     scopes,
                     user,
                     mergedOptions,
@@ -338,7 +339,13 @@ namespace Microsoft.Identity.Web
         }
 
         // This method mutate the user claims to include claims uid and utid to perform the silent flow for subsequent calls.
-        private async Task<AuthenticationResult?> TryGetAuthenticationResultForConfidentialClientUsingRopcAsync(IConfidentialClientApplication application, IEnumerable<string> scopes, ClaimsPrincipal? user, MergedOptions mergedOptions, TokenAcquisitionOptions? tokenAcquisitionOptions)
+        private async Task<AuthenticationResult?> TryGetAuthenticationResultForConfidentialClientUsingRopcAsync(
+            IConfidentialClientApplication application,
+            string? tenantId,
+            IEnumerable<string> scopes,
+            ClaimsPrincipal? user,
+            MergedOptions mergedOptions,
+            TokenAcquisitionOptions? tokenAcquisitionOptions)
         {
             string? username = null;
             string? password = null;
@@ -425,6 +432,11 @@ namespace Microsoft.Identity.Web
                 if (tokenAcquisitionOptions.PoPConfiguration != null)
                 {
                     builder.WithSignedHttpRequestProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);
+                }
+
+                if (!string.IsNullOrEmpty(tenantId))
+                {
+                    builder.WithTenantId(tenantId);
                 }
             }
 


### PR DESCRIPTION
# Support multi-tenant agent user identities

## Description

Enable developers of agent apps to override the tenant Id.

Fixes #3461
