### PR TITLE
Backport: Pin Microsoft.Kiota.Abstractions to 1.22.0 for GraphServiceClientBeta

### DIFF
--- a/src/Microsoft.Identity.Web.GraphServiceClientBeta/Microsoft.Identity.Web.GraphServiceClientBeta.csproj
+++ b/src/Microsoft.Identity.Web.GraphServiceClientBeta/Microsoft.Identity.Web.GraphServiceClientBeta.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph.Beta" Version="5.56.0-preview" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of the GraphServiceClient pin from #3817 to the **GraphServiceClientBeta** project on el/3v.%0A%0Amaster already has this fix (it landed via #3805 — a Copilot SWE Agent added the same one-line pin to unblock that PR's CI). On el/3v, the GraphServiceClient project was already pinned, but the Beta sibling was missed, so any CI run on el/3v (or branches off it) currently fails with:%0A%0A`%0Aerror NU1903: Warning As Error: Package 'Microsoft.Kiota.Abstractions' 1.8.4 has a known high severity vulnerability,%0Ahttps://github.com/advisories/GHSA-7j59-v9qr-6fq9%0A`%0A%0AThis PR is the trivial one-line backport that mirrors what's already on master.%0A%0Aper @cpp11nullptr's request in https://github.com/AzureAD/microsoft-identity-web/pull/3805.