### PR TITLE
First Pass Lab Migration with Lab.API 2.x (#3710)

### DIFF
--- a/benchmark/Directory.Build.props
+++ b/benchmark/Directory.Build.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Common dependency versions">
-    <MicrosoftIdentityLabApiVersion>1.0.0</MicrosoftIdentityLabApiVersion>
+    <MicrosoftIdentityLabApiVersion>2.0.0</MicrosoftIdentityLabApiVersion>
     <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
     <BenchmarkDotNetDiagnosticsWindowsVersion>0.13.12</BenchmarkDotNetDiagnosticsWindowsVersion>
 	</PropertyGroup>

--- a/benchmark/appsettings.json
+++ b/benchmark/appsettings.json
@@ -1,8 +1,8 @@
 ﻿{
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "TenantId": "msidlab4.onmicrosoft.com",
-        "ClientId": "f6b698c0-140c-448f-8155-4aa9bf77ceba",
+        "TenantId": "id4slab1.onmicrosoft.com",
+        "ClientId": "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
         "ClientCredentials": [
             {
                 "SourceType": "StoreWithDistinguishedName",

--- a/tests/DevApps/AjaxCallActionsWithDynamicConsent/appsettings.json
+++ b/tests/DevApps/AjaxCallActionsWithDynamicConsent/appsettings.json
@@ -1,9 +1,9 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
         // To call an API
         "ClientSecret": "[secret-from-portal]",
         "CallbackPath": "/signin-oidc"

--- a/tests/DevApps/ContosoWorker/appsettings.json
+++ b/tests/DevApps/ContosoWorker/appsettings.json
@@ -1,8 +1,8 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "TenantId": "msidlab4.onmicrosoft.com",
-        "ClientId": "f6b698c0-140c-448f-8155-4aa9bf77ceba",
+        "TenantId": "id4slab1.onmicrosoft.com",
+        "ClientId": "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
         "ClientCredentials": [
             {
                 "SourceType": "StoreWithDistinguishedName",

--- a/tests/DevApps/MultipleAuthSchemes/appsettings.json
+++ b/tests/DevApps/MultipleAuthSchemes/appsettings.json
@@ -12,9 +12,9 @@
     },
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
         //"ClientSecret": "",
         "ClientCertificates": [
         ],

--- a/tests/DevApps/WebAppCallsMicrosoftGraph/appsettings.json
+++ b/tests/DevApps/WebAppCallsMicrosoftGraph/appsettings.json
@@ -1,9 +1,9 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
         // To call an API
         //"EnablePiiLogging": true,
         "CallbackPath": "/signin-oidc",

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Controllers/HomeController.cs
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/Controllers/HomeController.cs
@@ -51,7 +51,7 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
             var channel = GrpcChannel.ForAddress("https://localhost:5001");
             var client = new Greeter.GreeterClient(channel);
 
-            string token = await _tokenAcquisition.GetAccessTokenForUserAsync(new string[] { "api://556d438d-2f4b-4add-9713-ede4e5f5d7da/access_as_user" }).ConfigureAwait(false);
+            string token = await _tokenAcquisition.GetAccessTokenForUserAsync(new string[] { "api://a021aff4-57ad-453a-bae8-e4192e5860f3/access_as_user" }).ConfigureAwait(false);
 
             var headers = new Metadata();
             headers.Add("Authorization", $"Bearer {token}");

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/appsettings.json
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/Client/appsettings.json
@@ -1,9 +1,9 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
         "CallbackPath": "/signin-oidc",
         "SignedOutCallbackPath ": "/signout-callback-oidc",
         "EnablePiiLogging": true,
@@ -21,23 +21,23 @@
     "DownstreamApis": {
         "TodoList": {
             // TodoListScope is the scope of the Web API you want to call.
-            "Scopes": [ "api://556d438d-2f4b-4add-9713-ede4e5f5d7da/access_as_user" ],
+            "Scopes": [ "api://a021aff4-57ad-453a-bae8-e4192e5860f3/access_as_user" ],
             "BaseUrl": "http://localhost:44350"
 
         },
         "SayHello": {
             // Scope for the web API set up w/gRPC
-            "Scopes": [ "api://556d438d-2f4b-4add-9713-ede4e5f5d7da/access_as_user" ],
+            "Scopes": [ "api://a021aff4-57ad-453a-bae8-e4192e5860f3/access_as_user" ],
             "BaseUrl": "https://localhost:5001"
         },
         "AzureFunction": {
             // Scope for the web API set up Azure function
-            "Scopes": [ "api://556d438d-2f4b-4add-9713-ede4e5f5d7da/access_as_user" ],
+            "Scopes": [ "api://a021aff4-57ad-453a-bae8-e4192e5860f3/access_as_user" ],
             "BaseUrl": "http://localhost:7071/api/SampleFunc"
         },
         "TodoListJwe": {
             // Scope for the web API used with the token decryption certificates.
-            "Scopes": [ "api://556d438d-2f4b-4add-9713-ede4e5f5d7da/access_as_user" ],
+            "Scopes": [ "api://a021aff4-57ad-453a-bae8-e4192e5860f3/access_as_user" ],
             "BaseUrl": "https://localhost:44350"
         }
     },

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/TodoListController.cs
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/TodoListService/Controllers/TodoListController.cs
@@ -16,7 +16,7 @@ using TodoListService.Models;
 
 namespace TodoListService.Controllers
 {
-    /* equivalent 
+    /* equivalent
     [Authorize(Policy = "RequiredScope(|AzureAd:Scope")]
     [Authorize(Policy = "RequiredScope(User.Read")]
     */
@@ -61,7 +61,7 @@ namespace TodoListService.Controllers
 
             await RegisterPeriodicCallbackForLongProcessing(null);
 
-            // string token1 = await _tokenAcquisition.GetAccessTokenForUserAsync(new string[] { "user.read" }, "f645ad92-e38d-4d1a-b510-d1b09a74a8ca").ConfigureAwait(false);
+            // string token1 = await _tokenAcquisition.GetAccessTokenForUserAsync(new string[] { "user.read" }, "10c419d4-4a50-45b2-aa4e-919fb84df24f").ConfigureAwait(false);
             // string token2 = await _tokenAcquisition.GetAccessTokenForUserAsync(new string[] { "user.read" }, "3ebb7dbb-24a5-4083-b60c-5a5977aabf3d").ConfigureAwait(false);
 
             await Task.FromResult(0); // fix CS1998 while the lines about the 2 tokens are commented out.
@@ -92,7 +92,7 @@ namespace TodoListService.Controllers
             Timer timer = new Timer(async (state) =>
             {
                 HttpClient httpClient = new HttpClient();
-                
+
                 var message = await httpClient.GetAsync(url); // CodeQL [SM03781] Requests are made to a sample controller on localhost
             }, null, 1000, 1000 * 60 * 1);  // Callback every minute
         }

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/TodoListService/appsettings.json
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/TodoListService/appsettings.json
@@ -1,12 +1,12 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "556d438d-2f4b-4add-9713-ede4e5f5d7da", //"712ae8d7-548a-4306-95b6-ee9117ee86f0", JWE clientID
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a021aff4-57ad-453a-bae8-e4192e5860f3", //"712ae8d7-548a-4306-95b6-ee9117ee86f0", JWE clientID
 
         // Or instead of Instance + TenantId, you can use the Authority
-        // "Authority": "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/",
+        // "Authority": "https://login.microsoftonline.com/10c419d4-4a50-45b2-aa4e-919fb84df24f/",
 
         // To exercise the signing-key issuer:
         // - uncomment the following line (Authority)

--- a/tests/DevApps/WebAppCallsWebApiCallsGraph/gRPC/appsettings.json
+++ b/tests/DevApps/WebAppCallsWebApiCallsGraph/gRPC/appsettings.json
@@ -1,9 +1,9 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "556d438d-2f4b-4add-9713-ede4e5f5d7da",
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+            "ClientId": "a021aff4-57ad-453a-bae8-e4192e5860f3",
         "ClientCertificates": [
             {
                 "SourceType": "StoreWithDistinguishedName",

--- a/tests/DevApps/aspnet-mvc/OwinWebApi/appsettings.json
+++ b/tests/DevApps/aspnet-mvc/OwinWebApi/appsettings.json
@@ -1,9 +1,9 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "556d438d-2f4b-4add-9713-ede4e5f5d7da", //"712ae8d7-548a-4306-95b6-ee9117ee86f0", JWE clientID
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a021aff4-57ad-453a-bae8-e4192e5860f3", //"712ae8d7-548a-4306-95b6-ee9117ee86f0", JWE clientID
         // "ClientSecret": "",
         "Scopes": "access_as_user",
         "EnableCacheSynchronization": false,

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/Web.config
@@ -9,10 +9,10 @@
     <add key="webpages:Enabled" value="false"/>
     <add key="ClientValidationEnabled" value="true"/>
     <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
-    <!--<add key="ida:ClientId" value="556d438d-2f4b-4add-9713-ede4e5f5d7da"/>
+	<!--<add key="ida:ClientId" value="a021aff4-57ad-453a-bae8-e4192e5860f3"/>
     <add key="ida:AADInstance" value="https://login.microsoftonline.com/"/>
-    <add key="ida:Domain" value="msidlab4.onmicrosoft.com"/>
-    <add key="ida:TenantId" value="f645ad92-e38d-4d1a-b510-d1b09a74a8ca"/>
+    <add key="ida:Domain" value="id4slab1.onmicrosoft.com"/>
+    <add key="ida:TenantId" value="10c419d4-4a50-45b2-aa4e-919fb84df24f"/>
     <add key="ida:PostLogoutRedirectUri" value="https://localhost:44386/signin-oidc"/>-->
   </appSettings>
   <system.web>

--- a/tests/DevApps/aspnet-mvc/OwinWebApp/appsettings.json
+++ b/tests/DevApps/aspnet-mvc/OwinWebApp/appsettings.json
@@ -1,9 +1,9 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+            "ClientId": "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
         "RedirectUri": "https://localhost:44386/",
         //        "ClientSecret": "",
         "EnableCacheSynchronization": false,

--- a/tests/DevApps/blazor/BlazorApp/Components/Pages/Weather.razor
+++ b/tests/DevApps/blazor/BlazorApp/Components/Pages/Weather.razor
@@ -88,7 +88,7 @@ else
         try
         {
             // Get the authorization header
-            var authorizationHeader = await authorizationHeaderProvider.CreateAuthorizationHeaderForUserAsync(["api://556d438d-2f4b-4add-9713-ede4e5f5d7da/.default"]
+                var authorizationHeader = await authorizationHeaderProvider.CreateAuthorizationHeaderForUserAsync(["api://a021aff4-57ad-453a-bae8-e4192e5860f3/.default"]
                     //claimsPrincipal: authenticationSate.User,
                     );
         }

--- a/tests/DevApps/blazor/BlazorApp/Program.cs
+++ b/tests/DevApps/blazor/BlazorApp/Program.cs
@@ -16,7 +16,7 @@ builder.Services.AddRazorComponents()
 
 builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
     .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"))
-    .EnableTokenAcquisitionToCallDownstreamApi(["api://556d438d-2f4b-4add-9713-ede4e5f5d7da/.default"])
+    .EnableTokenAcquisitionToCallDownstreamApi(["api://a021aff4-57ad-453a-bae8-e4192e5860f3/.default"])
     .AddInMemoryTokenCaches();
 
 builder.Services.AddMicrosoftIdentityConsentHandler();

--- a/tests/DevApps/blazor/BlazorApp/appsettings.json
+++ b/tests/DevApps/blazor/BlazorApp/appsettings.json
@@ -2,9 +2,9 @@
     "$schema": "https://raw.githubusercontent.com/AzureAD/microsoft-identity-web/refs/heads/master/JsonSchemas/microsoft-identity-web.json",
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
         "CallbackPath": "/signin-oidc",
         "SignedOutCallbackPath ": "/signout-callback-oidc",
         "EnablePiiLogging": true,

--- a/tests/DevApps/blazorserver-calls-api/Client/appsettings.json
+++ b/tests/DevApps/blazorserver-calls-api/Client/appsettings.json
@@ -1,9 +1,9 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
         "ClientCertificates": [
             {
                 "SourceType": "StoreWithDistinguishedName",
@@ -20,7 +20,7 @@
       - a scope corresponding to a V1 application (for instance <GUID>/user_impersonation, where  <GUID> is the
         clientId of a V1 application, created in the https://portal.azure.com portal.
     */
-        "Scopes": [ "api://556d438d-2f4b-4add-9713-ede4e5f5d7da/access_as_user" ],
+        "Scopes": [ "api://a021aff4-57ad-453a-bae8-e4192e5860f3/access_as_user" ],
         "BaseUrl": "https://localhost:44351",
         "RelativePath": "/api/todolist"
 

--- a/tests/DevApps/blazorserver-calls-api/Service/appsettings.json
+++ b/tests/DevApps/blazorserver-calls-api/Service/appsettings.json
@@ -1,9 +1,9 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "556d438d-2f4b-4add-9713-ede4e5f5d7da"
+        "Domain": "id4slab1.onmicrosoft.com",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a021aff4-57ad-453a-bae8-e4192e5860f3"
     },
     "Kestrel": {
         "Endpoints": {

--- a/tests/DevApps/daemon-app/Daemon-app/Program - SDK.cs
+++ b/tests/DevApps/daemon-app/Daemon-app/Program - SDK.cs
@@ -27,8 +27,8 @@ namespace daemon_console
             /*
             var tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer(new MicrosoftIdentityApplicationOptions
             {
-                ClientId = "f6b698c0-140c-448f-8155-4aa9bf77ceba",
-                Authority = "https://login.microsoftonline.com/msidlab4.onmicrosoft.com",
+                ClientId = "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
+                    Authority = "https://login.microsoftonline.com/id4slab1.onmicrosoft.com",
                 ClientCredentials = new[]
                 {
                     new CredentialDescription()
@@ -42,8 +42,8 @@ namespace daemon_console
             */
             // Or
             var tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer(
-                authority: "https://login.microsoftonline.com/msidlab4.onmicrosoft.com",
-                clientId: "f6b698c0-140c-448f-8155-4aa9bf77ceba",
+                    authority: "https://login.microsoftonline.com/id4slab1.onmicrosoft.com",
+                clientId: "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
                 clientCredentials: new[]
                 {
                     new CredentialDescription()

--- a/tests/DevApps/daemon-app/Daemon-app/Program-net60.cs
+++ b/tests/DevApps/daemon-app/Daemon-app/Program-net60.cs
@@ -23,11 +23,11 @@ namespace daemon_console
         {
             var builder = WebApplication.CreateBuilder(args);
             var services = builder.Services;
-            
+
             services.Configure<MicrosoftIdentityOptions>(option => builder.Configuration.GetSection("AzureAd").Bind(option));
             services.AddTokenAcquisition();
             services.AddHttpClient();
-           
+
             //services.AddMicrosoftGraph(); // or services.AddTokenAcquisition() if you don't need graph
 
             // Add a cache
@@ -47,7 +47,7 @@ namespace daemon_console
             // Get the token acquisition service
             ITokenAcquirerFactory tokenAcquirerFactory = app.Services.GetRequiredService<ITokenAcquirerFactory>();
             var tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer();
-            var result = await tokenAcquirer.GetTokenForAppAsync("api://556d438d-2f4b-4add-9713-ede4e5f5d7da/.default");
+            var result = await tokenAcquirer.GetTokenForAppAsync("api://a021aff4-57ad-453a-bae8-e4192e5860f3/.default");
             Console.WriteLine($"Token expires on {result.ExpiresOn}");
 
 #endif

--- a/tests/DevApps/daemon-app/Daemon-app/appsettings.json
+++ b/tests/DevApps/daemon-app/Daemon-app/appsettings.json
@@ -1,8 +1,8 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "TenantId": "msidlab4.onmicrosoft.com",
-        "ClientId": "f6b698c0-140c-448f-8155-4aa9bf77ceba",
+        "TenantId": "id4slab1.onmicrosoft.com",
+        "ClientId": "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
         "ClientCredentials": [
             {
                 "SourceType": "StoreWithDistinguishedName",

--- a/tests/DevApps/daemon-app/daemon-app-msi/appsettings.json
+++ b/tests/DevApps/daemon-app/daemon-app-msi/appsettings.json
@@ -8,7 +8,7 @@
     // downstream API settings (per-resource)
     "AzureKeyVault": {
         "BaseUrl": "https://msidlabs.vault.azure.net/",
-        "RelativePath": "secrets/msidlab4?api-version=7.4",
+        "RelativePath": "secrets/id4slab1?api-version=7.4",
         "RequestAppToken": true,
         "Scopes": [ "https://vault.azure.net/.default" ],
         // per request settings

--- a/tests/DevApps/daemon-app/daemon-console-calling-downstreamApi/appsettings.json
+++ b/tests/DevApps/daemon-app/daemon-console-calling-downstreamApi/appsettings.json
@@ -1,8 +1,8 @@
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "TenantId": "msidlab4.onmicrosoft.com",
-    "ClientId": "f6b698c0-140c-448f-8155-4aa9bf77ceba",
+    "TenantId": "id4slab1.onmicrosoft.com",
+    "ClientId": "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
     "ClientCredentials": [
       {
         "SourceType": "StoreWithDistinguishedName",
@@ -16,6 +16,6 @@
     "BaseUrl": "https://localhost:7060/",
     "RelativePath": "/WeatherForecast",
     "RequestAppToken": true,
-    "Scopes": [ "api://556d438d-2f4b-4add-9713-ede4e5f5d7da/.default" ]
+    "Scopes": [ "api://a021aff4-57ad-453a-bae8-e4192e5860f3/.default" ]
   }
 }

--- a/tests/DevApps/daemon-app/daemon-console-calling-msgraph/appsettings.json
+++ b/tests/DevApps/daemon-app/daemon-console-calling-msgraph/appsettings.json
@@ -1,8 +1,8 @@
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "TenantId": "msidlab4.onmicrosoft.com",
-    "ClientId": "f6b698c0-140c-448f-8155-4aa9bf77ceba",
+    "TenantId": "id4slab1.onmicrosoft.com",
+    "ClientId": "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
     "ClientCredentials": [
       {
         "SourceType": "StoreWithDistinguishedName",

--- a/tests/DevApps/daemon-app/minimal-web-api/appsettings.json
+++ b/tests/DevApps/daemon-app/minimal-web-api/appsettings.json
@@ -1,8 +1,8 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "TenantId": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-        "ClientId": "556d438d-2f4b-4add-9713-ede4e5f5d7da",
+        "TenantId": "10c419d4-4a50-45b2-aa4e-919fb84df24f",
+        "ClientId": "a021aff4-57ad-453a-bae8-e4192e5860f3",
         "Scopes": "Weather.All",
         "TokenDecryptionCredentials": [
         ]

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -38,7 +38,7 @@
     <!--CVE-2021-24112-->
     <SystemDrawingCommonVersion>5.0.3</SystemDrawingCommonVersion>
     <SystemManagementVersion>8.0.0</SystemManagementVersion>
-    <MicrosoftIdentityLabApiVersion>1.0.2</MicrosoftIdentityLabApiVersion>
+    <MicrosoftIdentityLabApiVersion>2.0.0</MicrosoftIdentityLabApiVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemTextRegularExpressions>4.3.1</SystemTextRegularExpressions>
   </PropertyGroup>

--- a/tests/E2E Tests/CustomSignedAssertionProviderTests/CustomSignedAssertionProviderExtensibilityTests.cs
+++ b/tests/E2E Tests/CustomSignedAssertionProviderTests/CustomSignedAssertionProviderExtensibilityTests.cs
@@ -27,12 +27,12 @@ namespace CustomSignedAssertionProviderTests
 
             // this is how the authentication options can be configured in code rather than
             // in the appsettings file, though using the appsettings file is recommended
-            /*            
+            /*
             tokenAcquirerFactory.Services.Configure<MicrosoftIdentityApplicationOptions>(options =>
             {
                 options.Instance = "https://login.microsoftonline.com/";
-                options.TenantId = "msidlab4.onmicrosoft.com";
-                options.ClientId = "f6b698c0-140c-448f-8155-4aa9bf77ceba";
+                    options.TenantId = "id4slab1.onmicrosoft.com";
+                options.ClientId = "4ebc2cfc-14bf-4c88-9678-26543ec1c59d";
                 options.ClientCredentials = [ new CredentialDescription() {
                     SourceType = CredentialSource.CustomSignedAssertion,
                     CustomSignedAssertionProviderName = "MyCustomExtension"

--- a/tests/E2E Tests/CustomSignedAssertionProviderTests/appsettings.json
+++ b/tests/E2E Tests/CustomSignedAssertionProviderTests/appsettings.json
@@ -1,8 +1,8 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "TenantId": "msidlab4.onmicrosoft.com",
-        "ClientId": "f6b698c0-140c-448f-8155-4aa9bf77ceba",
+        "TenantId": "id4slab1.onmicrosoft.com",
+        "ClientId": "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
         "ClientCredentials": [
             {
                 "SourceType": "CustomSignedAssertion",

--- a/tests/E2E Tests/IntegrationTestService/Startup.cs
+++ b/tests/E2E Tests/IntegrationTestService/Startup.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.Test.Common;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 
 namespace IntegrationTestService
@@ -25,9 +25,6 @@ namespace IntegrationTestService
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            KeyVaultSecretsProvider keyVaultSecretsProvider = new();
-            string secret = keyVaultSecretsProvider.GetSecretByName(TestConstants.OBOClientKeyVaultUri).Value;
-
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                                   .AddMicrosoftIdentityWebApi(Configuration, jwtBearerScheme: JwtBearerDefaults.AuthenticationScheme, subscribeToJwtBearerMiddlewareDiagnosticsEvents: true)
                                   .EnableTokenAcquisitionToCallDownstreamApi()
@@ -46,16 +43,6 @@ namespace IntegrationTestService
 
             // Will be overriden by tests if needed
             services.AddInMemoryTokenCaches();
-
-            services.Configure<MicrosoftIdentityOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
-            {
-                options.ClientSecret = secret;
-            });
-
-            services.Configure<MicrosoftIdentityOptions>(TestConstants.CustomJwtScheme2, options =>
-            {
-                options.ClientSecret = secret;
-            });
 
             services.AddAuthorization();
 

--- a/tests/E2E Tests/IntegrationTestService/appsettings.json
+++ b/tests/E2E Tests/IntegrationTestService/appsettings.json
@@ -1,15 +1,29 @@
 {
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
+        "Domain": "id4slab1.onmicrosoft.com",
         "TenantId": "common",
-        "ClientId": "f4aa5217-e87c-42b2-82af-5624dd14ee72"
+        "ClientId": "8837cde9-4029-4bfc-9259-e9e70ce670f7",
+        "ClientCertificates": [
+            {
+                "SourceType": "KeyVault",
+                "KeyVaultUrl": "https://msidlabs.vault.azure.net",
+                "KeyVaultCertificateName": "LabAuth"
+            }
+        ]
     },
     "AzureAd2": {
         "Instance": "https://login.microsoftonline.com/",
-        "Domain": "msidlab4.onmicrosoft.com",
+        "Domain": "id4slab1.onmicrosoft.com",
         "TenantId": "common",
-        "ClientId": "f4aa5217-e87c-42b2-82af-5624dd14ee72"
+        "ClientId": "8837cde9-4029-4bfc-9259-e9e70ce670f7",
+        "ClientCertificates": [
+            {
+                "SourceType": "KeyVault",
+                "KeyVaultUrl": "https://msidlabs.vault.azure.net",
+                "KeyVaultCertificateName": "LabAuth"
+            }
+        ]
     },
     "CalledApi": {
         "Scopes": [ "user.read" ],

--- a/tests/E2E Tests/OidcIdPSignedAssertionProviderTests/OidCIdPSignedAssertionProviderExtensibilityTests.cs
+++ b/tests/E2E Tests/OidcIdPSignedAssertionProviderTests/OidCIdPSignedAssertionProviderExtensibilityTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.Test.Common;
 using Microsoft.Identity.Web.Test.Common.Mocks;
@@ -42,12 +43,12 @@ namespace CustomSignedAssertionProviderTests
 
             // this is how the authentication options can be configured in code rather than
             // in the appsettings file, though using the appsettings file is recommended
-            /*            
+            /*
             tokenAcquirerFactory.Services.Configure<MicrosoftIdentityApplicationOptions>(options =>
             {
                 options.Instance = "https://login.microsoftonline.com/";
-                options.TenantId = "msidlab4.onmicrosoft.com";
-                options.ClientId = "5e71875b-ae52-4a3c-8b82-f6fdc8e1dbe1";
+                    options.TenantId = "id4slab1.onmicrosoft.com";
+                options.ClientId = "af83f987-992d-4219-af18-d200268d3a89";
                 options.ClientCredentials = [ new CredentialDescription() {
                     SourceType = CredentialSource.CustomSignedAssertion,
                     CustomSignedAssertionProviderName = "MyCustomExtension"

--- a/tests/E2E Tests/OidcIdPSignedAssertionProviderTests/appsettings.json
+++ b/tests/E2E Tests/OidcIdPSignedAssertionProviderTests/appsettings.json
@@ -2,9 +2,9 @@
     "$schema": "https://raw.githubusercontent.com/AzureAD/microsoft-identity-web/refs/heads/master/JsonSchemas/microsoft-identity-web.json",
     "AzureAd": {
         "Instance": "https://login.microsoftonline.com/",
-        "TenantId": "msidlab4.onmicrosoft.com",
+        "TenantId": "id4slab1.onmicrosoft.com",
         "ExtraQueryParameters": { "dc": "ESTS-PUB-WEULR1-AZ1-FD000-TEST1" },
-        "ClientId": "5e71875b-ae52-4a3c-8b82-f6fdc8e1dbe1", // this app is configured to trust credentials (tokens) from f6b698c0-140c-448f-8155-4aa9bf77ceba
+        "ClientId": "af83f987-992d-4219-af18-d200268d3a89", // this app is configured to trust credentials (tokens) from 4ebc2cfc-14bf-4c88-9678-26543ec1c59d
         "ClientCapabilities": [ "cp1" ],
         "ClientCredentials": [
             {

--- a/tests/E2E Tests/SimulateOidc/Properties/openid-configuration
+++ b/tests/E2E Tests/SimulateOidc/Properties/openid-configuration
@@ -1,5 +1,5 @@
 {
-    "token_endpoint": "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/oauth2/v2.0/token",
+    "token_endpoint": "https://login.microsoftonline.com/10c419d4-4a50-45b2-aa4e-919fb84df24f/oauth2/v2.0/token",
     "token_endpoint_auth_methods_supported": [
         "client_secret_post",
         "private_key_jwt",
@@ -29,14 +29,14 @@
         "email",
         "offline_access"
     ],
-    "issuer": "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/v2.0",
+    "issuer": "https://login.microsoftonline.com/10c419d4-4a50-45b2-aa4e-919fb84df24f/v2.0",
     "request_uri_parameter_supported": false,
     "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
-    "authorization_endpoint": "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/oauth2/v2.0/authorize",
-    "device_authorization_endpoint": "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/oauth2/v2.0/devicecode",
+    "authorization_endpoint": "https://login.microsoftonline.com/10c419d4-4a50-45b2-aa4e-919fb84df24f/oauth2/v2.0/authorize",
+    "device_authorization_endpoint": "https://login.microsoftonline.com/10c419d4-4a50-45b2-aa4e-919fb84df24f/oauth2/v2.0/devicecode",
     "http_logout_supported": true,
     "frontchannel_logout_supported": true,
-    "end_session_endpoint": "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/oauth2/v2.0/logout",
+    "end_session_endpoint": "https://login.microsoftonline.com/10c419d4-4a50-45b2-aa4e-919fb84df24f/oauth2/v2.0/logout",
     "claims_supported": [
         "sub",
         "iss",
@@ -58,7 +58,7 @@
         "c_hash",
         "email"
     ],
-    "kerberos_endpoint": "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/kerberos",
+    "kerberos_endpoint": "https://login.microsoftonline.com/10c419d4-4a50-45b2-aa4e-919fb84df24f/kerberos",
     "tenant_region_scope": "NA",
     "cloud_instance_name": "microsoftonline.com",
     "cloud_graph_host_name": "graph.windows.net",

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Graph;
 using Microsoft.Identity.Abstractions;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.Test.Common;
 using Microsoft.Identity.Web.TestOnly;
@@ -102,14 +102,14 @@ namespace TokenAcquirerTests
             var tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
             _ = tokenAcquirerFactory.Build();
 
-            var labResponse = await LabUserHelper.GetSpecificUserAsync(TestConstants.OBOUser);
+            var userConfig = await LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON");
 
             ITokenAcquirer tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer(
-               authority: "https://login.microsoftonline.com/organizations",
-               clientId: "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+                   authority: "https://login.microsoftonline.com/organizations",
+                   clientId: "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
                clientCredentials: s_clientCredentials);
 
-            var user = ClaimsPrincipalFactory.FromUsernamePassword(labResponse.User.Upn, labResponse.User.GetOrFetchPassword());
+            var user = ClaimsPrincipalFactory.FromUsernamePassword(userConfig.Upn, LabResponseHelper.FetchUserPassword(userConfig.LabName));
 
             var result = await tokenAcquirer.GetTokenForUserAsync(
                 scopes: new[] { "https://graph.microsoft.com/.default" }, user: user);
@@ -132,14 +132,14 @@ namespace TokenAcquirerTests
             var tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
             _ = tokenAcquirerFactory.Build();
 
-            var labResponse = await LabUserHelper.GetSpecificUserAsync(TestConstants.OBOUser);
+            var userConfig = await LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON");
 
             ITokenAcquirer tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer(
-               authority: "https://login.microsoftonline.com/organizations",
-               clientId: "9a192b78-6580-4f8a-aace-f36ffea4f7be",
+                   authority: "https://login.microsoftonline.com/organizations",
+                   clientId: "a599ce88-0a5f-4a6e-beca-e67d3fc427f4",
                clientCredentials: s_clientCredentials);
 
-            var user = ClaimsPrincipalFactory.FromUsernamePassword(labResponse.User.Upn, labResponse.User.GetOrFetchPassword());
+            var user = ClaimsPrincipalFactory.FromUsernamePassword(userConfig.Upn, LabResponseHelper.FetchUserPassword(userConfig.LabName));
 
             var result = await tokenAcquirer.GetTokenForUserAsync(
                 scopes: new[] { "https://graph.microsoft.com/.default" }, user: user);
@@ -209,8 +209,8 @@ namespace TokenAcquirerTests
             services.Configure<MicrosoftIdentityOptions>(s_optionName, option =>
             {
                 option.Instance = "https://login.microsoftonline.com/";
-                option.TenantId = "msidlab4.onmicrosoft.com";
-                option.ClientId = "f6b698c0-140c-448f-8155-4aa9bf77ceba";
+                option.TenantId = "id4slab1.onmicrosoft.com";
+                option.ClientId = "4ebc2cfc-14bf-4c88-9678-26543ec1c59d";
                 if (withClientCredentials)
                 {
                     option.ClientCertificates = s_clientCredentials.OfType<CertificateDescription>();
@@ -235,8 +235,8 @@ namespace TokenAcquirerTests
             services.Configure<MicrosoftIdentityApplicationOptions>(s_optionName, option =>
             {
                 option.Instance = "https://login.microsoftonline.com/";
-                option.TenantId = "msidlab4.onmicrosoft.com";
-                option.ClientId = "f6b698c0-140c-448f-8155-4aa9bf77ceba";
+                option.TenantId = "id4slab1.onmicrosoft.com";
+                option.ClientId = "4ebc2cfc-14bf-4c88-9678-26543ec1c59d";
                 option.ClientCredentials = s_clientCredentials;
             });
 
@@ -273,8 +273,8 @@ namespace TokenAcquirerTests
             // Get the token acquirer from the options.
             var tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer(new MicrosoftIdentityApplicationOptions
             {
-                ClientId = "f6b698c0-140c-448f-8155-4aa9bf77ceba",
-                Authority = "https://login.microsoftonline.com/msidlab4.onmicrosoft.com",
+                ClientId = "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
+                Authority = "https://login.microsoftonline.com/id4slab1.onmicrosoft.com",
                 ClientCredentials = s_clientCredentials
             });
 
@@ -292,8 +292,8 @@ namespace TokenAcquirerTests
             tokenAcquirerFactory.Build();
 
             var tokenAcquirer = tokenAcquirerFactory.GetTokenAcquirer(
-                authority: "https://login.microsoftonline.com/msidlab4.onmicrosoft.com",
-                clientId: "f6b698c0-140c-448f-8155-4aa9bf77ceba",
+                authority: "https://login.microsoftonline.com/id4slab1.onmicrosoft.com",
+                clientId: "4ebc2cfc-14bf-4c88-9678-26543ec1c59d",
                 clientCredentials: s_clientCredentials);
 
             var result = await tokenAcquirer.GetTokenForAppAsync("https://graph.microsoft.com/.default");
@@ -311,8 +311,8 @@ namespace TokenAcquirerTests
             services.Configure<MicrosoftIdentityApplicationOptions>(s_optionName, option =>
             {
                 option.Instance = "https://login.microsoftonline.com/";
-                option.TenantId = "msidlab4.onmicrosoft.com";
-                option.ClientId = "f6b698c0-140c-448f-8155-4aa9bf77ceba";
+                option.TenantId = "id4slab1.onmicrosoft.com";
+                option.ClientId = "4ebc2cfc-14bf-4c88-9678-26543ec1c59d";
                 option.ClientCredentials = s_clientCredentials;
             });
 
@@ -352,8 +352,8 @@ namespace TokenAcquirerTests
             services.Configure<MicrosoftIdentityApplicationOptions>(s_optionName, option =>
             {
                 option.Instance = "https://login.microsoftonline.com/";
-                option.TenantId = "msidlab4.onmicrosoft.com";
-                option.ClientId = "f6b698c0-140c-448f-8155-4aa9bf77ceba";
+                option.TenantId = "id4slab1.onmicrosoft.com";
+                option.ClientId = "4ebc2cfc-14bf-4c88-9678-26543ec1c59d";
                 option.ClientCredentials = s_clientCredentials;
             });
 
@@ -382,8 +382,8 @@ namespace TokenAcquirerTests
             services.Configure<MicrosoftIdentityApplicationOptions>(s_optionName, option =>
             {
                 option.Instance = "https://login.microsoftonline.com/";
-                option.TenantId = "msidlab4.onmicrosoft.com";
-                option.ClientId = "f6b698c0-140c-448f-8155-4aa9bf77ceba";
+                option.TenantId = "id4slab1.onmicrosoft.com";
+                option.ClientId = "4ebc2cfc-14bf-4c88-9678-26543ec1c59d";
                 option.ClientCredentials = s_clientCredentials;
             });
 

--- a/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/B2CWebAppCallsWebApiLocally.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Azure.Identity;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/TestingWebAppLocally.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;
@@ -30,7 +30,7 @@ public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixtur
     private readonly string _uiTestAssemblyLocation = typeof(TestingWebAppLocally).Assembly.Location;
     private readonly LocatorAssertionsToBeVisibleOptions _assertVisibleOptions = new() { Timeout = 15000 };
 
-    public TestingWebAppLocally(ITestOutputHelper output) 
+    public TestingWebAppLocally(ITestOutputHelper output)
     {
         _output = output;
     }
@@ -39,11 +39,11 @@ public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixtur
     [SupportedOSPlatform("windows")]
     public async Task ChallengeUser_MicrosoftIdFlow_LocalApp_ValidEmailPasswordAsync()
     {
-        LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync();
+        var userConfig = await LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON");
 
         var clientEnvVars = new Dictionary<string, string>();
 
-        await ExecuteWebAppCallsGraphFlowAsync(labResponse.User.Upn, labResponse.User.GetOrFetchPassword(), clientEnvVars, TraceFileClassName);
+        await ExecuteWebAppCallsGraphFlowAsync(userConfig.Upn, LabResponseHelper.FetchUserPassword(userConfig.LabName), clientEnvVars, TraceFileClassName);
     }
 
     [Theory(Skip = "https://github.com/AzureAD/microsoft-identity-web/issues/3288")]
@@ -61,7 +61,7 @@ public class TestingWebAppLocally : IClassFixture<InstallPlaywrightBrowserFixtur
             {"AzureAd__Instance", "" }
         };
 
-        await ExecuteWebAppCallsGraphFlowAsync("idlab@msidlabciam6.onmicrosoft.com", LabUserHelper.FetchUserPassword("msidlabciam6"), clientEnvVars, TraceFileClassNameCiam);
+        await ExecuteWebAppCallsGraphFlowAsync("idlab@msidlabciam6.onmicrosoft.com", LabResponseHelper.FetchUserPassword("msidlabciam6"), clientEnvVars, TraceFileClassNameCiam);
     }
 
     private async Task ExecuteWebAppCallsGraphFlowAsync(string upn, string credential, Dictionary<string, string>? clientEnvVars, string traceFileClassName)

--- a/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
+++ b/tests/E2E Tests/WebAppUiTests/UiTestHelpers.cs
@@ -69,14 +69,21 @@ namespace WebAppUiTests
         }
 
         /// <summary>
-        /// In the Microsoft Identity flow, the user is at certain stages presented with a list of accounts known in 
+        /// In the Microsoft Identity flow, the user is at certain stages presented with a list of accounts known in
         /// the current browsing session to choose from. This method selects the account using the user's email.
         /// </summary>
         /// <param name="page">page for the playwright browser</param>
         /// <param name="email">user email address to select</param>
         private static async Task SelectKnownAccountByEmail_MicrosoftIdFlowAsync(IPage page, string email)
         {
-            await page.Locator($"[data-test-id=\"{email}\"]").ClickAsync();
+            ILocator accountLocator = page.Locator($"[data-test-id=\"{email}\"]");
+            if (await accountLocator.CountAsync() == 0)
+            {
+                string normalizedEmail = email.ToLowerInvariant();
+                accountLocator = page.Locator($"[data-test-id=\"{normalizedEmail}\"]");
+            }
+
+            await accountLocator.ClickAsync();
         }
 
         /// <summary>
@@ -89,7 +96,7 @@ namespace WebAppUiTests
         public static async Task EnterPassword_MicrosoftIdFlow_ValidPasswordAsync(IPage page, string password, string staySignedInText, ITestOutputHelper? output = null)
         {
             // If using an account that has other non-password validation options, the below code should be uncommented
-            /* WriteLine(output, "Selecting \"Password\" as authentication method"); 
+            /* WriteLine(output, "Selecting \"Password\" as authentication method");
             await page.GetByRole(AriaRole.Button, new() { Name = TestConstants.PasswordText }).ClickAsync();*/
 
             WriteLine(output, "Logging in ... entering and submitting password.");

--- a/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
+++ b/tests/E2E Tests/WebAppUiTests/WebAppCallsApiCallsGraphLocally.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/E2E Tests/WebAppUiTests/WebAppIntegrationTests.cs
+++ b/tests/E2E Tests/WebAppUiTests/WebAppIntegrationTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Playwright;
 using Xunit;
 

--- a/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestConstants.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string ClientId = "87f0ee88-8251-48b3-8825-e0c9563f5234";
         public const string GuestTenantId = "guest-tenant-id";
         public const string HomeTenantId = "home-tenant-id";
-        public const string TenantIdAsGuid = "f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+        public const string TenantIdAsGuid = "10c419d4-4a50-45b2-aa4e-919fb84df24f";
         public const string ObjectIdAsGuid = "6364bb70-9521-3fa8-989d-c2c19ff90223";
         public const string Domain = "contoso.onmicrosoft.com";
         public const string Uid = "my-home-object-id";
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string AadIssuer = AadInstance + "/" + TenantIdAsGuid + "/v2.0";
         public const string UsGovIssuer = "https://login.microsoftonline.us/" + UsGovTenantId + "/v2.0";
         public const string UsGovTenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
-        public const string V1Issuer = "https://sts.windows.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/";
+        public const string V1Issuer = "https://sts.windows.net/10c419d4-4a50-45b2-aa4e-919fb84df24f/";
         public const string GraphBaseUrlBeta = "https://graph.microsoft.com/beta";
         public const string GraphBaseUrl = "https://graph.microsoft.com/v1.0";
 
@@ -106,16 +106,17 @@ namespace Microsoft.Identity.Web.Test.Common
         public const string GraphScopes = "user.write user.read.all";
 
         // Constants for the lab
-        public const string OBOClientKeyVaultUri = "TodoListServiceV2-OBO";
         public const string ConfidentialClientKeyVaultUri = "https://msidlabs.vault.azure.net/secrets/LabVaultAccessCert/";
-        public const string ConfidentialClientId = "88f91eac-c606-4c67-a0e2-a5e8a186854f";
-        public const string ConfidentialClientLabTenant = "f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
-        public const string OBOUser = "idlab1@msidlab4.onmicrosoft.com";
-        public const string OBOClientSideClientId = "c0485386-1e9a-4663-bc96-7ab30656de7f";
-        public static string[] s_oBOApiScope = new string[] { "api://f4aa5217-e87c-42b2-82af-5624dd14ee72/.default" };
+        public const string ConfidentialClientId = "3bf56293-fbb5-42bd-a407-248ba7431a8c";
+        public const string ConfidentialClientLabTenant = "10c419d4-4a50-45b2-aa4e-919fb84df24f";
+        public const string OBOUser = "MSAL-User-Default@id4slab1.onmicrosoft.com";
+        public const string OBOClientSideClientId = "9c0e534b-879c-4dce-b0e2-0e1be873ba14";
+        public static string[] s_oBOApiScope = new string[] { "api://8837cde9-4029-4bfc-9259-e9e70ce670f7/.default" };
         public const string LabClientId = "f62c5ae3-bf3a-4af5-afa8-a68b800396e9";
         public const string MSIDLabLabKeyVaultName = "https://msidlabs.vault.azure.net";
-        public const string AzureADIdentityDivisionTestAgentSecret = "MSIDLAB4-IDLABS-APP-AzureADMyOrg-CC";
+        public const string ID4sKeyVaultName = "id4skeyvault";
+        public const string ID4sKeyVaultUri = "https://id4skeyvault.vault.azure.net/";
+        public const string AzureADIdentityDivisionTestAgentSecret = "MISE-App-FMICLIENT";
         public const string BuildAutomationKeyVaultName = "https://buildautomation.vault.azure.net/";
 
         // This value is only for testing purposes. It is for a certificate that is not used for anything other than running tests

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForAppIntegrationTests.cs
@@ -18,7 +18,7 @@ using Microsoft.Identity.Client;
 using Microsoft.Identity.Web.Test.Common;
 using Microsoft.Identity.Web.Test.Common.Mocks;
 using Microsoft.Identity.Web.Test.Common.TestHelpers;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 using Xunit;
 using Xunit.Abstractions;
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Web.Test.Integration
         {
             _output = output;
 
-            KeyVaultSecretsProvider keyVaultSecretsProvider = new KeyVaultSecretsProvider(TestConstants.MSIDLabLabKeyVaultName);
+            KeyVaultSecretsProvider keyVaultSecretsProvider = new KeyVaultSecretsProvider(TestConstants.ID4sKeyVaultUri);
             _ccaSecret = keyVaultSecretsProvider.GetSecretByName(TestConstants.AzureADIdentityDivisionTestAgentSecret).Value;
 
             // Need the secret before building the services
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Web.Test.Integration
                 throw new ArgumentNullException(message: "No secret returned from Key Vault. ", null);
             }
         }
-        
+
         [Theory]
         [InlineData(true, Constants.Bearer)]
         [InlineData(true, "PoP")]

--- a/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForUserIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test.Integration/AcquireTokenForUserIntegrationTests.cs
@@ -14,7 +14,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Web.Test.Common;
 using Microsoft.Identity.Web.Test.Common.TestHelpers;
 using Microsoft.Identity.Web.TokenCacheProviders.Distributed;
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Web.Test.Integration
             string authority = "http://localhost:1234";
             Process? p = ExternalApp.Start(
                 typeof(AcquireTokenForUserIntegrationTests),
-                @"tests\E2E Tests\SimulateOidc\", 
+                @"tests\E2E Tests\SimulateOidc\",
                 "SimulateOidc.exe",
                 $"--urls={authority}");
             if (p != null && !p.HasExited)
@@ -194,18 +194,18 @@ namespace Microsoft.Identity.Web.Test.Integration
 
         private static async Task<AuthenticationResult> AcquireTokenForLabUserAsync()
         {
-            var labResponse = await LabUserHelper.GetSpecificUserAsync(TestConstants.OBOUser);
+            var userConfig = await LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON");
             var msalPublicClient = PublicClientApplicationBuilder
                .Create(TestConstants.OBOClientSideClientId)
-               .WithAuthority(labResponse.Lab.Authority, TestConstants.Organizations)
+               .WithAuthority($"https://login.microsoftonline.com/{TestConstants.TenantIdAsGuid}", TestConstants.Organizations)
                .Build();
 
 #pragma warning disable CS0618 // Obsolete
             AuthenticationResult authResult = await msalPublicClient
                 .AcquireTokenByUsernamePassword(
                 TestConstants.s_oBOApiScope,
-                TestConstants.OBOUser,
-                labResponse.User.GetOrFetchPassword())
+                userConfig.Upn,
+                LabResponseHelper.FetchUserPassword(userConfig.LabName))
                 .ExecuteAsync(CancellationToken.None)
                 ;
 #pragma warning restore CS0618 // Obsolete

--- a/tests/Microsoft.Identity.Web.Test/Certificates/DefaultCertificateLoaderTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/DefaultCertificateLoaderTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
 {
     public class DefaultCertificateLoaderTests
     {
-        // https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/Credentials/appId/9a192b78-6580-4f8a-aace-f36ffea4f7be/isMSAApp/
+        // https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/Credentials/appId/a599ce88-0a5f-4a6e-beca-e67d3fc427f4/isMSAApp/
         // [InlineData(CertificateSource.KeyVault, TestConstants.KeyVaultContainer, TestConstants.KeyVaultReference)]
         // [InlineData(CertificateSource.Path, @"c:\temp\WebAppCallingWebApiCert.pfx", "")]
         // [InlineData(CertificateSource.StoreWithDistinguishedName, "CurrentUser/My", "CN=WebAppCallingWebApiCert")]

--- a/tests/Microsoft.Identity.Web.Test/Certificates/WithClientCredentialsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Certificates/WithClientCredentialsTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
             var ficCredential = new CredentialDescription
             {
                 SourceType = CredentialSource.SignedAssertionFromManagedIdentity,
-                ManagedIdentityClientId = "9a192b78-6580-4f8a-aace-f36ffea4f7be"
+                ManagedIdentityClientId = "a599ce88-0a5f-4a6e-beca-e67d3fc427f4"
             };
 
             await RunFailToLoadLogicAsync(new[] { ficCredential });
@@ -112,7 +112,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
             var ficCredential = new CredentialDescription
             {
                 SourceType = CredentialSource.SignedAssertionFromManagedIdentity,
-                ManagedIdentityClientId = "9a192b78-6580-4f8a-aace-f36ffea4f7be"
+                ManagedIdentityClientId = "a599ce88-0a5f-4a6e-beca-e67d3fc427f4"
             };
 
             var certCredential = new CredentialDescription
@@ -138,7 +138,7 @@ namespace Microsoft.Identity.Web.Test.Certificates
             var ficCredential = new CredentialDescription
             {
                 SourceType = CredentialSource.SignedAssertionFromManagedIdentity,
-                ManagedIdentityClientId = "9a192b78-6580-4f8a-aace-f36ffea4f7be"
+                ManagedIdentityClientId = "a599ce88-0a5f-4a6e-beca-e67d3fc427f4"
             };
 
             await RunFailToLoadLogicAsync(new[] { ficCredential, certCredential });

--- a/tests/Microsoft.Identity.Web.Test/FmiTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/FmiTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Web.Test
             tokenAcquirerFactory.Services.Configure<MicrosoftIdentityApplicationOptions>(options =>
             {
                 options.Instance = "https://login.microsoftonline.com/";
-                options.TenantId = "f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+                options.TenantId = "10c419d4-4a50-45b2-aa4e-919fb84df24f";
                 options.ClientId = "urn:microsoft:identity:fmi";
                 options.ExtraQueryParameters = new Dictionary<string, string>
                         {

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Identity.Web.Test
             tokenAcquirerFactory.Services.Configure<MicrosoftIdentityApplicationOptions>(options =>
             {
                 options.Instance = "https://login.microsoftonline.com/";
-                options.TenantId = "f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+                options.TenantId = "10c419d4-4a50-45b2-aa4e-919fb84df24f";
                 options.ClientId = "idu773ld-e38d-jud3-45lk-d1b09a74a8ca";
                 options.ExtraQueryParameters = new Dictionary<string, string>
                     {

--- a/tests/PerformanceTests/Microsoft.Identity.Web.Perf.Benchmark/TokenAcquisitionTests.cs
+++ b/tests/PerformanceTests/Microsoft.Identity.Web.Perf.Benchmark/TokenAcquisitionTests.cs
@@ -12,7 +12,7 @@ using IntegrationTestService;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Web.Test.Common;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 
 namespace Microsoft.Identity.Web.Perf.Benchmark
 {
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Web.Perf.Benchmark
         private readonly WebApplicationFactory<Startup> _factory;
         private HttpClient _client;
 
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
         // The GlobalSetup ensures that the _client is not null.
         public TokenAcquisitionTests()
         {
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Web.Perf.Benchmark
         public async Task GetAccessTokenForUserAsync()
         {
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, TestConstants.SecurePageGetTokenForUserAsync);
-            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);    
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
             if (!response.IsSuccessStatusCode)
             {
                 throw new HttpRequestException($"GetAccessTokenForUserAsync failed. Status code: {response.StatusCode}. Reason phrase: {response.ReasonPhrase}.");
@@ -79,18 +79,18 @@ namespace Microsoft.Identity.Web.Perf.Benchmark
 
         private static async Task<AuthenticationResult> AcquireTokenForLabUserAsync()
         {
-            var labResponse = await LabUserHelper.GetSpecificUserAsync(TestConstants.OBOUser).ConfigureAwait(false);
+            var userConfig = await LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON");
             var msalPublicClient = PublicClientApplicationBuilder
                .Create(TestConstants.OBOClientSideClientId)
-               .WithAuthority(labResponse.Lab.Authority, TestConstants.Organizations)
+               .WithAuthority($"https://login.microsoftonline.com/{TestConstants.TenantIdAsGuid}", TestConstants.Organizations)
                .Build();
 
 #pragma warning disable CS0618 // Obsolete
             AuthenticationResult authResult = await msalPublicClient
                 .AcquireTokenByUsernamePassword(
                 TestConstants.s_oBOApiScope,
-                TestConstants.OBOUser,
-                labResponse.User.GetOrFetchPassword())
+                userConfig.Upn,
+                LabResponseHelper.FetchUserPassword(userConfig.LabName))
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/Benchmark/Benchmark.csproj
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/Benchmark/Benchmark.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
-    <PackageReference Include="Microsoft.Identity.Lab.Api" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Identity.Lab.Api" Version="2.0.0" />
 
   </ItemGroup>
 

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/Benchmark/Program.cs
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/Benchmark/Program.cs
@@ -8,7 +8,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 
 namespace Brenchmark
 {
@@ -25,24 +25,24 @@ namespace Brenchmark
     public class ValidateBenchmark
     {
         private static IPublicClientApplication msalPublicClient;
-        private static LabResponse labResponse;
+        private static LabUserConfig userConfig;
         private static string authorizationHeader;
 
         static ValidateBenchmark()
         {
-            Initialize("https://login.microsoftonline.com/organizations", "f4aa5217-e87c-42b2-82af-5624dd14ee72");
-            labResponse = LabUserHelper.GetSpecificUserAsync(OBOUser).GetAwaiter().GetResult();
+            Initialize("https://login.microsoftonline.com/organizations", "8837cde9-4029-4bfc-9259-e9e70ce670f7");
+            userConfig = LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON").GetAwaiter().GetResult();
             msalPublicClient = PublicClientApplicationBuilder
                .Create(OBOClientSideClientId)
-               .WithAuthority(labResponse.Lab.Authority, Organizations)
+               .WithAuthority($"{userConfig.Authority}{userConfig.TenantId}", Organizations)
                .Build();
             authorizationHeader = AcquireTokenForLabUserAsync().Result.CreateAuthorizationHeader();
         }
 
         public const string Organizations = "organizations";
-        public const string OBOUser = "idlab1@msidlab4.onmicrosoft.com";
-        public const string OBOClientSideClientId = "c0485386-1e9a-4663-bc96-7ab30656de7f";
-        public static string[] s_oBOApiScope = new string[] { "api://f4aa5217-e87c-42b2-82af-5624dd14ee72/.default" };
+        public const string OBOUser = "MSAL-User-Default@id4slab1.onmicrosoft.com";
+        public const string OBOClientSideClientId = "9c0e534b-879c-4dce-b0e2-0e1be873ba14";
+        public static string[] s_oBOApiScope = new string[] { "api://8837cde9-4029-4bfc-9259-e9e70ce670f7/.default" };
         public int numberValidations = 1000000;
 
         [DllImport("CrossPlatformValidation.dll")]
@@ -80,7 +80,7 @@ namespace Brenchmark
                     .AcquireTokenByUsernamePassword(
                     s_oBOApiScope,
                     OBOUser,
-                    labResponse.User.GetOrFetchPassword())
+                    LabResponseHelper.FetchUserPassword(userConfig.LabName))
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
             }

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/BenchmarkCSharp/BenchmarkCSharp.csproj
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/BenchmarkCSharp/BenchmarkCSharp.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
-    <PackageReference Include="Microsoft.Identity.Lab.Api" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Identity.Lab.Api" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseWilson7)' == 'true'">
@@ -34,5 +34,5 @@
     <PackageReference Include="Microsoft.IdentityModel.Validators" Version="6.32.3" />
     <!--<RdXmlFile Include="rd.xml" />-->
   </ItemGroup>
-  
+
 </Project>

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/BenchmarkCSharp/Program.cs
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/BenchmarkCSharp/Program.cs
@@ -9,7 +9,7 @@ using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using CrossPlatformValidation;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 
 namespace BenchmarkCSharp
 {
@@ -37,7 +37,7 @@ namespace BenchmarkCSharp
     public class ValidateBenchmark
     {
         private static IPublicClientApplication msalPublicClient;
-        private static LabResponse labResponse;
+        private static LabUserConfig userConfig;
         private static string authorizationHeader;
         private static RequestValidator _requestValidator;
 
@@ -45,19 +45,19 @@ namespace BenchmarkCSharp
         static ValidateBenchmark()
         {
             _requestValidator = new RequestValidator();
-            _requestValidator.Initialize("https://login.microsoftonline.com/organizations", "f4aa5217-e87c-42b2-82af-5624dd14ee72");
-            labResponse = LabUserHelper.GetSpecificUserAsync(OBOUser).GetAwaiter().GetResult();
+            _requestValidator.Initialize("https://login.microsoftonline.com/organizations", "8837cde9-4029-4bfc-9259-e9e70ce670f7");
+            userConfig = LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON").GetAwaiter().GetResult();
             msalPublicClient = PublicClientApplicationBuilder
                .Create(OBOClientSideClientId)
-               .WithAuthority(labResponse.Lab.Authority, Organizations)
+               .WithAuthority($"{userConfig.Authority}{userConfig.TenantId}", Organizations)
                .Build();
             authorizationHeader = AcquireTokenForLabUserAsync().Result.CreateAuthorizationHeader();
         }
 
         public const string Organizations = "organizations";
-        public const string OBOUser = "idlab1@msidlab4.onmicrosoft.com";
-        public const string OBOClientSideClientId = "c0485386-1e9a-4663-bc96-7ab30656de7f";
-        public static string[] s_oBOApiScope = new string[] { "api://f4aa5217-e87c-42b2-82af-5624dd14ee72/.default" };
+        public const string OBOUser = "MSAL-User-Default@id4slab1.onmicrosoft.com";
+        public const string OBOClientSideClientId = "9c0e534b-879c-4dce-b0e2-0e1be873ba14";
+        public static string[] s_oBOApiScope = new string[] { "api://8837cde9-4029-4bfc-9259-e9e70ce670f7/.default" };
         public int numberValidations = 1000000;
 
         [Benchmark]
@@ -89,7 +89,7 @@ namespace BenchmarkCSharp
                     .AcquireTokenByUsernamePassword(
                     s_oBOApiScope,
                     OBOUser,
-                    labResponse.User.GetOrFetchPassword())
+                    LabResponseHelper.FetchUserPassword(userConfig.LabName))
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
             }

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/CSharpConsoleApp/CSharpConsoleApp.csproj
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/CSharpConsoleApp/CSharpConsoleApp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Lab.Api" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Identity.Lab.Api" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/CSharpConsoleApp/Program.cs
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/CSharpConsoleApp/Program.cs
@@ -3,13 +3,13 @@
 
 using CrossPlatformValidation;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 
 Console.WriteLine("Hello, World!");
 
 RequestValidator requestValidator = new();
 
-requestValidator.Initialize("https://login.microsoftonline.com/organizations", "f4aa5217-e87c-42b2-82af-5624dd14ee72");
+requestValidator.Initialize("https://login.microsoftonline.com/organizations", "8837cde9-4029-4bfc-9259-e9e70ce670f7");
 string authorizationHeader = AcquireTokenForLabUserAsync().Result.CreateAuthorizationHeader();
 var result = requestValidator.Validate(authorizationHeader);
 //string token = "Bearer ";
@@ -23,22 +23,22 @@ Console.ReadLine();
 
 static async Task<AuthenticationResult> AcquireTokenForLabUserAsync()
 {
- string Organizations = "organizations";
- string OBOUser = "idlab1@msidlab4.onmicrosoft.com";
- string OBOClientSideClientId = "c0485386-1e9a-4663-bc96-7ab30656de7f";
- string[] s_oBOApiScope = new string[] { "api://f4aa5217-e87c-42b2-82af-5624dd14ee72/.default" };
+    string Organizations = "organizations";
+    string OBOUser = "MSAL-User-Default@id4slab1.onmicrosoft.com";
+    string OBOClientSideClientId = "9c0e534b-879c-4dce-b0e2-0e1be873ba14";
+    string[] s_oBOApiScope = new string[] { "api://8837cde9-4029-4bfc-9259-e9e70ce670f7/.default" };
 
-var labResponse = await LabUserHelper.GetSpecificUserAsync(OBOUser).ConfigureAwait(false);
+    var userConfig = await LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON");
     var msalPublicClient = PublicClientApplicationBuilder
        .Create(OBOClientSideClientId)
-       .WithAuthority(labResponse.Lab.Authority, Organizations)
+       .WithAuthority($"{userConfig.Authority}{userConfig.TenantId}", Organizations)
        .Build();
 
     AuthenticationResult authResult = await msalPublicClient
         .AcquireTokenByUsernamePassword(
         s_oBOApiScope,
         OBOUser,
-        labResponse.User.GetOrFetchPassword())
+        LabResponseHelper.FetchUserPassword(userConfig.LabName))
         .ExecuteAsync(CancellationToken.None)
         .ConfigureAwait(false);
 

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/CrossPlatformValidatorTests/CrossPlatformValidatorTests.csproj
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/CrossPlatformValidatorTests/CrossPlatformValidatorTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Lab.Api" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Identity.Lab.Api" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/tools/CrossPlatformValidator/CrossPlatformValidation/CrossPlatformValidatorTests/InitializeAndValidateTests.cs
+++ b/tools/CrossPlatformValidator/CrossPlatformValidation/CrossPlatformValidatorTests/InitializeAndValidateTests.cs
@@ -3,16 +3,16 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Lab.Api;
+using Microsoft.Identity.Test.LabInfrastructure;
 
 namespace CrossPlatformValidatorTests
 {
     public class InitializeAndValidateTests
     {
         public const string Organizations = "organizations";
-        public const string OBOUser = "idlab1@msidlab4.onmicrosoft.com";
-        public const string OBOClientSideClientId = "c0485386-1e9a-4663-bc96-7ab30656de7f";
-        public static string[] s_oBOApiScope = new string[] { "api://f4aa5217-e87c-42b2-82af-5624dd14ee72/.default" };
+        public const string OBOUser = "MSAL-User-Default@id4slab1.onmicrosoft.com";
+        public const string OBOClientSideClientId = "9c0e534b-879c-4dce-b0e2-0e1be873ba14";
+        public static string[] s_oBOApiScope = new string[] { "api://8837cde9-4029-4bfc-9259-e9e70ce670f7/.default" };
         public int numberValidations = 1000000;
 
         [DllImport("CrossPlatformValidation.dll")]
@@ -31,29 +31,29 @@ namespace CrossPlatformValidatorTests
         [Fact]
         public void ValidateTestSucceeds()
         {
-            Initialize("https://login.microsoftonline.com/organizations", "f4aa5217-e87c-42b2-82af-5624dd14ee72");
+            Initialize("https://login.microsoftonline.com/organizations", "8837cde9-4029-4bfc-9259-e9e70ce670f7");
             string authorizationHeader = AcquireTokenForLabUserAsync().Result.CreateAuthorizationHeader();
             for (int i = 0; i < numberValidations; i++)
             {
                 var result = Validate(authorizationHeader);
                 Assert.NotNull(result);
             }
-            
+
         }
 
         private static async Task<AuthenticationResult> AcquireTokenForLabUserAsync()
         {
-            var labResponse = await LabUserHelper.GetSpecificUserAsync(OBOUser).ConfigureAwait(false);
+            var userConfig = await LabResponseHelper.GetUserConfigAsync("MSAL-User-Default-JSON");
             var msalPublicClient = PublicClientApplicationBuilder
                .Create(OBOClientSideClientId)
-               .WithAuthority(labResponse.Lab.Authority, Organizations)
+               .WithAuthority($"{userConfig.Authority}{userConfig.TenantId}", Organizations)
                .Build();
 
             AuthenticationResult authResult = await msalPublicClient
                 .AcquireTokenByUsernamePassword(
                 s_oBOApiScope,
                 OBOUser,
-                labResponse.User.GetOrFetchPassword())
+                LabResponseHelper.FetchUserPassword(userConfig.LabName))
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 


### PR DESCRIPTION
* Add comprehensive certificate reload logic tests and lab migration updates

* Add certificate test fixes to lab migration

- Fixed certificate validation logic in MockHttpMessageHandler to use thumbprint-based comparison instead of object reference equality
- Added robust certificate store verification with timing controls to handle asynchronous store operations
- Implemented unique certificate naming with GUID prefixes to prevent cross-framework test interference
- Resolved AADSTS700027 authentication errors and parallel test execution conflicts

Combined with lab migration changes for comprehensive update.

* Fix lab API migration compilation errors

- Fix missing System.Diagnostics using statement in CertificatesObserverTests.cs
- Update UserConfig.UPN to userConfig.Upn in integration and performance tests
- Fix string interpolation syntax errors in authority URL construction

These changes resolve compilation failures caused by:
1. Missing using statement for Stopwatch class
2. Lab API migration UserConfig property name changes (UPN → Upn)
3. Escaped quotes in string interpolation causing syntax errors

* Complete lab API migration fixes for WebAppUiTests

- Fix UserConfig.UPN to userConfig.Upn in TestingWebAppLocally.cs
- Fix LabUserHelper to LabResponseHelper in TestingWebAppLocally.cs and WebAppCallsApiCallsGraphLocally.cs
- Fix LabResponse type and GetB2CLocalAccountAsync method in B2CWebAppCallsWebApiLocally.cs

All WebAppUiTests compilation errors from lab API migration are now resolved.

* Remove unused labResponse variable in B2C test

The B2C test uses Azure Key Vault credentials, not lab infrastructure, so the LabResponseHelper.GetUserConfigAsync call was unused.

* Fix authentication configuration and clean up test constants

- Updated TestConstants.cs to correct vault references and remove unused constants
- Configured IntegrationTestService for certificate-based authentication
- Fixed Key Vault references to use msidlabs vault with LabAuth certificate
- Removed unused OBOClientKeyVaultUri and BuildAutomationKeyVaultName constants
- Ensured all test constants are aligned with id4slab1 tenant

* Update lab tenant app configs

* Fix UI test stability and update test config

* Use ID4s Key Vault for integration test secret

* Update Microsoft.Identity.Lab.Api to 2.0.0

* Remove conflict markers

* Restore ID4s Key Vault constants

* Fix JSON indentation in appsettings.json files

- blazorserver-calls-api/Client: Fix ClientId and Scopes indentation
- MultipleAuthSchemes: Fix ClientId indentation
- aspnet-mvc/OwinWebApi: Fix ClientId indentation
- E2E Tests/IntegrationTestService: Fix Domain indentation in AzureAd and AzureAd2