### PR TITLE
Add CAE claims support for FIC + Managed Identity

### DIFF
--- a/src/Microsoft.Identity.Web.Certificateless/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Certificateless/InternalAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 #nullable enable
 Microsoft.Identity.Web.ManagedIdentityClientAssertion.ManagedIdentityClientAssertion(string? managedIdentityClientId, string? tokenExchangeUrl, Microsoft.Extensions.Logging.ILogger? logger, Microsoft.Identity.Client.IMsalHttpClientFactory? testHttpClientFactory) -> void
+Microsoft.Identity.Web.TestOnly.ManagedIdentityClientAssertionTestHook
+static Microsoft.Identity.Web.TestOnly.ManagedIdentityClientAssertionTestHook.HttpClientFactoryForTests.get -> Microsoft.Identity.Client.IMsalHttpClientFactory?
+static Microsoft.Identity.Web.TestOnly.ManagedIdentityClientAssertionTestHook.HttpClientFactoryForTests.set -> void

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Web
                 managedIdentityClientId,
                 tokenExchangeUrl,
                 logger,
-                ManagedIdentityClientAssertionTestHook.HttpClientFactory)
+                ManagedIdentityClientAssertionTestHook.HttpClientFactoryForTests)
         {
         }
 

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertionTestHook.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertionTestHook.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Identity.Web.TestOnly
     /// TEST-ONLY hook so unit tests can override the HttpClient factory used by
     /// ManagedIdentityClientAssertion.
     /// </summary>
-    public static class ManagedIdentityClientAssertionTestHook
+    internal static class ManagedIdentityClientAssertionTestHook
     {
         /// <summary>
         /// Gets or sets the <see cref="IMsalHttpClientFactory"/> used by <c>ManagedIdentityClientAssertion</c> for unit testing purposes.
         /// </summary>
-        public static IMsalHttpClientFactory? HttpClientFactory { get; set; }
+        internal static IMsalHttpClientFactory? HttpClientFactoryForTests { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Web.Certificateless/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Certificateless/PublicAPI.Unshipped.txt
@@ -1,4 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.TestOnly.ManagedIdentityClientAssertionTestHook
-static Microsoft.Identity.Web.TestOnly.ManagedIdentityClientAssertionTestHook.HttpClientFactory.get -> Microsoft.Identity.Client.IMsalHttpClientFactory?
-static Microsoft.Identity.Web.TestOnly.ManagedIdentityClientAssertionTestHook.HttpClientFactory.set -> void

--- a/src/Microsoft.Identity.Web/Resource/MicrosoftIdentityIssuerValidatorFactory.cs
+++ b/src/Microsoft.Identity.Web/Resource/MicrosoftIdentityIssuerValidatorFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Identity.Web.Resource
         /// Initializes a new instance of the <see cref="MicrosoftIdentityIssuerValidatorFactory"/> class.
         /// </summary>
         /// <param name="aadIssuerValidatorOptions">Options passed-in to create the AadIssuerValidator object.</param>
-        /// <param name="httpClientFactory">HttpClientFactory.</param>
+        /// <param name="httpClientFactory">HttpClientFactoryForTests.</param>
         public MicrosoftIdentityIssuerValidatorFactory(
             IOptions<AadIssuerValidatorOptions> aadIssuerValidatorOptions,
             IHttpClientFactory httpClientFactory)

--- a/tests/Microsoft.Identity.Web.Test/FederatedIdentityCaeTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/FederatedIdentityCaeTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Web.Tests.Certificateless
             mockMiHttp.AddMockHandler(MockHttpCreator.CreateMsiTokenHandler("mi-assertion-token"));
 
             var miTestFactory = new TestManagedIdentityHttpFactory(mockMiHttp);
-            ManagedIdentityClientAssertionTestHook.HttpClientFactory = miTestFactory.Create();
+            ManagedIdentityClientAssertionTestHook.HttpClientFactoryForTests = miTestFactory.Create();
             factory.Services.AddSingleton<IManagedIdentityTestHttpClientFactory>(_ => miTestFactory);
 
             // Mock AAD token responses for client credentials


### PR DESCRIPTION
# Add CAE claims support for FIC + Managed Identity

## This change wires CAE claims all the way through Federated Identity Credentials (FIC) and Managed Identity, and adds coverage to ensure that:

- when CAE claims are present, app tokens bypass cache and are obtained from the identity provider, and
- FIC (both MSI‑based and OIDC‑based) correctly propagates FMI path / tenant and cooperates with those CAE claims.
- It also introduces a small test‑only hook so tests can fully mock the managed identity pipeline without affecting production code.

