### PR TITLE
[3.x] Update Azure.Identity and related dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -170,7 +170,7 @@
     <MicrosoftExtensionsCachingMemoryVersion>6.0.2</MicrosoftExtensionsCachingMemoryVersion>
     <!-- Microsoft.Extensions.* 5.* are obsoleted -->
     <MicrosoftExtensionsHostingVersion>6.0.0</MicrosoftExtensionsHostingVersion>
-    <MicrosoftExtensionsHttpVersion>8.0.0</MicrosoftExtensionsHttpVersion>
+    <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
     <MicrosoftAspNetCoreDataProtectionVersion>6.0.0</MicrosoftAspNetCoreDataProtectionVersion>
     <SystemSecurityCryptographyPkcsVersion>7.0.2</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyXmlVersion>6.0.1</SystemSecurityCryptographyXmlVersion>
@@ -192,7 +192,7 @@
     <SystemSecurityCryptographyXmlVersion>4.7.1</SystemSecurityCryptographyXmlVersion>
     <MicrosoftExtensionsCachingMemoryVersion>2.1.0</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsHostingVersion>2.1.1</MicrosoftExtensionsHostingVersion>
-    <MicrosoftExtensionsHttpVersion>8.0.0</MicrosoftExtensionsHttpVersion>
+    <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>8.0.0</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsConfigurationBinderVersion>8.0.0</MicrosoftExtensionsConfigurationBinderVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -83,17 +83,21 @@
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>
-    <AzureIdentityVersion>1.11.4</AzureIdentityVersion>
+    <AzureIdentityVersion>1.17.2</AzureIdentityVersion>
     <AzureSecurityKeyVaultCertificatesVersion>4.6.0</AzureSecurityKeyVaultCertificatesVersion>
     <MicrosoftGraphVersion>4.36.0</MicrosoftGraphVersion>
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
     <MicrosoftIdentityAbstractionsVersion>9.3.0</MicrosoftIdentityAbstractionsVersion>
     <!--CVE-2024-43485-->
-    <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
+    <SystemTextJsonVersion>8.0.6</SystemTextJsonVersion>
     <!--CVE-2023-29331-->
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <BannedApiAnalyzersVersion>4.14.0</BannedApiAnalyzersVersion>
     <PublicApiAnalyzersVersion>4.14.0</PublicApiAnalyzersVersion>
+    <!-- Logging.Abstractions needs a separate version variable because Azure.Core 1.50.0
+         (via System.ClientModel 1.8.0) requires Logging.Abstractions >= 8.0.3, but the full
+         Microsoft.Extensions.Logging package has no 8.0.3 release (jumps from 8.0.1 to 9.0.0). -->
+    <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.3</MicrosoftExtensionsLoggingAbstractionsVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -104,9 +108,10 @@
     <MicrosoftExtensionsCachingMemoryVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsHostingVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsHostingVersion>
     <MicrosoftAspNetCoreDataProtectionVersion>$(AspNetCoreNineRuntimeVersion)</MicrosoftAspNetCoreDataProtectionVersion>
-    <SystemSecurityCryptographyPkcsVersion>$(NetNineRuntimeVersion)</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyXmlVersion>$(NetNineRuntimeVersion)</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityCryptographyPkcsVersion>9.0.15</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyXmlVersion>9.0.15</SystemSecurityCryptographyXmlVersion>
     <MicrosoftExtensionsLoggingVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsConfigurationBinderVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsConfigurationBinderVersion>
     <SystemFormatsAsn1Version>$(NetNineRuntimeVersion)</SystemFormatsAsn1Version>
     <SystemTextJsonVersion>$(NetNineRuntimeVersion)</SystemTextJsonVersion>
@@ -119,9 +124,10 @@
     <MicrosoftExtensionsCachingMemoryVersion>8.0.1</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsHostingVersion>8.0.0</MicrosoftExtensionsHostingVersion>
     <MicrosoftAspNetCoreDataProtectionVersion>8.0.1</MicrosoftAspNetCoreDataProtectionVersion>
-    <SystemSecurityCryptographyPkcsVersion>8.0.0</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyXmlVersion>8.0.1</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityCryptographyPkcsVersion>8.0.1</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyXmlVersion>8.0.3</SystemSecurityCryptographyXmlVersion>
     <MicrosoftExtensionsLoggingVersion>8.0.0</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.3</MicrosoftExtensionsLoggingAbstractionsVersion>
     <SystemTextEncodingsWebVersion>8.0.0</SystemTextEncodingsWebVersion>
     <MicrosoftExtensionsConfigurationBinderVersion>8.0.0</MicrosoftExtensionsConfigurationBinderVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>8.0.0</MicrosoftExtensionsDependencyInjectionVersion>
@@ -149,7 +155,7 @@
     <MicrosoftAspNetCoreDataProtectionVersion>6.0.0</MicrosoftAspNetCoreDataProtectionVersion>
     <SystemSecurityCryptographyXmlVersion>6.0.1</SystemSecurityCryptographyXmlVersion>
     <!--CVE-2023-29331-->
-    <SystemFormatsAsn1Version>6.0.1</SystemFormatsAsn1Version>
+    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <!--CVE-2023-29331-->
     <SystemSecurityCryptographyPkcsVersion>6.0.4</SystemSecurityCryptographyPkcsVersion>
     <!-- CVE-2022-34716 due to DataProtection 5.0.8 -->
@@ -164,7 +170,7 @@
     <MicrosoftExtensionsCachingMemoryVersion>6.0.2</MicrosoftExtensionsCachingMemoryVersion>
     <!-- Microsoft.Extensions.* 5.* are obsoleted -->
     <MicrosoftExtensionsHostingVersion>6.0.0</MicrosoftExtensionsHostingVersion>
-    <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
+    <MicrosoftExtensionsHttpVersion>8.0.0</MicrosoftExtensionsHttpVersion>
     <MicrosoftAspNetCoreDataProtectionVersion>6.0.0</MicrosoftAspNetCoreDataProtectionVersion>
     <SystemSecurityCryptographyPkcsVersion>7.0.2</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyXmlVersion>6.0.1</SystemSecurityCryptographyXmlVersion>
@@ -175,9 +181,8 @@
     <!-- 6.0.0 as 5.x are deprecated -->
     <MicrosoftExtensionsLoggingVersion>6.0.0</MicrosoftExtensionsLoggingVersion>
 
-    <!-- Microsoft.Extensions.Configuration.Binder 6.* are obsoleted -->
-    <MicrosoftExtensionsConfigurationBinderVersion>6.0.0</MicrosoftExtensionsConfigurationBinderVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>2.1.0</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsConfigurationBinderVersion>8.0.0</MicrosoftExtensionsConfigurationBinderVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>8.0.0</MicrosoftExtensionsDependencyInjectionVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
@@ -185,13 +190,12 @@
     <!-- CVE-2022-34716 due to DataProtection 2.1.0 -->
     <SystemSecurityCryptographyPkcsVersion>7.0.2</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyXmlVersion>4.7.1</SystemSecurityCryptographyXmlVersion>
-    <MicrosoftExtensionsLoggingVersion>4.7.1</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsCachingMemoryVersion>2.1.0</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsHostingVersion>2.1.1</MicrosoftExtensionsHostingVersion>
-    <MicrosoftExtensionsHttpVersion>3.1.3</MicrosoftExtensionsHttpVersion>
+    <MicrosoftExtensionsHttpVersion>8.0.0</MicrosoftExtensionsHttpVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.0</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>2.1.0</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsConfigurationBinderVersion>2.2.4</MicrosoftExtensionsConfigurationBinderVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>8.0.0</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsConfigurationBinderVersion>8.0.0</MicrosoftExtensionsConfigurationBinderVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,7 +79,7 @@
 
   <PropertyGroup Label="Common dependency versions">
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.14.0</MicrosoftIdentityModelVersion>
-    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.76.0</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.83.1</MicrosoftIdentityClientVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>

--- a/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/KeyVaultCertificateLoader.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Identity.Web
                     ExcludeAzureDeveloperCliCredential = true,
                     ExcludeAzurePowerShellCredential = true,
                     ExcludeInteractiveBrowserCredential = true,
-                    ExcludeSharedTokenCacheCredential = true,
                     ExcludeVisualStudioCodeCredential = true,
                     ExcludeVisualStudioCredential = true
                 };

--- a/src/Microsoft.Identity.Web.Certificate/Microsoft.Identity.Web.Certificate.csproj
+++ b/src/Microsoft.Identity.Web.Certificate/Microsoft.Identity.Web.Certificate.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="$(AzureSecurityKeyVaultSecretsVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="$(AzureSecurityKeyVaultCertificatesVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Identity.Abstractions" Version="$(MicrosoftIdentityAbstractionsVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -91,6 +91,11 @@ namespace Microsoft.Identity.Web
           string message,
           bool containsPii)
         {
+            if (_logger == null)
+            {
+                return;
+            }
+
             switch (level)
             {
                 case Client.LogLevel.Always:

--- a/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
+++ b/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens " Version="$(MicrosoftIdentityModelVersion)" />
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
   </ItemGroup>

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -516,7 +516,7 @@ namespace Microsoft.Identity.Web
 
             await UpdateRequestAsync(httpRequestMessage, content, effectiveOptions, appToken, user, cancellationToken);
 
-            using HttpClient client = string.IsNullOrEmpty(serviceName) ? _httpClientFactory.CreateClient() : _httpClientFactory.CreateClient(serviceName);
+            using HttpClient client = string.IsNullOrEmpty(serviceName) ? _httpClientFactory.CreateClient() : _httpClientFactory.CreateClient(serviceName!);
 
             // Send the HTTP message           
             var downstreamApiResult = await client.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
+++ b/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs
@@ -62,10 +62,10 @@ namespace Microsoft.Identity.Web
                     configuration?.GetSection(configurationSection).Bind(option);
                 }));
 
-            string instance = configuration.GetValue<string>($"{configurationSection}:Instance");
-            string tenantId = configuration.GetValue<string>($"{configurationSection}:TenantId");
-            string clientId = configuration.GetValue<string>($"{configurationSection}:ClientId");
-            string audience = configuration.GetValue<string>($"{configurationSection}:Audience");
+            string? instance = configuration.GetValue<string>($"{configurationSection}:Instance");
+            string? tenantId = configuration.GetValue<string>($"{configurationSection}:TenantId");
+            string? clientId = configuration.GetValue<string>($"{configurationSection}:ClientId");
+            string? audience = configuration.GetValue<string>($"{configurationSection}:Audience");
             string authority = instance + tenantId + "/v2.0";
             TokenValidationParameters tokenValidationParameters = new()
             {
@@ -121,10 +121,10 @@ namespace Microsoft.Identity.Web
                     configuration?.GetSection(configurationSection).Bind(option);
                 }));
 
-            string instance = configuration.GetValue<string>($"{configurationSection}:Instance");
-            string tenantId = configuration.GetValue<string>($"{configurationSection}:TenantId");
-            string clientId = configuration.GetValue<string>($"{configurationSection}:ClientId");
-            string postLogoutRedirectUri = configuration.GetValue<string>($"{configurationSection}:SignedOutCallbackPath");
+            string? instance = configuration.GetValue<string>($"{configurationSection}:Instance");
+            string? tenantId = configuration.GetValue<string>($"{configurationSection}:TenantId");
+            string? clientId = configuration.GetValue<string>($"{configurationSection}:ClientId");
+            string? postLogoutRedirectUri = configuration.GetValue<string>($"{configurationSection}:SignedOutCallbackPath");
             string authority = instance + tenantId + "/v2.0";
 
             OpenIdConnectAuthenticationOptions options = new()

--- a/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj
+++ b/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj
@@ -23,8 +23,8 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-   <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.24" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.24" />
+   <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
     <PackageReference Include="Microsoft.Graph" Version="$(MicrosoftGraphVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="$(MicrosoftIdentityModelVersion)" />

--- a/src/Microsoft.Identity.Web.OWIN/OwinTokenAcquirerFactory.cs
+++ b/src/Microsoft.Identity.Web.OWIN/OwinTokenAcquirerFactory.cs
@@ -25,15 +25,15 @@ namespace Microsoft.Identity.Web.OWIN
         /// <returns></returns>
         protected override string DefineConfiguration(IConfigurationBuilder builder)
         {
-            _ = builder.AddInMemoryCollection(new Dictionary<string, string>()
+            _ = builder.AddInMemoryCollection(new Dictionary<string, string?>()
             {
-                ["AzureAd:Instance"] = EnsureTrailingSlash(ConfigurationManager.AppSettings["ida:Instance"] ?? ConfigurationManager.AppSettings["ida:AADInstance"] ?? "https://login.microsoftonline.com/"),
-                ["AzureAd:ClientId"] = ConfigurationManager.AppSettings["ida:ClientId"],
-                ["AzureAd:TenantId"] = ConfigurationManager.AppSettings["ida:Tenant"] ?? ConfigurationManager.AppSettings["ida:TenantId"],
-                ["AzureAd:Audience"] = ConfigurationManager.AppSettings["ida:Audience"],
-                ["AzureAd:ClientSecret"] = ConfigurationManager.AppSettings["ida:ClientSecret"],
-                ["AzureAd:SignedOutCallbackPath"] = ConfigurationManager.AppSettings["ida:PostLogoutRedirectUri"],
-                ["AzureAd:RedirectUri"] = ConfigurationManager.AppSettings["ida:RedirectUri"],
+                ["AzureAd:Instance"] = EnsureTrailingSlash(System.Configuration.ConfigurationManager.AppSettings["ida:Instance"] ?? System.Configuration.ConfigurationManager.AppSettings["ida:AADInstance"] ?? "https://login.microsoftonline.com/"),
+                ["AzureAd:ClientId"] = System.Configuration.ConfigurationManager.AppSettings["ida:ClientId"],
+                ["AzureAd:TenantId"] = System.Configuration.ConfigurationManager.AppSettings["ida:Tenant"] ?? System.Configuration.ConfigurationManager.AppSettings["ida:TenantId"],
+                ["AzureAd:Audience"] = System.Configuration.ConfigurationManager.AppSettings["ida:Audience"],
+                ["AzureAd:ClientSecret"] = System.Configuration.ConfigurationManager.AppSettings["ida:ClientSecret"],
+                ["AzureAd:SignedOutCallbackPath"] = System.Configuration.ConfigurationManager.AppSettings["ida:PostLogoutRedirectUri"],
+                ["AzureAd:RedirectUri"] = System.Configuration.ConfigurationManager.AppSettings["ida:RedirectUri"],
             });
 
             return HostingEnvironment.MapPath("~/");

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/JwtBearerOptionsMerger.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/JwtBearerOptionsMerger.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Identity.Web
         private readonly IMergedOptionsStore _mergedOptionsMonitor;
 
         public void PostConfigure(
-#if NET7_0_OR_GREATER
+#if !NET6_0
             string? name,
 #else
             string name,
-#endif            
+#endif
             JwtBearerOptions options)
         {
             MergedOptions mergedOptions = _mergedOptionsMonitor.Get(name ?? string.Empty);

--- a/src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj
@@ -26,7 +26,7 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/OptionsMergers/ConfidentialClientApplicationOptionsMerger.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/OptionsMergers/ConfidentialClientApplicationOptionsMerger.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Web
         private readonly IMergedOptionsStore _mergedOptionsMonitor;
 
         public void PostConfigure(
-#if NET7_0_OR_GREATER
+#if !NET6_0
             string? name,
 #else
             string name,

--- a/src/Microsoft.Identity.Web.TokenAcquisition/OptionsMergers/MicrosoftAuthenticationOptionsMerger.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/OptionsMergers/MicrosoftAuthenticationOptionsMerger.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Identity.Web
         private readonly IMergedOptionsStore _mergedOptionsMonitor;
 
         public void PostConfigure(
-#if NET7_0_OR_GREATER
+#if !NET6_0
             string? name,
 #else
             string name,
-#endif            
+#endif
             MicrosoftIdentityApplicationOptions options)
         {
             MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityApplicationOptions(options, _mergedOptionsMonitor.Get(name ?? string.Empty));

--- a/src/Microsoft.Identity.Web.TokenAcquisition/OptionsMergers/MicrosoftIdentityOptionsMerger.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/OptionsMergers/MicrosoftIdentityOptionsMerger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Web
         private readonly IMergedOptionsStore _mergedOptionsMonitor;
 
         public void PostConfigure(
-#if NET7_0_OR_GREATER
+#if !NET6_0
             string? name,
 #else
             string name,

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net462/InternalAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+*REMOVED*Microsoft.Identity.Web.ConfidentialClientApplicationOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Client.ConfidentialClientApplicationOptions! options) -> void
+Microsoft.Identity.Web.ConfidentialClientApplicationOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Client.ConfidentialClientApplicationOptions! options) -> void
+*REMOVED*Microsoft.Identity.Web.MicrosoftIdentityApplicationOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options) -> void
+Microsoft.Identity.Web.MicrosoftIdentityApplicationOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options) -> void
+*REMOVED*Microsoft.Identity.Web.MicrosoftIdentityOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Web.MicrosoftIdentityOptions! options) -> void
+Microsoft.Identity.Web.MicrosoftIdentityOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Web.MicrosoftIdentityOptions! options) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/net472/InternalAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+*REMOVED*Microsoft.Identity.Web.ConfidentialClientApplicationOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Client.ConfidentialClientApplicationOptions! options) -> void
+Microsoft.Identity.Web.ConfidentialClientApplicationOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Client.ConfidentialClientApplicationOptions! options) -> void
+*REMOVED*Microsoft.Identity.Web.MicrosoftIdentityApplicationOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options) -> void
+Microsoft.Identity.Web.MicrosoftIdentityApplicationOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options) -> void
+*REMOVED*Microsoft.Identity.Web.MicrosoftIdentityOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Web.MicrosoftIdentityOptions! options) -> void
+Microsoft.Identity.Web.MicrosoftIdentityOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Web.MicrosoftIdentityOptions! options) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+*REMOVED*Microsoft.Identity.Web.ConfidentialClientApplicationOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Client.ConfidentialClientApplicationOptions! options) -> void
+Microsoft.Identity.Web.ConfidentialClientApplicationOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Client.ConfidentialClientApplicationOptions! options) -> void
+*REMOVED*Microsoft.Identity.Web.MicrosoftIdentityApplicationOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options) -> void
+Microsoft.Identity.Web.MicrosoftIdentityApplicationOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions! options) -> void
+*REMOVED*Microsoft.Identity.Web.MicrosoftIdentityOptionsMerger.PostConfigure(string! name, Microsoft.Identity.Web.MicrosoftIdentityOptions! options) -> void
+Microsoft.Identity.Web.MicrosoftIdentityOptionsMerger.PostConfigure(string? name, Microsoft.Identity.Web.MicrosoftIdentityOptions! options) -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -149,7 +149,9 @@ namespace Microsoft.Identity.Web
 
                 if (mergedOptions.ExtraQueryParameters != null)
                 {
+#pragma warning disable CS0618
                     builder.WithExtraQueryParameters((Dictionary<string, string>)mergedOptions.ExtraQueryParameters);
+#pragma warning restore CS0618
                 }
 
                 if (!string.IsNullOrEmpty(authCodeRedemptionParameters.Tenant))
@@ -417,12 +419,14 @@ namespace Microsoft.Identity.Web
                 var dict = MergeExtraQueryParameters(mergedOptions, tokenAcquisitionOptions);
                 if (dict != null)
                 {
+#pragma warning disable CS0618 // WithExtraQueryParameters is deprecated in newer MSAL but used here for backward compat
                     builder.WithExtraQueryParameters(dict);
+#pragma warning restore CS0618
                 }
 
                 if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
                 {
-                    builder.WithExtraHttpHeaders(tokenAcquisitionOptions.ExtraHeadersParameters);
+                    Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders(builder, tokenAcquisitionOptions.ExtraHeadersParameters);
                 }
                 if (tokenAcquisitionOptions.CorrelationId != null)
                 {
@@ -602,11 +606,13 @@ namespace Microsoft.Identity.Web
 
                 if (dict != null)
                 {
+#pragma warning disable CS0618 // WithExtraQueryParameters is deprecated in newer MSAL but used here for backward compat
                     builder.WithExtraQueryParameters(dict);
+#pragma warning restore CS0618
                 }
                 if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
                 {
-                    builder.WithExtraHttpHeaders(tokenAcquisitionOptions.ExtraHeadersParameters);
+                    Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders(builder, tokenAcquisitionOptions.ExtraHeadersParameters);
                 }
 
                 AddExtraBodyParametersIfNeeded(tokenAcquisitionOptions, builder);
@@ -1143,11 +1149,13 @@ namespace Microsoft.Identity.Web
                                 dict.Remove(subAssertionConstant);
                             }
 
+#pragma warning disable CS0618
                             builder.WithExtraQueryParameters(dict);
+#pragma warning restore CS0618
                         }
                         if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
                         {
-                            builder.WithExtraHttpHeaders(tokenAcquisitionOptions.ExtraHeadersParameters);
+                            Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders(builder, tokenAcquisitionOptions.ExtraHeadersParameters);
                         }
                         if (tokenAcquisitionOptions.CorrelationId != null)
                         {
@@ -1300,11 +1308,13 @@ namespace Microsoft.Identity.Web
 
                 if (dict != null)
                 {
+#pragma warning disable CS0618
                     builder.WithExtraQueryParameters(dict);
+#pragma warning restore CS0618
                 }
                 if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
                 {
-                    builder.WithExtraHttpHeaders(tokenAcquisitionOptions.ExtraHeadersParameters);
+                    Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders(builder, tokenAcquisitionOptions.ExtraHeadersParameters);
                 }
                 if (tokenAcquisitionOptions.CorrelationId != null)
                 {


### PR DESCRIPTION
This PR updates Azure.Identity to 1.17.2 to pick up certain fixes related to sovereign clouds. For the ID Web 4.x version, see: https://github.com/AzureAD/microsoft-identity-web/pull/3787

Unfortunately, Azure.Identity 1.17.2 pulls in Azure.Core 1.50.0, which introduces a 4-layer transitive cascade on older TFMs (netstandard2.0/net472/net462):
Azure.Identity 1.17.2 
→ Azure.Core 1.50.0 
→ System.ClientModel 1.8.0 (was 1.0.0) 
→ Logging.Abstractions ≥ 8.0.3 (NEW dependency) 
→ DI.Abstractions ≥ 8.0.2

This causes a ServiceCollection type collision (CS0433) on older TFMs: DI.Abstractions 8.0.2 defines ServiceCollection, which was previously only in the full DI package (pinned at 2.1.0 via Extensions.Http 3.1.3).

All approaches to resolve the collision result in DI ≥ 8.0.0 flowing to consumers on older TFMs. This PR takes a minimal approach: only bumping the packages strictly required by the cascade chain (DI, ConfigBinder, Configuration, Logging.Abstractions). Unlike the 4.x version, this PR leaves Extensions.Http and Caching packages at their original versions: since the 3.x branch is on a deprecation path, minimizing consumer-facing dependency changes is likely preferred over version alignment and future maintainence.

Additionally, on net6.0, System.Formats.Asn1 must be bumped from 6.0.1 to 8.0.1 because Azure.Identity 1.17.2 transitively pulls MSAL 4.83.1, which requires ≥ 8.0.1. The 3.x branch also carries net6.0 and net7.0 TFMs not present in the 4.x branch, requiring adapted conditional compilation.

Package updates and reasoning (all on netstandard2.0/net472/net462 only unless noted):
- Azure.Identity 1.11.4 to 1.17.2
  - security/behavior fix
- Extensions.DI 2.1.0 to 8.0.0
  - Align with DI.Abstractions 8.0.2
- Extensions.Configuration.Binder 2.2.4–6.0.0 to 8.0.0
  - Required by Options.ConfigurationExtensions 8.0.0
- Extensions.Configuration / .Json 3.1.0–3.1.24 to 8.0.0
  - Required by Options.ConfigurationExtensions 8.0.0 cascade (OWIN + TokenAcquisition)
- System.Text.Json (all TFMs) 8.0.5 to 8.0.6
  - Azure.Core 1.50.0 minimum
- System.Formats.Asn1 (net6.0) 6.0.1 to 8.0.1
  - MSAL 4.83.1 minimum (transitive via Azure.Identity)
- System.Security.Cryptography.Pkcs (net8.0) 8.0.0 to 8.0.1, (net9.0) 9.0.0 to 9.0.15
  - CVE fix (NU1903 promoted to error by TreatWarningsAsErrors)
- System.Security.Cryptography.Xml (net8.0) 8.0.1 to 8.0.3, (net9.0) 9.0.0 to 9.0.15
  - CVE fix
- Microsoft.Identity.Client 4.76.0 to 4.83.1
  - Fixes the same sovereign cloud issues as Azure.Identity

To accommodate these new dependency versions, a few minor changes were made to the source code:
- A new MicrosoftExtensionsLoggingAbstractionsVersion variable in Directory.Build.props:  Logging.Abstractions 8.0.3 exists but the full Logging 8.0.3 package does not
- KeyVaultCertificateLoader.cs: Removed obsolete ExcludeSharedTokenCacheCredential = true (excluded by default in 1.17.2, see: https://github.com/AzureAD/microsoft-identity-web/pull/3787#discussion_r3138270069)
- ManagedIdentityClientAssertion.cs: Added null guard for _logger, as Logging.Abstractions 8.0.3 tightened ILogger to non-nullable)
- OptionsMergers (4 files): Changed #if NET7_0_OR_GREATER to #if !NET6_0, because Options 8.0.0 requires string? on all TFMs except net6.0 (which stays on DI 6.0.0)
- OWIN files: Disambiguated ConfigurationManager (Configuration 8.0.0 adds a conflicting type), fixed nullable annotations
- DownstreamApi.cs: Null-forgiving operator for IHttpClientFactory.CreateClient (Http 8.0.0 tightens nullable types)
- TokenAcquisition.cs: Added #pragma warning disable CS0618 around 5 WithExtraQueryParameters calls (deprecated in MSAL 4.83.1, pulled transitively by Azure.Identity). Fully-qualified 4 WithExtraHttpHeaders calls 
to Extensibility namespace (moved from Advanced in newer MSAL, creating CS0121 ambiguity)

No public API changes were made, and the only internal changes (PostConfigure string! → string?)
are tracked in InternalAPI.Unshipped.txt for net472, net462, and netstandard2.0.