### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/evergreen.yml
+++ b/.github/workflows/evergreen.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Run evergreen action
-        uses: github/evergreen@v1
+        uses: github-community-projects/evergreen@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORGANIZATION: AzureAD


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/evergreen` | `github-community-projects/evergreen` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
