### PR TITLE
Fixing OBO user error

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -1255,7 +1255,7 @@ namespace Microsoft.Identity.Web
                     {
                         if (addInOptions != null)
                         {
-                            await addInOptions.InvokeOnBeforeTokenAcquisitionForOnBehalfOfAsync(builder, tokenAcquisitionOptions, user!).ConfigureAwait(false);
+                            await addInOptions.InvokeOnBeforeTokenAcquisitionForOnBehalfOfAsync(builder, tokenAcquisitionOptions, userHint!).ConfigureAwait(false);
                         }
 
                         AddFmiPathForSignedAssertionIfNeeded(tokenAcquisitionOptions, builder);


### PR DESCRIPTION
This pull request introduces improvements to the handling and testing of the `OnBeforeTokenAcquisitionForOnBehalfOf` event in token acquisition scenarios, specifically ensuring that the correct `ClaimsPrincipal` is passed and its context is preserved. The most important changes are grouped below by theme.

**Token Acquisition Logic Improvement:**

* Updated the `NotifyCertificateSelection` method in `TokenAcquisition.cs` to use `userHint` instead of `user` when invoking the `OnBeforeTokenAcquisitionForOnBehalfOfAsync` event, ensuring the correct principal is used during token acquisition.

**Unit Test Enhancements:**

* In `AuthorizationHeaderProviderTests.cs`, enhanced the `LongRunningSessionForDefaultAuthProviderForUserDefaultKeyTest` by configuring the `TokenAcquisitionExtensionOptions` to subscribe to the `OnBeforeTokenAcquisitionForOnBehalfOf` event. The test now verifies that the `ClaimsPrincipal` passed to the event matches the one used in the authorization header provider and that the `BootstrapContext` is preserved.
* Refactored the test setup by moving the creation of the test `ClaimsPrincipal` and its identity earlier in the test and removing duplicate code.

**Dependency Update:**

* Added `NSubstitute.Extensions` to the test file imports, likely to support more advanced mocking scenarios in unit tests.Fixing OBO user error