### PR TITLE
Add tests and fixes for downstream api sidecar endpoint

### DIFF
--- a/src/Microsoft.Identity.Web.Sidecar/Models/DownstreamApiRequest.cs
+++ b/src/Microsoft.Identity.Web.Sidecar/Models/DownstreamApiRequest.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Abstractions;
+
+namespace Microsoft.Identity.Web.Sidecar.Models;
+
+/// <summary>
+/// Represents the inputs to the downstream API endpoint.
+/// </summary>
+public readonly struct DownstreamApiRequest
+{
+    [FromQuery]
+    public string? AgentIdentity { get; init; }
+
+    [FromQuery]
+    public string? AgentUsername { get; init; }
+
+    [FromQuery]
+    public string? Tenant { get; init; }
+}

--- a/src/Microsoft.Identity.Web.Sidecar/OpenAPI/Microsoft.Identity.Web.Sidecar.json
+++ b/src/Microsoft.Identity.Web.Sidecar/OpenAPI/Microsoft.Identity.Web.Sidecar.json
@@ -146,13 +146,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "Tenant",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DownstreamApiOptions"
+                "$ref": "#/components/schemas/DownstreamApiOptions2"
               }
             }
           }
@@ -336,6 +343,68 @@
           }
         },
         "nullable": true
+      },
+      "DownstreamApiOptions2": {
+        "type": "object",
+        "properties": {
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "serializer": {
+            "$ref": "#/components/schemas/FuncOfObjectAndHttpContent"
+          },
+          "deserializer": {
+            "$ref": "#/components/schemas/FuncOfHttpContentAndObject"
+          },
+          "acceptHeader": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "extraHeaderParameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "extraQueryParameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "baseUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "relativePath": {
+            "type": "string"
+          },
+          "httpMethod": {
+            "type": "string",
+            "default": "Get"
+          },
+          "customizeHttpRequestMessage": {
+            "$ref": "#/components/schemas/ActionOfHttpRequestMessage"
+          },
+          "acquireTokenOptions": {
+            "$ref": "#/components/schemas/AcquireTokenOptions"
+          },
+          "protocolScheme": {
+            "type": "string",
+            "default": "Bearer"
+          },
+          "requestAppToken": {
+            "type": "boolean"
+          }
+        }
       },
       "DownstreamApiResult": {
         "required": [

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -38,6 +38,7 @@
     <MicrosoftIdentityLabApiVersion>1.0.2</MicrosoftIdentityLabApiVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemTextRegularExpressions>4.3.1</SystemTextRegularExpressions>
+    <MoqVersion>4.18.4</MoqVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/tests/E2E Tests/Sidecar.Tests/DownstreamApiEndpointTests.cs
+++ b/tests/E2E Tests/Sidecar.Tests/DownstreamApiEndpointTests.cs
@@ -1,0 +1,485 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.Sidecar.Models;
+using Moq;
+using Xunit;
+
+namespace Sidecar.Tests;
+
+public class DownstreamApiEndpointTests(SidecarApiFactory factory) : IClassFixture<SidecarApiFactory>
+{
+    private readonly SidecarApiFactory _factory = factory;
+
+    [Fact]
+    public async Task DownstreamApi_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/test-api", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithValidApiButNoScopes_ReturnsBadRequest()
+    {
+        // Arrange
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                // Configure a downstream API without scopes
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.RelativePath = "/test";
+                    // Intentionally not setting Scopes
+                });
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/test-api", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("No scopes found for the API 'test-api'", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithValidApiButNoScopesInOptionsOverride_ReturnsBadRequest()
+    {
+        // Arrange
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                // Configure a downstream API without scopes
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.RelativePath = "/test";
+                    // Intentionally not setting Scopes
+                });
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        var optionsOverride = new DownstreamApiOptions
+        {
+            // Not setting Scopes
+            RelativePath = "/override"
+        };
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/test-api", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("No scopes found for the API 'test-api' or in optionsOverride", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithMicrosoftIdentityWebChallengeUserException_ReturnsUnauthorized()
+    {
+        // Arrange
+        var mockDownstreamApi = new Mock<IDownstreamApi>();
+        var msalException = new MsalUiRequiredException("AADSTS50076", "Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access.");
+        mockDownstreamApi
+            .Setup(x => x.CallApiAsync(It.IsAny<DownstreamApiOptions>(), It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<HttpContent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new MicrosoftIdentityWebChallengeUserException(msalException, ["user.read"]));
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.Scopes = ["user.read"];
+                });
+
+                services.AddSingleton(mockDownstreamApi.Object);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/test-api", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Due to a configuration change made by your administrator", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithGenericException_ReturnsInternalServerError()
+    {
+        // Arrange
+        var mockDownstreamApi = new Mock<IDownstreamApi>();
+        mockDownstreamApi
+            .Setup(x => x.CallApiAsync(It.IsAny<DownstreamApiOptions>(), It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<HttpContent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Unexpected error"));
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.Scopes = ["user.read"];
+                });
+
+                services.AddSingleton(mockDownstreamApi.Object);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/test-api", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("An unexpected error occurred", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithSuccessfulCall_ReturnsOkWithDownstreamApiResult()
+    {
+        // Arrange
+        var responseContent = "{\"result\": \"success\"}";
+        var mockResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
+        };
+
+        var mockDownstreamApi = new Mock<IDownstreamApi>();
+        mockDownstreamApi
+            .Setup(x => x.CallApiAsync(It.IsAny<DownstreamApiOptions>(), It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<HttpContent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockResponse);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.Scopes = ["user.read"];
+                });
+
+                services.AddSingleton(mockDownstreamApi.Object);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/test-api", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var result = await response.Content.ReadFromJsonAsync<DownstreamApiResult>();
+        Assert.NotNull(result);
+        Assert.Equal(200, result.StatusCode);
+        Assert.NotNull(result.Headers);
+        Assert.Equal(responseContent, result.Content);
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithEmptyResponseContent_ReturnsOkWithNullContent()
+    {
+        // Arrange
+        var mockResponse = new HttpResponseMessage(HttpStatusCode.NoContent)
+        {
+            Content = new StringContent("", Encoding.UTF8)
+        };
+        mockResponse.Content.Headers.ContentLength = 0;
+
+        var mockDownstreamApi = new Mock<IDownstreamApi>();
+        mockDownstreamApi
+            .Setup(x => x.CallApiAsync(It.IsAny<DownstreamApiOptions>(), It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<HttpContent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockResponse);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.Scopes = ["user.read"];
+                });
+
+                services.AddSingleton(mockDownstreamApi.Object);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/test-api", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var result = await response.Content.ReadFromJsonAsync<DownstreamApiResult>();
+        Assert.NotNull(result);
+        Assert.Equal(204, result.StatusCode);
+        Assert.Null(result.Content);
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithRequestBody_PassesContentCorrectly()
+    {
+        // Arrange
+        var responseContent = "{\"result\": \"success\"}";
+        var requestContent = new StringContent("{\"request\": \"value\"}", Encoding.UTF8, "application/json");
+
+        var mockResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
+        };
+
+        HttpContent? capturedContent = null;
+        var mockDownstreamApi = new Mock<IDownstreamApi>();
+        mockDownstreamApi
+            .Setup(x => x.CallApiAsync(It.IsAny<DownstreamApiOptions>(), It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<HttpContent>(), It.IsAny<CancellationToken>()))
+            .Callback<DownstreamApiOptions, System.Security.Claims.ClaimsPrincipal, HttpContent?, CancellationToken>((_, _, content, _) =>
+            {
+                capturedContent = content;
+            })
+            .ReturnsAsync(mockResponse);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.Scopes = ["user.read"];
+                });
+
+                services.AddSingleton(mockDownstreamApi.Object);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/test-api", requestContent);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equivalent(capturedContent, requestContent);
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithAgentIdentity_PassesAgentIdentityToOptions()
+    {
+        // Arrange
+        var responseContent = "{\"result\": \"success\"}";
+        var mockResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
+        };
+
+        DownstreamApiOptions? capturedOptions = null;
+        var mockDownstreamApi = new Mock<IDownstreamApi>();
+        mockDownstreamApi
+            .Setup(x => x.CallApiAsync(It.IsAny<DownstreamApiOptions>(), It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<HttpContent>(), It.IsAny<CancellationToken>()))
+            .Callback<DownstreamApiOptions, System.Security.Claims.ClaimsPrincipal, HttpContent?, CancellationToken>((options, _, _, _) =>
+            {
+                capturedOptions = options;
+            })
+            .ReturnsAsync(mockResponse);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.Scopes = ["user.read"];
+                });
+
+                services.AddSingleton(mockDownstreamApi.Object);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+        
+        var agentIdentity = "test-agent-id";
+
+        // Act
+        var response = await client.PostAsync($"/DownstreamApi/test-api?agentidentity={agentIdentity}", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.True(capturedOptions?.AcquireTokenOptions?.ExtraParameters?.Keys.Contains("IDWEB_FMI_PATH_FOR_CLIENT_ASSERTION"));
+    }
+
+    [Fact]
+    public async Task DownstreamApi_WithAgentIdentityAndUsername_PassesAgentUserIdentityToOptions()
+    {
+        // Arrange
+        var responseContent = "{\"result\": \"success\"}";
+        var mockResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
+        };
+
+        DownstreamApiOptions? capturedOptions = null;
+        var mockDownstreamApi = new Mock<IDownstreamApi>();
+        mockDownstreamApi
+            .Setup(x => x.CallApiAsync(It.IsAny<DownstreamApiOptions>(), It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<HttpContent>(), It.IsAny<CancellationToken>()))
+            .Callback<DownstreamApiOptions, System.Security.Claims.ClaimsPrincipal, HttpContent?, CancellationToken>((options, _, _, _) =>
+            {
+                capturedOptions = options;
+            })
+            .ReturnsAsync(mockResponse);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+                
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.Scopes = ["user.read"];
+                });
+
+                services.AddSingleton(mockDownstreamApi.Object);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+        
+        var agentIdentity = "test-agent-id";
+        var agentUsername = "test-user@example.com";
+
+        // Act
+        var response = await client.PostAsync($"/DownstreamApi/test-api?agentidentity={agentIdentity}&agentUsername={agentUsername}", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(capturedOptions?.AcquireTokenOptions?.ExtraParameters?.Keys.Contains("IDWEB_AGENT_IDENTITY"));
+        Assert.True(capturedOptions?.AcquireTokenOptions?.ExtraParameters?.Keys.Contains("IDWEB_USERNAME"));
+    }
+
+
+    [Fact]
+    public async Task DownstreamApi_WithTenantOverride_PassesTenantIdToOptions()
+    {
+        // Arrange
+        var responseContent = "{\"result\": \"success\"}";
+        var mockResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
+        };
+
+        string tenantOverride = Guid.NewGuid().ToString();
+
+        DownstreamApiOptions? capturedOptions = null;
+        var mockDownstreamApi = new Mock<IDownstreamApi>();
+        mockDownstreamApi
+            .Setup(x => x.CallApiAsync(It.IsAny<DownstreamApiOptions>(), It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<HttpContent>(), It.IsAny<CancellationToken>()))
+            .Callback<DownstreamApiOptions, System.Security.Claims.ClaimsPrincipal, HttpContent?, CancellationToken>((options, _, _, _) =>
+            {
+                capturedOptions = options;
+            })
+            .ReturnsAsync(mockResponse);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+
+                services.Configure<DownstreamApiOptions>("test-api", options =>
+                {
+                    options.BaseUrl = "https://api.example.com";
+                    options.Scopes = ["user.read"];
+                });
+
+                services.AddSingleton(mockDownstreamApi.Object);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        // Act
+        var response = await client.PostAsync($"/DownstreamApi/test-api?tenant={tenantOverride}", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(tenantOverride, capturedOptions?.AcquireTokenOptions?.Tenant);
+    }
+
+    [Fact] 
+    public async Task DownstreamApi_WithNonExistentApiName_ReturnsBadRequestWithProblemDetails()
+    {
+        // Arrange
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                TestAuthenticationHandler.AddAlwaysSucceedTestAuthentication(services);
+            });
+        }).CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+        // Act
+        var response = await client.PostAsync("/DownstreamApi/non-existent-api", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        // Just verify it returns 400 - that's sufficient for this test
+    }
+
+}

--- a/tests/E2E Tests/Sidecar.Tests/ModelsTests.cs
+++ b/tests/E2E Tests/Sidecar.Tests/ModelsTests.cs
@@ -181,4 +181,176 @@ public class ModelsTests
         // Assert
         Assert.Equal(token, result.Token);
     }
+
+    [Fact]
+    public void DownstreamApiResult_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var statusCode = 200;
+        var headers = new Dictionary<string, IEnumerable<string>>
+        {
+            { "Content-Type", ["application/json"] },
+            { "Cache-Control", ["no-cache", "no-store"] }
+        };
+        var content = "{\"result\": \"success\"}";
+
+        // Act
+        var result = new DownstreamApiResult(statusCode, headers, content);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+        Assert.Equal(headers, result.Headers);
+        Assert.Equal(content, result.Content);
+    }
+
+    [Fact]
+    public void DownstreamApiResult_WithNullContent_HandlesCorrectly()
+    {
+        // Arrange
+        var statusCode = 204;
+        var headers = new Dictionary<string, IEnumerable<string>>();
+
+        // Act
+        var result = new DownstreamApiResult(statusCode, headers, null);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+        Assert.Equal(headers, result.Headers);
+        Assert.Null(result.Content);
+    }
+
+    [Fact]
+    public void DownstreamApiResult_WithEmptyHeaders_HandlesCorrectly()
+    {
+        // Arrange
+        var statusCode = 200;
+        var headers = new Dictionary<string, IEnumerable<string>>();
+        var content = "test content";
+
+        // Act
+        var result = new DownstreamApiResult(statusCode, headers, content);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+        Assert.Empty(result.Headers);
+        Assert.Equal(content, result.Content);
+    }
+
+    [Fact]
+    public void DownstreamApiResult_WithComplexHeaders_HandlesCorrectly()
+    {
+        // Arrange
+        var statusCode = 201;
+        var headers = new Dictionary<string, IEnumerable<string>>
+        {
+            { "Content-Type", ["application/json; charset=utf-8"] },
+            { "Cache-Control", ["max-age=3600", "public"] },
+            { "X-Custom-Header", ["value1", "value2", "value3"] },
+            { "Location", ["https://api.example.com/resource/123"] }
+        };
+        var content = "{\"id\": 123, \"name\": \"New Resource\"}";
+
+        // Act
+        var result = new DownstreamApiResult(statusCode, headers, content);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+        Assert.Equal(4, result.Headers.Count);
+        Assert.Equal(["application/json; charset=utf-8"], result.Headers["Content-Type"]);
+        Assert.Equal(["max-age=3600", "public"], result.Headers["Cache-Control"]);
+        Assert.Equal(["value1", "value2", "value3"], result.Headers["X-Custom-Header"]);
+        Assert.Equal(["https://api.example.com/resource/123"], result.Headers["Location"]);
+        Assert.Equal(content, result.Content);
+    }
+
+    [Theory]
+    [InlineData(200)]
+    [InlineData(201)]
+    [InlineData(204)]
+    [InlineData(400)]
+    [InlineData(401)]
+    [InlineData(404)]
+    [InlineData(500)]
+    public void DownstreamApiResult_WithDifferentStatusCodes_HandlesCorrectly(int statusCode)
+    {
+        // Arrange
+        var headers = new Dictionary<string, IEnumerable<string>>();
+        var content = "test content";
+
+        // Act
+        var result = new DownstreamApiResult(statusCode, headers, content);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+    }
+
+    [Fact]
+    public void DownstreamApiResult_Equality_WorksCorrectly()
+    {
+        // Arrange
+        var headers = new Dictionary<string, IEnumerable<string>>
+        {
+            { "Content-Type", ["application/json"] }
+        };
+        var content = "test content";
+        
+        var result1 = new DownstreamApiResult(200, headers, content);
+        var result2 = new DownstreamApiResult(200, headers, content);
+        var result3 = new DownstreamApiResult(201, headers, content);
+
+        // Act & Assert
+        Assert.Equal(result1, result2);
+        Assert.NotEqual(result1, result3);
+    }
+
+    [Fact]
+    public void DownstreamApiResult_ToString_ReturnsExpectedFormat()
+    {
+        // Arrange
+        var headers = new Dictionary<string, IEnumerable<string>>
+        {
+            { "Content-Type", ["application/json"] }
+        };
+        var result = new DownstreamApiResult(200, headers, "test content");
+
+        // Act
+        var stringResult = result.ToString();
+
+        // Assert
+        Assert.Contains("DownstreamApiResult", stringResult, StringComparison.Ordinal);
+        Assert.Contains("200", stringResult, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DownstreamApiResult_WithLargeContent_HandlesCorrectly()
+    {
+        // Arrange
+        var statusCode = 200;
+        var headers = new Dictionary<string, IEnumerable<string>>();
+        var largeContent = new string('x', 10000); // 10KB of 'x' characters
+
+        // Act
+        var result = new DownstreamApiResult(statusCode, headers, largeContent);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+        Assert.Equal(largeContent, result.Content);
+        Assert.Equal(10000, result.Content?.Length);
+    }
+
+    [Fact]
+    public void DownstreamApiResult_WithSpecialCharactersInContent_HandlesCorrectly()
+    {
+        // Arrange
+        var statusCode = 200;
+        var headers = new Dictionary<string, IEnumerable<string>>();
+        var specialContent = "Content with special chars: αβγδε, 中文, 🎉, \n\r\t, \"quotes\", 'apostrophes'";
+
+        // Act
+        var result = new DownstreamApiResult(statusCode, headers, specialContent);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+        Assert.Equal(specialContent, result.Content);
+    }
 }

--- a/tests/E2E Tests/Sidecar.Tests/Sidecar.Tests.csproj
+++ b/tests/E2E Tests/Sidecar.Tests/Sidecar.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)" />
   </ItemGroup>


### PR DESCRIPTION
# Add tests and fixes for downstream api sidecar endpoint

## Description

Changes were required for the downstream api endpoint.
Options override cannot be done through body as we need to
be able to forward the body of a request sent to the service
