### PR TITLE
docs: fix quickstart web API snippet typos

### DIFF
--- a/docs/getting-started/quickstart-webapi.md
+++ b/docs/getting-started/quickstart-webapi.md
@@ -58,11 +58,11 @@ dotnet add package Microsoft.Identity.Web
 ### 2. Configure authentication in `Program.cs`
 
 ```csharp
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Identity.Web;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add authentication
 // Add authentication
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddMicrosoftIdentityWebApi(builder.Configuration, "AzureAd");


### PR DESCRIPTION
Fixes #3596

Updates `docs/getting-started/quickstart-webapi.md`:
- Adds the missing `using Microsoft.AspNetCore.Authentication.JwtBearer;` so `JwtBearerDefaults.AuthenticationScheme` compiles when copied.
- Removes a duplicated comment.

Tested:
- Docs-only change
