### PR TITLE
Add validation baseline exclusions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,6 +56,12 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <PackageValidationBaselineFrameworkToIgnore Include="netcoreapp3.1" />
+    <PackageValidationBaselineFrameworkToIgnore Include="net6.0" />
+    <PackageValidationBaselineFrameworkToIgnore Include="net7.0" />
+  </ItemGroup>
+
   <PropertyGroup Label="Source Link">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Replacing validation exclusions removed in [PR #3659](https://github.com/AzureAD/microsoft-identity-web/pull/3659), these are needed to avoid packing errors when packing the GraphServiceClient project which has a different baseline validation version number from the rest of Id Web 
