### PR TITLE
Fix Certificate Reload Infinite Recursion Bug

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/IsInvalidClientCertificateErrorTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/IsInvalidClientCertificateErrorTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Web.Test
                 $"[Reason - The key was not found. Thumbprint of key used by client: 'ABC123']");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.True(result, "Should return true for AADSTS700027 (invalid key) error");
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web.Test
                 "AADSTS700024: Client assertion is not within its valid time range. Current time: 2024-01-15");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.True(result, "Should return true for AADSTS700024 (signed assertion time range) error");
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Web.Test
                 "AADSTS7000214: The client certificate has been revoked. Please use a valid certificate.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.True(result, "Should return true for AADSTS7000214 (certificate revoked) error");
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Web.Test
                 "AADSTS1000502: The client certificate is not within its valid time range. Ensure that the certificate is valid.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.True(result, "Should return true for AADSTS1000502 (certificate outside validity) error");
@@ -110,7 +110,7 @@ namespace Microsoft.Identity.Web.Test
                 "AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.False(result, "Should return false for AADSTS7000215 (invalid client secret) - not certificate related");
@@ -129,7 +129,7 @@ namespace Microsoft.Identity.Web.Test
                 "AADSTS700016: Application with identifier 'abc-123' was not found in the directory.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.False(result, "Should return false for AADSTS700016 (application not found) - not certificate related");
@@ -148,7 +148,7 @@ namespace Microsoft.Identity.Web.Test
                 "AADSTS7000222: The provided client secret keys are expired. Create new keys for your app in Azure Portal.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.False(result, "Should return false for AADSTS7000222 (expired client secret) - not certificate related");
@@ -167,7 +167,7 @@ namespace Microsoft.Identity.Web.Test
                 "AADSTS50011: The redirect URI specified in the request does not match the redirect URIs configured for the application.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.False(result, "Should return false for AADSTS50011 (invalid reply address) - not certificate related");
@@ -186,7 +186,7 @@ namespace Microsoft.Identity.Web.Test
                 "AADSTS50012: Invalid client credentials.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.False(result, "Should return false for AADSTS50012 (invalid client credentials) - too generic");
@@ -197,7 +197,7 @@ namespace Microsoft.Identity.Web.Test
         /// This prevents infinite retry loops.
         /// </summary>
         [Fact]
-        public void IsInvalidClientCertificateError_RetryAlreadyAttempted_ReturnsFalse()
+        public void IsInvalidClientCertificateError_RetryCountAtMax_ReturnsFalse()
         {
             // Arrange
             var exception = CreateMsalServiceException(
@@ -205,10 +205,28 @@ namespace Microsoft.Identity.Web.Test
                 $"{Constants.InvalidKeyError}: Client assertion contains an invalid signature.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: true);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 1);
 
             // Assert
-            Assert.False(result, "Should return false when retry has already been attempted to prevent infinite loops");
+            Assert.False(result, "Should return false when retry count has reached max (1) to prevent infinite loops");
+        }
+
+        /// <summary>
+        /// Test that the method returns true when retry count is below max.
+        /// </summary>
+        [Fact]
+        public void IsInvalidClientCertificateError_RetryCountBelowMax_ReturnsTrue()
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.InvalidKeyError}: Client assertion contains an invalid signature.");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
+
+            // Assert
+            Assert.True(result, "Should return true when retry count is below max");
         }
 
         /// <summary>
@@ -223,7 +241,7 @@ namespace Microsoft.Identity.Web.Test
                 "Client authentication failed.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.False(result, "Should return false for generic invalid_client error without certificate details");
@@ -242,7 +260,7 @@ namespace Microsoft.Identity.Web.Test
                 "aadsts700027: Client assertion contains an invalid signature.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.True(result, "Should match error codes case-insensitively");
@@ -260,7 +278,7 @@ namespace Microsoft.Identity.Web.Test
                 $"{Constants.InvalidKeyError}: Invalid key. {Constants.CertificateHasBeenRevoked}: Certificate revoked.");
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.True(result, "Should return true when message contains certificate-related error codes");
@@ -276,11 +294,218 @@ namespace Microsoft.Identity.Web.Test
             var exception = CreateMsalServiceException(Constants.InvalidClient, string.Empty);
 
             // Act
-            bool result = InvokeIsInvalidClientCertificateError(exception, retryAlreadyAttempted: false);
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
 
             // Assert
             Assert.False(result, "Should return false for empty error message");
         }
+
+        #region Retry Count Tests
+
+        /// <summary>
+        /// Test that retry count of 0 allows certificate reload.
+        /// </summary>
+        [Fact]
+        public void IsInvalidClientCertificateError_RetryCount0_AllowsRetry()
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.InvalidKeyError}: Invalid certificate signature");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
+
+            // Assert
+            Assert.True(result, "Should return true when retryCount is 0 (first attempt)");
+        }
+
+        /// <summary>
+        /// Test that retry count of 1 (at max) prevents further retries.
+        /// </summary>
+        [Fact]
+        public void IsInvalidClientCertificateError_RetryCount1_PreventsRetry()
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.InvalidKeyError}: Invalid certificate signature");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 1);
+
+            // Assert
+            Assert.False(result, "Should return false when retryCount is 1 (max attempts reached)");
+        }
+
+        /// <summary>
+        /// Test that retry count greater than max prevents retries.
+        /// </summary>
+        [Fact]
+        public void IsInvalidClientCertificateError_RetryCountAboveMax_PreventsRetry()
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.InvalidKeyError}: Invalid certificate signature");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: 2);
+
+            // Assert
+            Assert.False(result, "Should return false when retryCount exceeds max (safety check)");
+        }
+
+        /// <summary>
+        /// Test that retry count respects the limit even for multiple certificate error types.
+        /// </summary>
+        [Theory]
+        [InlineData(0, true)]   // First attempt - should allow retry
+        [InlineData(1, false)]  // Second attempt (max reached) - should not allow retry
+        [InlineData(2, false)]  // Beyond max - should not allow retry
+        public void IsInvalidClientCertificateError_RetryCountRespectedForAllCertErrors(int retryCount, bool expectedResult)
+        {
+            // Arrange - test with certificate revoked error
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.CertificateHasBeenRevoked}: Certificate has been revoked");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        /// <summary>
+        /// Test that non-certificate errors return false regardless of retry count.
+        /// </summary>
+        [Theory]
+        [InlineData(0)]  // First attempt
+        [InlineData(1)]  // At max
+        [InlineData(5)]  // Way beyond max
+        public void IsInvalidClientCertificateError_NonCertError_AlwaysReturnsFalse(int retryCount)
+        {
+            // Arrange - non-certificate related error
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                "AADSTS7000215: Invalid client secret provided");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount);
+
+            // Assert
+            Assert.False(result, $"Should return false for non-certificate error regardless of retryCount ({retryCount})");
+        }
+
+        /// <summary>
+        /// Test retry count behavior with signed assertion time range error.
+        /// </summary>
+        [Theory]
+        [InlineData(0, true)]
+        [InlineData(1, false)]
+        public void IsInvalidClientCertificateError_SignedAssertionError_RespectsRetryCount(int retryCount, bool expectedResult)
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.SignedAssertionInvalidTimeRange}: Signed assertion is not within valid time range");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        /// <summary>
+        /// Test retry count behavior with certificate outside validity window error.
+        /// </summary>
+        [Theory]
+        [InlineData(0, true)]
+        [InlineData(1, false)]
+        public void IsInvalidClientCertificateError_CertOutsideValidityWindow_RespectsRetryCount(int retryCount, bool expectedResult)
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.CertificateIsOutsideValidityWindow}: Certificate is not within its valid time range");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        /// <summary>
+        /// Test that negative retry count is handled gracefully (should allow retry as it's less than max).
+        /// </summary>
+        [Fact]
+        public void IsInvalidClientCertificateError_NegativeRetryCount_AllowsRetry()
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.InvalidKeyError}: Invalid certificate signature");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount: -1);
+
+            // Assert
+            Assert.True(result, "Should return true for negative retryCount (defensive programming - treats as first attempt)");
+        }
+
+        /// <summary>
+        /// Test boundary condition: retry count exactly at the maximum allowed attempts.
+        /// </summary>
+        [Fact]
+        public void IsInvalidClientCertificateError_RetryCountAtBoundary_BehavesCorrectly()
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{Constants.InvalidKeyError}: Invalid certificate signature");
+
+            // Act - Test just below max (should allow)
+            bool resultBelowMax = InvokeIsInvalidClientCertificateError(exception, retryCount: 0);
+            
+            // Act - Test at max (should not allow)
+            bool resultAtMax = InvokeIsInvalidClientCertificateError(exception, retryCount: 1);
+
+            // Assert
+            Assert.True(resultBelowMax, "Should return true when retryCount is below max (0 < 1)");
+            Assert.False(resultAtMax, "Should return false when retryCount equals max (1 >= 1)");
+        }
+
+        /// <summary>
+        /// Test that each certificate error type respects the retry limit independently.
+        /// </summary>
+        [Theory]
+        [InlineData(Constants.InvalidKeyError, 0, true)]
+        [InlineData(Constants.InvalidKeyError, 1, false)]
+        [InlineData(Constants.SignedAssertionInvalidTimeRange, 0, true)]
+        [InlineData(Constants.SignedAssertionInvalidTimeRange, 1, false)]
+        [InlineData(Constants.CertificateHasBeenRevoked, 0, true)]
+        [InlineData(Constants.CertificateHasBeenRevoked, 1, false)]
+        [InlineData(Constants.CertificateIsOutsideValidityWindow, 0, true)]
+        [InlineData(Constants.CertificateIsOutsideValidityWindow, 1, false)]
+        public void IsInvalidClientCertificateError_AllCertErrorTypes_RespectRetryLimit(
+            string errorCode, int retryCount, bool expectedResult)
+        {
+            // Arrange
+            var exception = CreateMsalServiceException(
+                Constants.InvalidClient,
+                $"{errorCode}: Certificate error occurred");
+
+            // Act
+            bool result = InvokeIsInvalidClientCertificateError(exception, retryCount);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        #endregion
 
         #region Helper Methods
 
@@ -295,10 +520,10 @@ namespace Microsoft.Identity.Web.Test
         /// <summary>
         /// Uses reflection to invoke the private IsInvalidClientCertificateOrSignedAssertionError method.
         /// </summary>
-        private static bool InvokeIsInvalidClientCertificateError(MsalServiceException exception, bool retryAlreadyAttempted)
+        private static bool InvokeIsInvalidClientCertificateError(MsalServiceException exception, int retryCount)
         {
             // Create a minimal TokenAcquisition instance for testing
-            var tokenAcquisition = TokenAcquisitionTestHelper.CreateTokenAcquisition(retryAlreadyAttempted);
+            var tokenAcquisition = TokenAcquisitionTestHelper.CreateTokenAcquisition();
 
             // Use reflection to invoke the private method
             var method = typeof(TokenAcquisition).GetMethod(
@@ -310,7 +535,7 @@ namespace Microsoft.Identity.Web.Test
                 throw new InvalidOperationException("Could not find IsInvalidClientCertificateOrSignedAssertionError method via reflection");
             }
 
-            var result = method.Invoke(tokenAcquisition, new object[] { exception });
+            var result = method.Invoke(tokenAcquisition, new object[] { exception, retryCount });
             return (bool)result!;
         }
 
@@ -323,9 +548,9 @@ namespace Microsoft.Identity.Web.Test
     internal static class TokenAcquisitionTestHelper
     {
         /// <summary>
-        /// Creates a TokenAcquisition instance with the specified retry state for testing purposes.
+        /// Creates a TokenAcquisition instance for testing purposes.
         /// </summary>
-        public static TokenAcquisition CreateTokenAcquisition(bool retryAlreadyAttempted)
+        public static TokenAcquisition CreateTokenAcquisition()
         {
             var services = new ServiceCollection();
             services.AddSingleton<IMemoryCache>(new MemoryCache(new MemoryCacheOptions()));
@@ -352,16 +577,6 @@ namespace Microsoft.Identity.Web.Test
                 serviceProvider.GetRequiredService<ILogger<TokenAcquisition>>(),
                 serviceProvider,
                 new DefaultCredentialsLoader());
-
-            // Set the _retryClientCertificate field using reflection
-            if (retryAlreadyAttempted)
-            {
-                var field = typeof(TokenAcquisition).GetField(
-                    "_retryClientCertificate",
-                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-
-                field?.SetValue(tokenAcquisition, true);
-            }
 
             return tokenAcquisition;
         }


### PR DESCRIPTION
# Fix Certificate Reload Infinite Recursion Bug
## Description
Certificate reload logic was triggering for all invalid_client errors, not just certificate-related ones. This caused unnecessary retries for unrelated authentication failures like wrong passwords or missing app registrations.
Additionally, the shared _retryClientCertificate boolean flag had thread-safety issues in concurrent scenarios.
Solution
Restored specific error checking - Only reload certificates for actual cert errors:
•	AADSTS700027 - Invalid key
•	AADSTS700024 - Invalid time range
•	AADSTS7000214 - Certificate revoked
•	AADSTS1000502 - Certificate expired Replaced shared flag with per-call counter - Each call tracks its own retry count (max 1 retry), 
preventing infinite loops and other conditions.
Fixes issues : 
#3653 and #3654
<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->
## Solution
•	Removed: `private bool _retryClientCertificate` (shared state)
•	Added: `private const int MaxCertificateRetryAttempts = 1`
•	Added `int retryCount` parameter to private overloads of:	`AddAccountToCacheFromAuthorizationCodeAsync(AuthCodeRedemptionParameters)` and `GetAuthenticationResultForUserAsync(IEnumerable<string>, string?, string?, string?, ClaimsPrincipal?, TokenAcquisitionOptions?)`
•	GetAuthenticationResultForAppAsync(string, string?, string?, TokenAcquisitionOptions?)
•	Updated `IsInvalidClientCertificateOrSignedAssertionError(MsalServiceException, int)` to check retryCount < MaxCertificateRetryAttempts
### Others
- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.


