### PR TITLE
[3.x] Skip legacy B2C local-account Todo UI test in WebAppUiTests

### DIFF
--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -39,7 +39,7 @@ namespace WebAppUiTests
             _output = output;
         }
 
-        [Fact]
+        [Fact(Skip = "Legacy B2C test infrastructure (webappsapistests Key Vault / fabrikamb2c tenant) is no longer valid.")]
         [SupportedOSPlatform("windows")]
         public async Task Susi_B2C_LocalAccount_TodoAppFunctionsCorrectlyAsync()
         {


### PR DESCRIPTION
3.x version of https://github.com/AzureAD/microsoft-identity-web/pull/3778

The test is the same in both major versions, and fails due to outdated test resources rather than any code change.