### PR TITLE
Removing unnessesary Warning removal

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -437,9 +437,7 @@ namespace Microsoft.Identity.Web
                 var dict = MergeExtraQueryParameters(mergedOptions, tokenAcquisitionOptions);
                 if (dict != null)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
                     builder.WithExtraQueryParameters(dict);
-#pragma warning restore CS0618 // Type or member is obsolete
                 }
 
                 if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
@@ -646,9 +644,7 @@ namespace Microsoft.Identity.Web
 
                 if (dict != null)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
                     builder.WithExtraQueryParameters(dict);
-#pragma warning restore CS0618 // Type or member is obsolete
                 }
                 if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
                 {
@@ -1289,9 +1285,7 @@ namespace Microsoft.Identity.Web
                                 dict.Remove(subAssertionConstant);
                             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
                             builder.WithExtraQueryParameters(dict);
-#pragma warning restore CS0618 // Type or member is obsolete
                         }
                         if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
                         {
@@ -1453,9 +1447,7 @@ namespace Microsoft.Identity.Web
 
                 if (dict != null)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
                     builder.WithExtraQueryParameters(dict);
-#pragma warning restore CS0618 // Type or member is obsolete
                 }
                 if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
                 {


### PR DESCRIPTION
This pull request removes unnecessary pragma warning suppressions around calls to the obsolete `WithExtraQueryParameters` method in the `TokenAcquisition.cs` file. The suppression was previously used to silence compiler warnings, but is no longer needed.

Refactoring and code cleanup:

* Removed `#pragma warning disable CS0618` and `#pragma warning restore CS0618` directives from all usages of `WithExtraQueryParameters` in the following methods: `GetAuthenticationResultForUserAsync`, `GetAuthenticationResultForAppAsync`, `NotifyCertificateSelection`, and `GetAuthenticationResultForWebAppWithAccountFr` in `TokenAcquisition.cs`. [[1]](diffhunk://#diff-3600735102cf2582ea4dc8277f799690b8a8135f4971e0be919fbecd053ae2caL440-L442) [[2]](diffhunk://#diff-3600735102cf2582ea4dc8277f799690b8a8135f4971e0be919fbecd053ae2caL649-L651) [[3]](diffhunk://#diff-3600735102cf2582ea4dc8277f799690b8a8135f4971e0be919fbecd053ae2caL1292-L1294) [[4]](diffhunk://#diff-3600735102cf2582ea4dc8277f799690b8a8135f4971e0be919fbecd053ae2caL1456-L1458)Removing unnessesary Warning suppression