### PR TITLE
Add new CerticateObserverAction type: SuccessfullyUsed

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/ICertificatesObserver.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ICertificatesObserver.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Identity.Web.Experimental
         /// happens when the STS does not accept the certificate any longer.
         /// </summary>
         Deselected,
+
+        /// <summary>
+        /// The certificate was successfully used.
+        /// </summary>
+        SuccessfullyUsed,
     }
 
     /// <summary>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Identity.Web.Experimental.CerticateObserverAction.SuccessfullyUsed = 2 -> Microsoft.Identity.Web.Experimental.CerticateObserverAction

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Identity.Web.Experimental.CerticateObserverAction.SuccessfullyUsed = 2 -> Microsoft.Identity.Web.Experimental.CerticateObserverAction

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Identity.Web.Experimental.CerticateObserverAction.SuccessfullyUsed = 2 -> Microsoft.Identity.Web.Experimental.CerticateObserverAction

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Identity.Web.Experimental.CerticateObserverAction.SuccessfullyUsed = 2 -> Microsoft.Identity.Web.Experimental.CerticateObserverAction

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Identity.Web.Experimental.CerticateObserverAction.SuccessfullyUsed = 2 -> Microsoft.Identity.Web.Experimental.CerticateObserverAction

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -171,14 +171,16 @@ namespace Microsoft.Identity.Web
                     _tokenAcquisitionHost.SetSession(Constants.SpaAuthCode, result.SpaAuthCode);
                 }
 
+                NotifyCertificateSelection(mergedOptions, application, CerticateObserverAction.SuccessfullyUsed, null);
+
                 return new AcquireTokenResult(
-                result.AccessToken,
-                result.ExpiresOn,
-                result.TenantId,
-                result.IdToken,
-                result.Scopes,
-                result.CorrelationId,
-                result.TokenType);
+                    result.AccessToken,
+                    result.ExpiresOn,
+                    result.TenantId,
+                    result.IdToken,
+                    result.Scopes,
+                    result.CorrelationId,
+                    result.TokenType);
             }
             catch (MsalServiceException exMsal) when (IsInvalidClientCertificateOrSignedAssertionError(exMsal))
             {
@@ -660,7 +662,9 @@ namespace Microsoft.Identity.Web
 
             try
             {
-                return await builder.ExecuteAsync(tokenAcquisitionOptions != null ? tokenAcquisitionOptions.CancellationToken : CancellationToken.None);
+                var result = await builder.ExecuteAsync(tokenAcquisitionOptions != null ? tokenAcquisitionOptions.CancellationToken : CancellationToken.None);
+                NotifyCertificateSelection(mergedOptions, application, CerticateObserverAction.SuccessfullyUsed, null);
+                return result;
             }
             catch (MsalServiceException exMsal) when (IsInvalidClientCertificateOrSignedAssertionError(exMsal))
             {


### PR DESCRIPTION
# Add new CerticateObserverAction type: SuccessfullyUsed

Adds a new enum value for CerticateObserverAction which is used every time a certificate is successfully used.

## Description

Currently there are two enum values:

* Selected: This is fired _before_ a certificate is used for the first time, regardless of the result of that usage.
* Deselected: Fired whenever a certificate is failed to be used.

We want to be able to act on situations where a certificate is successfully used, so that we can log the usage and update Last-Known-Good. This adds a new enum value which will be used whenever the certificate is successfully used.
