### PR TITLE
Fix initialization of ConfidentialClientApplicationOptions in MergedOptions

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using IdWebLogger = Microsoft.Extensions.Logging;
 using Microsoft.Identity.Abstractions;
 
@@ -32,10 +33,11 @@ namespace Microsoft.Identity.Web
         {
             get
             {
-                if (_confidentialClientApplicationOptions == null)
+                if (_confidentialClientApplicationOptions is null)
                 {
-                    _confidentialClientApplicationOptions = new ConfidentialClientApplicationOptions();
-                    UpdateConfidentialClientApplicationOptionsFromMergedOptions(this, _confidentialClientApplicationOptions);
+                    var options = new ConfidentialClientApplicationOptions();
+                    UpdateConfidentialClientApplicationOptionsFromMergedOptions(this, options);
+                    Interlocked.CompareExchange(ref _confidentialClientApplicationOptions, options, null);
                 }
 
                 return _confidentialClientApplicationOptions;

--- a/tests/Microsoft.Identity.Web.Test/MergedOptionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MergedOptionsTests.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Identity.Abstractions;
 using Xunit;
 
@@ -312,6 +314,40 @@ namespace Microsoft.Identity.Web.Test
             Assert.Null(options.TenantId);
             Assert.Null(options.Authority);
             Assert.Null(options.PreparedInstance);
+        }
+
+        [Fact]
+        public async Task ConfidentialClientApplicationOptions_IsThreadSafe()
+        {
+            // Arrange
+            var mergedOptions = new MergedOptions
+            {
+                ClientId = "test-client-id",
+                ClientSecret = "test-client-secret",
+                Instance = "https://login.microsoftonline.com/",
+                TenantId = "test-tenant-id",
+            };
+
+            const int threadCount = 50;
+            var barrier = new Barrier(threadCount);
+            var results = new Microsoft.Identity.Client.ConfidentialClientApplicationOptions[threadCount];
+
+            // Act
+            var tasks = Enumerable.Range(0, threadCount).Select(i => Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                results[i] = mergedOptions.ConfidentialClientApplicationOptions;
+            })).ToArray();
+            await Task.WhenAll(tasks);
+
+            // Assert
+            for (int i = 0; i < threadCount; i++)
+            {
+                Assert.NotNull(results[i]);
+                Assert.Equal("test-client-id", results[i].ClientId);
+                Assert.Equal("test-client-secret", results[i].ClientSecret);
+                Assert.Equal("test-tenant-id", results[i].TenantId);
+            }
         }
     }
 }


### PR DESCRIPTION
## ﻿Problem

The `ConfidentialClientApplicationOptions` property getter in `MergedOptions` assignes a new empty instance to the backing field, then populated it - allowing a concurrent thread to observe the partially-initialized (empty) object. This caused sporadic "MsalClientException: No ClientId was specified" errors under concurrent GraphServiceClient usage.

## Fix

Build and populate the `ConfidentialClientApplicationOptions` instance in a local variable, then atomically publish it using `Interlocked.CompareExchange` - this ensures no thread observes an unpopulated instance.