### PR TITLE
Add in a managed certificate source type

### DIFF
--- a/src/Microsoft.Identity.Web.Certificate/CertificateSource.cs
+++ b/src/Microsoft.Identity.Web.Certificate/CertificateSource.cs
@@ -37,5 +37,14 @@ namespace Microsoft.Identity.Web
         /// From the certificate store, described by its distinguished name.
         /// </summary>
         StoreWithDistinguishedName = 5,
+
+        /// <summary>
+        /// Selected via standardized logic.
+        /// </summary>
+        /// <remarks>
+        /// This functionality to currently Microsoft-Internal.
+        /// Currently, it has no meaning outside of Microsoft-Internal scenarios.
+        /// </remarks>
+        ManagedCertificate = 6,
     }
 }

--- a/src/Microsoft.Identity.Web.Certificate/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Certificate/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Identity.Web.CertificateSource.ManagedCertificate = 6 -> Microsoft.Identity.Web.CertificateSource

--- a/tests/Microsoft.Identity.Web.Test/Certificates/DefaultCertificateLoaderTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/DefaultCertificateLoaderTests.cs
@@ -110,5 +110,20 @@ namespace Microsoft.Identity.Web.Test.Certificates
             Assert.NotNull(certificateDescription.Certificate);
             Assert.True(certificateDescription.Certificate.HasPrivateKey);
         }
+
+        [Fact]
+        public void TestDefaultCertificateLoader_Unsupported()
+        {
+            CertificateDescription certificateDescription = new()
+            {
+                // This source type exists, but is not supported.
+                SourceType = CertificateSource.ManagedCertificate,
+            };
+
+            ICertificateLoader loader = new DefaultCertificateLoader();
+            loader.LoadIfNeeded(certificateDescription);
+
+            Assert.Null(certificateDescription.Certificate);
+        }
     }
 }


### PR DESCRIPTION
# Add in a managed certificate source type

Adds a new enum member for CertificateSource. This is used by microsoft-internal processes to select the correct certificate (The overall project is called Managed Certificates, hence the name).

## Description

Adds an enum value with no default loader. This loader will need to be added via microsoft-internal nuget to function correctly.

The enum indicates that the ceritifcate must be loaded via "managed certificate", which is a new concept within Microsoft. While there are no concrete plans to bring the whole system 3P, we hope to bring some of it 3P at which point this enum will have value to those outside of Microsoft.
