### PR TITLE
Prevent OpenIdConnectMiddlewareDiagnostics from logging sensitive values

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/IDWebErrorMessage.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Identity.Web
         public const string ClientSecretAndCredentialsCannotBeCombined = "IDW10110: ClientSecret top level configuration cannot be combined with ClientCredentials. Instead, add a new entry in the ClientCredentials array describing the secret.";
         public const string MissingTokenBindingCertificate = "IDW10115: A signing certificate, which is required for token binding, is missing in loaded credentials.";
         public const string TokenBindingRequiresEnabledAppTokenAcquisition = "IDW10116: Token binding requires enabled app token acquisition.";
+        public const string OpenIdConnectMiddlewareDiagnosticsRequiresDevelopmentEnvironment = "IDW10117: 'subscribeToOpenIdConnectMiddlewareDiagnosticsEvents' was set to true outside of the Development environment. " +
+            "OpenIdConnectMiddlewareDiagnostics logs full protocol messages, including bearer tokens and PII, and must only be enabled when IHostEnvironment.IsDevelopment() returns true. " +
+            "Set the parameter to false (or only set it to true inside an `if (builder.Environment.IsDevelopment()) { ... }` block) and redeploy.";
 
         // Authorization IDW10200 = "IDW10200:"
         public const string NeitherScopeOrRolesClaimFoundInToken = "IDW10201: Neither scope nor roles claim was found in the bearer token. Authentication scheme used: '{0}'. ";

--- a/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnosticsEnvironmentValidator.cs
+++ b/src/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnosticsEnvironmentValidator.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Identity.Web.Resource
+{
+    /// <summary>
+    /// Hosted service that fails fast on application startup if the OpenID Connect
+    /// middleware diagnostics were enabled in a non-Development environment.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="OpenIdConnectMiddlewareDiagnostics"/> writes full OpenID Connect
+    /// protocol messages (including bearer tokens, codes, and PII) to the logger at
+    /// Debug level. The validator is only registered when the caller passes
+    /// <c>subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: true</c>, so a
+    /// successful registration outside Development means a production deployment is
+    /// about to leak credentials. Throwing in <see cref="StartAsync"/> aborts host
+    /// startup before any HTTP request can trigger the diagnostic.
+    /// </remarks>
+    internal sealed class OpenIdConnectMiddlewareDiagnosticsEnvironmentValidator : IHostedService
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public OpenIdConnectMiddlewareDiagnosticsEnvironmentValidator(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            IHostEnvironment? environment = _serviceProvider.GetService<IHostEnvironment>();
+            if (environment is null || !environment.IsDevelopment())
+            {
+                throw new InvalidOperationException(IDWebErrorMessage.OpenIdConnectMiddlewareDiagnosticsRequiresDevelopmentEnvironment);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -274,6 +274,8 @@ namespace Microsoft.Identity.Web
             if (subscribeToOpenIdConnectMiddlewareDiagnosticsEvents)
             {
                 builder.Services.AddSingleton<IOpenIdConnectMiddlewareDiagnostics, OpenIdConnectMiddlewareDiagnostics>();
+                builder.Services.TryAddEnumerable(
+                    ServiceDescriptor.Singleton<IHostedService, OpenIdConnectMiddlewareDiagnosticsEnvironmentValidator>());
             }
 
             if (AppServicesAuthenticationInformation.IsAppServicesAadAuthenticationEnabled)

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -182,6 +182,81 @@ namespace Microsoft.Identity.Web.Test
             AddMicrosoftIdentityWebApp_TestSubscribesToDiagnostics(services, diagnosticsMock, subscribeToDiagnostics);
         }
 
+        [Theory]
+        [InlineData("Development", false)]
+        [InlineData("Staging", true)]
+        [InlineData("Production", true)]
+        [InlineData("", true)]
+        public async Task AddMicrosoftIdentityWebApp_SubscribeToDiagnostics_ThrowsOutsideDevelopmentAsync(string environmentName, bool expectThrow)
+        {
+            // Arrange
+            var configMock = Substitute.For<IConfiguration>();
+            configMock.Configure().GetSection(ConfigSectionName).Returns(_configSection);
+
+            var env = new HostingEnvironment { EnvironmentName = environmentName };
+
+            var services = new ServiceCollection();
+            services.AddSingleton(configMock);
+            services.AddDataProtection();
+            services.AddSingleton<IHostEnvironment>(env);
+
+            services.AddAuthentication()
+                .AddMicrosoftIdentityWebApp(
+                    configMock,
+                    ConfigSectionName,
+                    OidcScheme,
+                    CookieScheme,
+                    subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: true);
+
+            using var provider = services.BuildServiceProvider();
+            var hostedServices = provider.GetServices<IHostedService>()
+                .OfType<OpenIdConnectMiddlewareDiagnosticsEnvironmentValidator>()
+                .ToList();
+
+            // Act
+            Assert.Single(hostedServices);
+
+            // Assert
+            if (expectThrow)
+            {
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => hostedServices[0].StartAsync(default));
+                Assert.Contains("IDW10117", ex.Message, StringComparison.Ordinal);
+            }
+            else
+            {
+                await hostedServices[0].StartAsync(default);
+            }
+        }
+
+        [Fact]
+        public void AddMicrosoftIdentityWebApp_SubscribeFalse_DoesNotRegisterValidator()
+        {
+            // Arrange
+            var configMock = Substitute.For<IConfiguration>();
+            configMock.Configure().GetSection(ConfigSectionName).Returns(_configSection);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(configMock);
+            services.AddDataProtection();
+            services.AddSingleton((provider) => _env);
+
+            // Act
+            services.AddAuthentication()
+                .AddMicrosoftIdentityWebApp(
+                    configMock,
+                    ConfigSectionName,
+                    OidcScheme,
+                    CookieScheme,
+                    subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: false);
+
+            using var provider = services.BuildServiceProvider();
+
+            // Assert
+            Assert.Empty(provider.GetServices<IHostedService>()
+                .OfType<OpenIdConnectMiddlewareDiagnosticsEnvironmentValidator>());
+        }
+
         [Fact]
         public Task AddMicrosoftIdentityWebApp_WithConfigAuthority_TestCorrectMetadataAddressAsync()
         {


### PR DESCRIPTION
## Description

`OpenIdConnectMiddlewareDiagnostics.DisplayProtocolMessage` reflected every `OpenIdConnectMessage` property to the Debug log, leaking bearer credentials (tokens, codes, secrets, client assertions, passwords) and PII (login hints, usernames, sids, etc.) in cleartext to anyone running with `LogLevel.Debug`.

Each property is now gated by the same two flags `Microsoft.IdentityModel.Logging` uses for its own output:

| Class | Gate | Fields |
|---|---|---|
| Security artifact | `IdentityModelEventSource.LogCompleteSecurityArtifact` | `Code`, `IdToken`, `IdTokenHint`, `AccessToken`, `RefreshToken`, `ClientSecret`, `ClientAssertion`, `Password` |
| PII / correlation | `IdentityModelEventSource.ShowPII` | `LoginHint`, `Username`, `UserId`, `Nonce`, `State`, `Sid` |

`ShowPII` is the master switch — when it is `false`, `LogCompleteSecurityArtifact` has no effect, matching `LogHelper.FormatInvariant`. Redacted values reuse Wilson's `HiddenPIIString` / `HiddenSecurityArtifactString` constants so the wording and `aka.ms` links are consistent with the rest of the IdentityModel stack.

No public API changes. New `[Theory]` covers all four flag combinations.
