### PR TITLE
Restrict hosts to localhost for sidecar

### DIFF
--- a/src/Microsoft.Identity.Web.Sidecar/README.md
+++ b/src/Microsoft.Identity.Web.Sidecar/README.md
@@ -41,6 +41,8 @@ Settings are supplied via `appsettings.json`, environment variables, or any stan
 
 `AllowWebApiToBeAuthorizedByACL` will be set to true by the application. No action is required from the user to configure this.
 
+`AllowedHosts` is not used by the sidecar. It will always be `localhost` outside of development environments.
+
 *Important sections*
 
 - **AzureAd**: Standard Microsoft.Identity.Web web API registration; client credentials are optional if only delegated flows are required.

--- a/src/Microsoft.Identity.Web.Sidecar/appsettings.json
+++ b/src/Microsoft.Identity.Web.Sidecar/appsettings.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/AzureAD/microsoft-identity-web/refs/heads/master/JsonSchemas/microsoft-identity-web.json",
     /*
-The following identity settings need to be configured
-before the project can be successfully executed.
-For more info see https://aka.ms/dotnet-template-ms-identity-platform
-*/
+    The following identity settings need to be configured
+    before the project can be successfully executed.
+    For more info see https://aka.ms/dotnet-template-ms-identity-platform
+    */
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
         "TenantId": "", // f645ad92-e38d-4d1a-b510-d1b09a74a8ca
@@ -34,8 +34,7 @@ For more info see https://aka.ms/dotnet-template-ms-identity-platform
             "Default": "Information",
             "Microsoft.AspNetCore": "Warning"
         }
-    },
-    "AllowedHosts": "*"
+    }
 }
 
 

--- a/tests/E2E Tests/Sidecar.Tests/HostFilteringTests.cs
+++ b/tests/E2E Tests/Sidecar.Tests/HostFilteringTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Sidecar.Tests;
+
+public class HostFilteringTests(SidecarApiFactory factory) : IClassFixture<SidecarApiFactory>
+{
+    readonly SidecarApiFactory _factory = factory;
+    const string EnvironmentKey = "environment"; // WebHostDefaults.EnvironmentKey constant value
+
+    [Fact]
+    public async Task HostFiltering_NotApplied_In_Development()
+    {
+        // Development environment (default for factory) -> no host filtering.
+        var devFactory = _factory.WithWebHostBuilder(b => { /* Development by default */ });
+        var client = devFactory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/healthz")
+        {
+            Headers = { Host = "notlocalhost" }
+        };
+        var response = await client.SendAsync(request);
+
+        Assert.True(response.IsSuccessStatusCode, "Expected success without host filtering in Development environment.");
+    }
+
+    [Fact]
+    public async Task HostFiltering_Blocks_Disallowed_Host_In_Production()
+    {
+        // Force Production by setting environment variable before building client.
+        var prodFactory = _factory.WithWebHostBuilder(b =>
+        {
+            b.UseSetting(EnvironmentKey, Environments.Production);
+        });
+        var client = prodFactory.CreateClient(); 
+
+        // Allowed host (localhost) should succeed.
+        var okResponse = await client.GetAsync("/healthz");
+        Assert.True(okResponse.IsSuccessStatusCode, "Expected success for localhost host.");
+
+        // Disallowed host should be rejected.
+        var badRequest = new HttpRequestMessage(HttpMethod.Get, "/healthz")
+        {
+            Headers = { Host = "notlocalhost" }
+        };
+        var badResponse = await client.SendAsync(badRequest);
+
+        var content = await badResponse.Content.ReadAsStringAsync();
+
+        Assert.Contains("Invalid Hostname", content, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Equal(HttpStatusCode.BadRequest, badResponse.StatusCode);
+    }
+}


### PR DESCRIPTION
# Restrict hosts

## Description

Implemented host filtering to restrict connections to `localhost` outside of development environments. Updated
`Program.cs` to include `AddHostFiltering` and `UseHostFiltering`.

Removed `AllowedHosts` from `appsettings.json` as it is now hardcoded. Updated `README.md` to clarify this behavior.

Fixes #3580
