### PR TITLE
Make ScopeOrAppPermissionAuthorization AOT safe, set Authority at JwtBearerOptions configure phase

### DIFF
--- a/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
+++ b/src/Microsoft.Identity.Web/Policy/RequiredScopeOrAppPermissionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,8 +21,6 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="services">The services being configured.</param>
         /// <returns>Services.</returns>
-        [RequiresUnreferencedCode("Calls Microsoft.Extensions.Configuration.ConfigurationBinder.GetValue")]
-        [RequiresDynamicCode("Calls Microsoft.Extensions.Configuration.ConfigurationBinder.GetValue")]
         public static IServiceCollection AddRequiredScopeOrAppPermissionAuthorization(this IServiceCollection services)
         {
             services.AddAuthorization();

--- a/src/Microsoft.Identity.Web/Policy/ScopeOrAppPermissionAuthorizationHandler.cs
+++ b/src/Microsoft.Identity.Web/Policy/ScopeOrAppPermissionAuthorizationHandler.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -18,8 +17,6 @@ namespace Microsoft.Identity.Web
     ///  Scope or app permission authorization handler that needs to be called for a specific requirement type.
     ///  In this case, <see cref="ScopeOrAppPermissionAuthorizationRequirement"/>.
     /// </summary>
-    [RequiresUnreferencedCode("Calls Microsoft.Extensions.Configuration.ConfigurationBinder.GetValue")]
-    [RequiresDynamicCode("Calls Microsoft.Extensions.Configuration.ConfigurationBinder.GetValue")]
     internal class ScopeOrAppPermissionAuthorizationHandler : AuthorizationHandler<ScopeOrAppPermissionAuthorizationRequirement>
     {
         private readonly IConfiguration _configuration;
@@ -77,7 +74,7 @@ namespace Microsoft.Identity.Web
 
             if (appPermissionConfigurationKey != null)
             {
-                appPermissions = _configuration.GetValue<string>(appPermissionConfigurationKey)?.Split(' ');
+                appPermissions = _configuration[appPermissionConfigurationKey]?.Split(' ');
             }
 
             if (appPermissions is null)


### PR DESCRIPTION
The pr includes the following changes

1. Make `ScopeOrAppPermissionAuthorizationHandler` AOT safe by replacing `Configuration.GetValue` with index access.
2. Sets the `Authority`during onfigure phase of `JwtBearerOptions` so the ASP.NET's built-in JwtBearerPostConfigureOptions can create the ConfigurationManager from it