### PR TITLE
[3.x] Fix #3785

### DIFF
--- a/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
+++ b/src/Microsoft.Identity.Web.UI/Areas/MicrosoftIdentity/Controllers/AccountController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -112,7 +114,36 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
             {
                 oAuthChallengeProperties.Scope = scope.Split(" ");
             }
-            oAuthChallengeProperties.RedirectUri = redirectUri;
+            // Validate the redirect URI. Accept:
+            //   * Local URLs (e.g. "/path") — the common MVC pattern.
+            //   * Same-origin absolute URLs (coerced to PathAndQuery) — required because
+            //     Microsoft.Identity.Web's own MicrosoftIdentityConsentAndConditionalAccessHandler
+            //     passes NavigationManager.Uri (always absolute) for Blazor Server step-up
+            //     consent and for Razor Pages / MVC step-up. Rejecting those would break the
+            //     canonical [AuthorizeForScopes] / MsalUiRequiredException flow.
+            // Reject everything else. The post-sign-in 302 honors AuthenticationProperties.RedirectUri
+            // as-is (CookieAuthenticationHandler does not enforce IsLocalUrl), so the check must
+            // happen here. This closes the open-redirect class of bug matching the SignIn action's
+            // own IsLocalUrl gate added in PR #1219.
+            string? safeRedirect = null;
+            if (!string.IsNullOrEmpty(redirectUri))
+            {
+                if (Url.IsLocalUrl(redirectUri) && !IsPercentEncodedSlashBypass(redirectUri))
+                {
+                    safeRedirect = redirectUri;
+                }
+                else if (Uri.TryCreate(redirectUri, UriKind.Absolute, out var absolute)
+                         && IsSameOrigin(absolute, HttpContext.Request))
+                {
+                    var candidate = absolute.PathAndQuery;
+                    if (Url.IsLocalUrl(candidate) && !IsPercentEncodedSlashBypass(candidate))
+                    {
+                        safeRedirect = candidate;
+                    }
+                }
+            }
+
+            oAuthChallengeProperties.RedirectUri = safeRedirect ?? Url.Content("~/")!;
 
             return Challenge(
                 oAuthChallengeProperties,
@@ -186,5 +217,39 @@ namespace Microsoft.Identity.Web.UI.Areas.MicrosoftIdentity.Controllers
             properties.Items[Constants.Policy] = _optionsMonitor.Get(scheme).EditProfilePolicyId;
             return Challenge(properties, scheme);
         }
+
+        /// <summary>
+        /// Returns <c>true</c> when <paramref name="absolute"/> has the same origin (scheme + host + port)
+        /// as <paramref name="request"/>. Used by <c>Challenge</c> to accept same-origin absolute redirect URIs
+        /// without opening an open-redirect sink.
+        /// </summary>
+        private static bool IsSameOrigin(Uri absolute, HttpRequest request)
+        {
+            if (!string.Equals(absolute.Scheme, request.Scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!string.Equals(absolute.Host, request.Host.Host, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            int requestPort = request.Host.Port ?? (request.IsHttps ? 443 : 80);
+            return absolute.Port == requestPort;
+        }
+
+        /// <summary>
+        /// Defense-in-depth: reject paths whose first segment starts with a percent-encoded
+        /// forward or backward slash (<c>%2f</c>/<c>%5c</c>). Browsers per RFC 3986 treat these
+        /// as literal path characters, but misconfigured reverse proxies (NGINX, IIS ARR, F5)
+        /// can decode them into <c>//</c> or <c>/\</c> when rewriting the <c>Location</c>
+        /// header, reopening the protocol-relative bypass that this controller otherwise
+        /// closes. Comparison is case-insensitive because the RFC 3986 encoding is
+        /// hex-case-insensitive.
+        /// </summary>
+        private static bool IsPercentEncodedSlashBypass(string path) =>
+            path.StartsWith("/%2f", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("/%5c", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/Microsoft.Identity.Web.UI.Test/Areas/MicrosoftIdentity/Controllers/AccountControllerTests.cs
+++ b/tests/Microsoft.Identity.Web.UI.Test/Areas/MicrosoftIdentity/Controllers/AccountControllerTests.cs
@@ -102,5 +102,315 @@ namespace Microsoft.Identity.Web.UI.Test.Areas.MicrosoftIdentity.Controllers
             Assert.NotNull(authProps); // Ensure authProps is not null
             Assert.Equal("/", authProps.RedirectUri);
         }
+
+        // --- Challenge action tests (F1 regression guard) -------------------------------
+        //
+        // The Challenge action historically assigned the raw `redirectUri` query parameter
+        // to OAuthChallengeProperties.RedirectUri without any local-URL validation. Because
+        // the ASP.NET Core cookie handler follows AuthenticationProperties.RedirectUri as-is
+        // after sign-in, this allowed an open redirect / phishing chain post-Azure-AD auth.
+        // These tests pin the IsLocalUrl gate.
+
+        [Fact]
+        public void Challenge_WithLocalRedirectUri_UsesProvidedRedirectUri()
+        {
+            // Arrange: IsLocalUrl returns true for local paths (default from constructor).
+            string scheme = OpenIdConnectDefaults.AuthenticationScheme;
+            string redirectUri = "/app/home";
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri,
+                scope: "User.Read",
+                loginHint: "user@example.com",
+                domainHint: "contoso.com",
+                claims: null!,
+                policy: null!,
+                scheme: scheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal(redirectUri, challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithExternalRedirectUri_UsesDefaultRedirectUri()
+        {
+            // Arrange: simulate IUrlHelper.IsLocalUrl rejecting an external URL.
+            string scheme = OpenIdConnectDefaults.AuthenticationScheme;
+            string redirectUri = "https://attacker.example.com/harvest";
+
+            var urlHelperMock = Substitute.For<IUrlHelper>();
+            urlHelperMock.IsLocalUrl(redirectUri).Returns(false);
+            urlHelperMock.Content("~/").Returns("/");
+            _accountController.Url = urlHelperMock;
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri,
+                scope: null!,
+                loginHint: null!,
+                domainHint: null!,
+                claims: null!,
+                policy: null!,
+                scheme: scheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithNullRedirectUri_UsesDefaultRedirectUri()
+        {
+            // Arrange
+            string scheme = OpenIdConnectDefaults.AuthenticationScheme;
+
+            var urlHelperMock = Substitute.For<IUrlHelper>();
+            urlHelperMock.IsLocalUrl(Arg.Any<string>()).Returns(false);
+            urlHelperMock.Content("~/").Returns("/");
+            _accountController.Url = urlHelperMock;
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: null!,
+                scope: null!,
+                loginHint: null!,
+                domainHint: null!,
+                claims: null!,
+                policy: null!,
+                scheme: scheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithEmptyRedirectUri_UsesDefaultRedirectUri()
+        {
+            // Arrange
+            string scheme = OpenIdConnectDefaults.AuthenticationScheme;
+
+            var urlHelperMock = Substitute.For<IUrlHelper>();
+            urlHelperMock.IsLocalUrl(Arg.Any<string>()).Returns(true);
+            urlHelperMock.Content("~/").Returns("/");
+            _accountController.Url = urlHelperMock;
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: string.Empty,
+                scope: null!,
+                loginHint: null!,
+                domainHint: null!,
+                claims: null!,
+                policy: null!,
+                scheme: scheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithProtocolRelativeRedirectUri_UsesDefaultRedirectUri()
+        {
+            // Arrange
+            string scheme = OpenIdConnectDefaults.AuthenticationScheme;
+            string redirectUri = "//attacker.example.com/";
+
+            var urlHelperMock = Substitute.For<IUrlHelper>();
+            urlHelperMock.IsLocalUrl(redirectUri).Returns(false);
+            urlHelperMock.Content("~/").Returns("/");
+            _accountController.Url = urlHelperMock;
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri,
+                scope: null!,
+                loginHint: null!,
+                domainHint: null!,
+                claims: null!,
+                policy: null!,
+                scheme: scheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        // -----------------------------------------------------------------------------
+        // Challenge action — same-origin absolute URL acceptance.
+        // -----------------------------------------------------------------------------
+
+        private void ConfigureRequest(string scheme, string host, int? port)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = scheme;
+            httpContext.Request.Host = port.HasValue ? new HostString(host, port.Value) : new HostString(host);
+            _accountController.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void UseRealisticIsLocalUrl()
+        {
+            var urlHelperMock = Substitute.For<IUrlHelper>();
+            urlHelperMock.IsLocalUrl(Arg.Any<string>()).Returns(ci =>
+            {
+                string? s = ci.Arg<string>();
+                if (string.IsNullOrEmpty(s)) return false;
+                if (s[0] != '/') return false;
+                if (s.Length == 1) return true;
+                return s[1] != '/' && s[1] != '\\';
+            });
+            urlHelperMock.Content("~/").Returns("/");
+            _accountController.Url = urlHelperMock;
+        }
+
+        [Fact]
+        public void Challenge_WithSameOriginAbsoluteRedirectUri_CoercesToPathAndQuery()
+        {
+            // Arrange
+            ConfigureRequest("https", "myapp.example.com", port: null);
+            UseRealisticIsLocalUrl();
+
+            string redirectUri = "https://myapp.example.com/weather?city=Seattle";
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri,
+                scope: "User.Read",
+                loginHint: null!, domainHint: null!, claims: null!, policy: null!,
+                scheme: OpenIdConnectDefaults.AuthenticationScheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/weather?city=Seattle", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithSameOriginAbsoluteRootRedirectUri_CoercesToSlash()
+        {
+            // Arrange
+            ConfigureRequest("https", "myapp.example.com", port: null);
+            UseRealisticIsLocalUrl();
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: "https://myapp.example.com/",
+                scope: null!, loginHint: null!, domainHint: null!, claims: null!, policy: null!,
+                scheme: OpenIdConnectDefaults.AuthenticationScheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithDifferentHostAbsoluteRedirectUri_UsesDefaultRedirectUri()
+        {
+            // Arrange
+            ConfigureRequest("https", "myapp.example.com", port: null);
+            UseRealisticIsLocalUrl();
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: "https://attacker.example.com/harvest",
+                scope: null!, loginHint: null!, domainHint: null!, claims: null!, policy: null!,
+                scheme: OpenIdConnectDefaults.AuthenticationScheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithDifferentSchemeAbsoluteRedirectUri_UsesDefaultRedirectUri()
+        {
+            // Arrange
+            ConfigureRequest("https", "myapp.example.com", port: null);
+            UseRealisticIsLocalUrl();
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: "http://myapp.example.com/page",
+                scope: null!, loginHint: null!, domainHint: null!, claims: null!, policy: null!,
+                scheme: OpenIdConnectDefaults.AuthenticationScheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithDifferentPortAbsoluteRedirectUri_UsesDefaultRedirectUri()
+        {
+            // Arrange
+            ConfigureRequest("https", "myapp.example.com", port: null);
+            UseRealisticIsLocalUrl();
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: "https://myapp.example.com:1234/page",
+                scope: null!, loginHint: null!, domainHint: null!, claims: null!, policy: null!,
+                scheme: OpenIdConnectDefaults.AuthenticationScheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithSameOriginExplicitPortAbsoluteRedirectUri_CoercesToPathAndQuery()
+        {
+            // Arrange
+            ConfigureRequest("https", "localhost", port: 5001);
+            UseRealisticIsLocalUrl();
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: "https://localhost:5001/counter",
+                scope: null!, loginHint: null!, domainHint: null!, claims: null!, policy: null!,
+                scheme: OpenIdConnectDefaults.AuthenticationScheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/counter", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithSameOriginAbsoluteButProtocolRelativePathAndQuery_UsesDefaultRedirectUri()
+        {
+            // Arrange
+            ConfigureRequest("https", "victim.app", port: null);
+            UseRealisticIsLocalUrl();
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: "https://victim.app//evil.com/x",
+                scope: null!, loginHint: null!, domainHint: null!, claims: null!, policy: null!,
+                scheme: OpenIdConnectDefaults.AuthenticationScheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
+
+        [Fact]
+        public void Challenge_WithSameOriginAbsoluteButSlashBackslashPathAndQuery_UsesDefaultRedirectUri()
+        {
+            // Arrange
+            ConfigureRequest("https", "victim.app", port: null);
+            UseRealisticIsLocalUrl();
+
+            // Act
+            var result = _accountController.Challenge(
+                redirectUri: @"https://victim.app/\evil.com",
+                scope: null!, loginHint: null!, domainHint: null!, claims: null!, policy: null!,
+                scheme: OpenIdConnectDefaults.AuthenticationScheme);
+
+            // Assert
+            var challengeResult = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal("/", challengeResult.Properties!.RedirectUri);
+        }
     }
 }


### PR DESCRIPTION
More-or-less a cherry pick of https://github.com/AzureAD/microsoft-identity-web/pull/3792, only including the changes relevant for 3.x

Most of the file changes in the 4.x version were related to Blazor which 3.x does not have, so this PR only includes the changes to AccountController and its test class.