### PR TITLE
Fix intermittent failures in CertificatesObserverTests

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/CertificatesObserverTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/CertificatesObserverTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -49,8 +50,12 @@ namespace Microsoft.Identity.Web.Test
                 var instance = "https://login.microsoftonline.com/";
                 var authority = instance + tenantId;
 
-                string certName = "CN=TestCert";
+                string certName = $"CN=TestCert-{Guid.NewGuid():N}";
                 cert1 = CreateAndInstallCertificate(certName);
+                
+                // Verify certificate is properly installed in store with timeout
+                await VerifyCertificateInStoreAsync(cert1, TimeSpan.FromSeconds(5));
+                
                 var description = new CredentialDescription
                 {
                     SourceType = CredentialSource.StoreWithDistinguishedName,
@@ -129,6 +134,9 @@ namespace Microsoft.Identity.Web.Test
                 // Change out the cert, so that if it reloads there will be a new one
                 RemoveCertificate(cert1);
                 cert2 = CreateAndInstallCertificate(certName);
+                
+                // Verify certificate is properly installed in store with timeout
+                await VerifyCertificateInStoreAsync(cert2, TimeSpan.FromSeconds(5));
 
                 // Rerun but it fails this time
                 mockHttpFactory.ValidCertificates.Clear();
@@ -190,6 +198,35 @@ namespace Microsoft.Identity.Web.Test
             x509Store.Close();
 
             return certWithPrivateKey;
+        }
+
+        /// <summary>
+        /// Verifies that a certificate is properly installed in the certificate store.
+        /// </summary>
+        /// <param name="certificate">The certificate to verify.</param>
+        /// <param name="timeout">Maximum time to wait for the certificate to appear in the store.</param>
+        private static async Task VerifyCertificateInStoreAsync(X509Certificate2 certificate, TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var minWaitTime = TimeSpan.FromSeconds(2); // Minimum wait to ensure store operations complete
+            
+            do
+            {
+                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+                store.Open(OpenFlags.ReadOnly);
+                
+                var foundCerts = store.Certificates.Find(X509FindType.FindByThumbprint, certificate.Thumbprint, false);
+                
+                if (foundCerts.Count > 0 && stopwatch.Elapsed >= minWaitTime)
+                {
+                    return; // Certificate found and minimum wait time elapsed
+                }
+                
+                await Task.Delay(100); // Wait 100ms before checking again
+            }
+            while (stopwatch.Elapsed < timeout);
+            
+            throw new TimeoutException($"Certificate with thumbprint {certificate.Thumbprint} was not found in the certificate store within {timeout.TotalSeconds} seconds.");
         }
 
         private class TestCertificatesObserver : ICertificatesObserver
@@ -327,7 +364,7 @@ namespace Microsoft.Identity.Web.Test
                     if (uri.StartsWith(kvp.Key, StringComparison.OrdinalIgnoreCase))
                     {
                         if (this.description.Certificate == null ||
-                            !this.ValidCertificates.Contains(this.description.Certificate))
+                            !this.ValidCertificates.Any(cert => cert.Thumbprint.Equals(this.description.Certificate.Thumbprint, StringComparison.OrdinalIgnoreCase)))
                         {
                             var errorResponse = new
                             {


### PR DESCRIPTION
This PR fixes intermittent test failures in CertificatesObserverTests.ObserverSendsCorrectEvents.

## Problem
The test was experiencing intermittent failures that were causing unreliable CI/CD pipeline results due to AADSTS700027 authentication errors.

## Root Causes Fixed

### 1. Certificate Validation Logic Issue
**Problem**: MockHttpMessageHandler was using object reference comparison for certificate validation.
**Fix**: Changed to thumbprint-based comparison using StringComparison.OrdinalIgnoreCase.

### 2. Cross-Framework Test Interference  
**Problem**: Parallel test execution across .NET frameworks caused certificate naming collisions.
**Fix**: Implemented unique certificate naming with GUID prefixes.

### 3. Certificate Store Timing Issues
**Problem**: Certificate store operations had timing inconsistencies.
**Fix**: Added robust certificate store verification with proper timing controls.

## Test Results
✅ Passes consistently across NET 8.0, 9.0, and 10.0 frameworks  
✅ Eliminated AADSTS700027 authentication errors  
✅ Resolved parallel test execution conflicts  
✅ Improved CI/CD pipeline reliability

## Files Changed
- 	ests/Microsoft.Identity.Web.Test/CertificatesObserverTests.cs - Only file modified

This PR contains only the specific fix for the certificate observer test, with no other changes.