### PR TITLE
Ssathe/update ts adapter

### DIFF
--- a/tests/DevApps/SidecarAdapter/typescript/src/app.ts
+++ b/tests/DevApps/SidecarAdapter/typescript/src/app.ts
@@ -1,47 +1,96 @@
 import express from 'express';
 import type { Server } from 'http';
+import type { NextFunction, Request, Response } from 'express';
+import {
+    SidecarClient,
+    SidecarRequestError,
+    type ValidateAuthorizationHeaderResult,
+} from './sidecar';
 
-interface ServerOptions {
-    port: number;
-    sidecarBaseUrl: string;
+declare module 'express-serve-static-core' {
+    interface Request {
+        sidecarValidation?: ValidateAuthorizationHeaderResult;
+    }
 }
 
-export function startServer(options: ServerOptions): Promise<Server> {
-    return new Promise((resolve, reject) => {
+export interface StartOptions {
+    port?: number;
+    sidecarBaseUrl?: string;
+}
+
+export const startServer = async ({
+    port = Number(process.env.PORT ?? '3000'),
+    sidecarBaseUrl = process.env.SIDECAR_BASE_URL ?? 'http://localhost:5178',
+}: StartOptions = {}): Promise<Server> => {
+    return new Promise((resolve) => {
         const app = express();
+        const sidecarClient = new SidecarClient({ baseUrl: sidecarBaseUrl });
 
-        // Add middleware
-        app.use(express.json());
+        app.use(async (req: Request, res: Response, next: NextFunction) => {
+            console.log('Validating request via sidecar at:', new Date().toString());
+            console.log('Request URL:', req.url);
+            console.log('Request method:', req.method);
 
-        // Health check endpoint
-        app.get('/health', (req, res) => {
-            res.json({ status: 'ok' });
-        });
-
-        // Main endpoint
-        app.get('/', (req, res) => {
-            console.log('Received request with headers:', req.headers);
-
-            // Check for authorization header
-            const authHeader = req.headers.authorization;
-            if (!authHeader || !authHeader.startsWith('Bearer ')) {
-                return res.status(401).json({ error: 'Unauthorized' });
+            const authorization = req.get('authorization');
+            if (!authorization) {
+                console.log('Missing Authorization header');
+                res.status(401).json({ error: 'Missing Authorization header' });
+                return;
             }
 
-            res.json({
-                message: 'Server is running',
-                timestamp: new Date().toISOString()
-            });
+            console.log('Authorization header present, calling sidecar...');
+            try {
+                const validation = await sidecarClient.validateAuthorizationHeader({
+                    authorizationHeader: authorization,
+                });
+
+                console.log('Sidecar validation successful');
+                req.sidecarValidation = validation;
+                next();
+            } catch (error) {
+                console.error('Sidecar validation error:', error);
+                if (error instanceof SidecarRequestError) {
+                    console.log('Returning SidecarRequestError response');
+                    res
+                        .status(error.status ?? 502)
+                        .json(error.problemDetails ?? { message: error.message });
+                    return;
+                }
+
+                console.log('Passing error to next handler');
+                next(error);
+            }
         });
 
-        const server = app.listen(options.port, () => {
-            console.log(`Server listening on port ${options.port}`);
+        app.get('/', (req: Request, res: Response) => {
+            console.log('Handling GET / request');
+            console.log('Sidecar validation:', req.sidecarValidation);
+
+            const responseData = {
+                message: 'Request authenticated via Microsoft Identity Web Sidecar',
+                protocol: req.sidecarValidation?.protocol ?? null,
+                token: req.sidecarValidation?.token ? '***redacted***' : null,
+                claims: req.sidecarValidation?.claims ?? null,
+            };
+
+            console.log('Sending response:', responseData);
+            res.json(responseData);
+        });
+
+        app.use((error: unknown, _req: Request, res: Response, _next: NextFunction) => {
+            console.error('Unhandled error serving request', error);
+            res.status(500).json({ error: 'Unexpected server error' });
+        });
+
+        const server = app.listen(port, () => {
+            console.log(
+                `Sidecar sample server listening on http://localhost:${port} (sidecar base: ${sidecarBaseUrl})`,
+            );
             resolve(server);
         });
-
-        server.on('error', (error) => {
-            console.error('Server error:', error);
-            reject(error);
-        });
     });
+};
+
+if (require.main === module) {
+    void startServer();
 }

--- a/tests/DevApps/SidecarAdapter/typescript/src/app.ts
+++ b/tests/DevApps/SidecarAdapter/typescript/src/app.ts
@@ -19,10 +19,10 @@ export interface StartOptions {
 }
 
 export const startServer = async ({
-    port = Number(process.env.PORT ?? '3000'),
+    port = Number(process.env.PORT ?? '5555'),
     sidecarBaseUrl = process.env.SIDECAR_BASE_URL ?? 'http://localhost:5178',
 }: StartOptions = {}): Promise<Server> => {
-    return new Promise((resolve) => {
+    return new Promise((resolve,reject) => {
         const app = express();
         const sidecarClient = new SidecarClient({ baseUrl: sidecarBaseUrl });
 
@@ -87,6 +87,10 @@ export const startServer = async ({
                 `Sidecar sample server listening on http://localhost:${port} (sidecar base: ${sidecarBaseUrl})`,
             );
             resolve(server);
+        });
+        server.on('error', (error) => {
+            console.error('Server error:', error);
+            reject(error);
         });
     });
 };


### PR DESCRIPTION
# Update typescript sidecar adapter to resolve express server startup issues
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [*] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [*] You've included unit or integration tests for your change, where applicable.
- [*] You've included inline docs for your change, where applicable.
- [*] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

The Typescript adapter had following issues:
1) Server startup errors: The script was saying server started on port 3000 when it wasnt. The script was just looking for a process running on port 3000 and calling it as server running which was wrong as the process could be any other service. 
2) Tests defined in sidecar.test.ts were failing due to server startup issues and wrong context. Start server used startApp function which started a server. But then while retuning the promise, the startserver function also tried starting a new server which was kind of confusing

