### PR TITLE
Fix CredentialsProvider DI lifetime mismatch causing startup crash in Development

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Identity.Web
             ServiceDescriptor? authenticationHeaderCreator = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthorizationHeaderProvider));
             ServiceDescriptor? tokenAcquirerFactory = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquirerFactory));
             ServiceDescriptor? authSchemeInfoProvider = services.FirstOrDefault(s => s.ServiceType == typeof(Abstractions.IAuthenticationSchemeInformationProvider));
+            ServiceDescriptor? credentialsProviderService = services.FirstOrDefault(s => s.ServiceType == typeof(ICredentialsProvider));
 
             if (tokenAcquisitionService != null && tokenAcquisitionInternalService != null &&
                 tokenAcquisitionhost != null && authenticationHeaderCreator != null && authSchemeInfoProvider != null)
@@ -87,6 +88,11 @@ namespace Microsoft.Identity.Web
                     services.Remove(tokenAcquisitionhost);
                     services.Remove(authenticationHeaderCreator);
                     services.Remove(authSchemeInfoProvider);
+
+                    if (credentialsProviderService != null)
+                    {
+                        services.Remove(credentialsProviderService);
+                    }
 
                     // To support ASP.NET Core 2.x on .NET FW. It won't use the TokenAcquirerFactory.GetDefaultInstance()
                     if (tokenAcquirerFactory != null)

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -46,11 +46,6 @@ namespace Microsoft.Identity.Web
             bool forceSdk = !services.Any(s => s.ServiceType.FullName == "Microsoft.AspNetCore.Authentication.IAuthenticationService");
 #endif
 
-            if (!HasImplementationType(services, typeof(CredentialsProvider)))
-            {
-                services.TryAddSingleton<ICredentialsProvider, CredentialsProvider>();
-            }
-
             if (!HasImplementationType(services, typeof(DefaultCertificateLoader)))
             {
                 services.TryAddSingleton<ICredentialsLoader, DefaultCertificateLoader>();
@@ -139,6 +134,10 @@ namespace Microsoft.Identity.Web
                 services.AddSingleton<Abstractions.IAuthenticationSchemeInformationProvider>(sp =>
                     sp.GetRequiredService<ITokenAcquisitionHost>());
                 services.AddSingleton<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
+                if (!HasImplementationType(services, typeof(CredentialsProvider)))
+                {
+                    services.TryAddSingleton<ICredentialsProvider, CredentialsProvider>();
+                }
             }
             else
             {
@@ -169,6 +168,10 @@ namespace Microsoft.Identity.Web
                 services.AddScoped<Abstractions.IAuthenticationSchemeInformationProvider>(sp =>
                     sp.GetRequiredService<ITokenAcquisitionHost>());
                 services.AddScoped<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
+                if (!HasImplementationType(services, typeof(CredentialsProvider)))
+                {
+                    services.TryAddScoped<ICredentialsProvider, CredentialsProvider>();
+                }
             }
 
             services.TryAddSingleton<IMergedOptionsStore, MergedOptionsStore>();


### PR DESCRIPTION
PR #3747 introduced `CredentialsProvider` and registered it as a singleton unconditionally, before the `isTokenAcquisitionSingleton` check in `services.TryAddSingleton<ICredentialsProvider, CredentialsProvider>();`

This caused two DI scope validation failures:
1. Scoped dependency consumed by singleton

`CredentialsProvider` takes an optional `ITokenAcquisitionHost` dependency, which is registered as scoped in the default ASP.NET Core path (`isTokenAcquisitionSingleton = false`). ASP.NET Core enables DI scope validation in Development mode, causing any app using `AddMicrosoftIdentityWebApi()` (or similar) to crash on startup with: `Cannot consume scoped service 'ITokenAcquisitionHost' from singleton 'ICredentialsProvider'`

This can be seen when running the `TodoListService` sample app locally, and is causing the failures in this pipeline run:
https://identitydivision.visualstudio.com/DevEx/_build/results?buildId=1622769&view=logs&j=209d31eb-74ac-5f16-8408-ec8d6b3913fc&t=9196b009-882a-5fd9-cf3b-dbb6d24a8df3&s=b49e7e65-b64b-557c-018e-3fd79c15ded6

2. Stale registration after lifetime upgrade
When `AddTokenAcquisition` is called twice with different lifetimes (e.g., `EnableTokenAcquisitionToCallDownstreamApi()` registers as scoped, then `AddOidcFic()` via `AddAgentIdentities()` re-registers as singleton), the method removes and re-registers core services to match the new lifetime. However, the stale scoped `ICredentialsProvider` was not included in this removal, so the `HasImplementationType` guard skipped the singleton re-registration. This left a scoped `ICredentialsProvider` consumed by the now-singleton `IDownstreamApi`, crashing the Sidecar and any app combining agent identities with downstream API calls with: `Cannot consume scoped service 'ICredentialsProvider' from singleton 'IDownstreamApi'`



This PR moves `ICredentialsProvider` registration into the existing `isTokenAcquisitionSingleton` conditional blocks, matching the pattern used by the other services in the method, and adds `ICredentialsProvider` to the lifetime-mismatch removal block so it is properly re-registered when the lifetime changes.