### PR TITLE
Propagate long running web API session key back to caller in user token acquisition flow

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirer.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquirer.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Identity.Web
                 ).ConfigureAwait(false);
 
             // Propagate LongRunningWebApiSessionKey (possibly auto-generated) back to the caller
-            if (tokenAcquisitionOptions is not null && effectiveOptions is not null)
+            if (tokenAcquisitionOptions is not null && effectiveOptions is not null
+                && !string.IsNullOrEmpty(effectiveOptions.LongRunningWebApiSessionKey))
             {
                 tokenAcquisitionOptions.LongRunningWebApiSessionKey = effectiveOptions.LongRunningWebApiSessionKey;
             }


### PR DESCRIPTION
When long running web API session is created with "AllocateForMe" session key, a [new](https://github.com/AzureAD/microsoft-identity-web/blob/dca1fc0404c1bfd5ae1349b77a36c4864ea9918d/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs#L1262) session key is auto-generated and set in `tokenAcquisitionOptions`. This change propagates a new session key to caller of `TokenAcquirer::GetTokenForUserAsync()` so consumer side can use this key to fetch cached token later.

Note that *CreateAuthorizationHeaderForUserAsync* scenario already [does](https://github.com/AzureAD/microsoft-identity-web/blob/dca1fc0404c1bfd5ae1349b77a36c4864ea9918d/src/Microsoft.Identity.Web.TokenAcquisition/DefaultAuthorizationHeaderProvider.cs#L185) it so no changes are needed there.