### PR TITLE
Prevent OpenIdConnectMiddlewareDiagnostics from logging sensitive values

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/IDWebErrorMessage.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Identity.Web
         public const string ClientSecretAndCredentialsCannotBeCombined = "IDW10110: ClientSecret top level configuration cannot be combined with ClientCredentials. Instead, add a new entry in the ClientCredentials array describing the secret.";
         public const string MissingTokenBindingCertificate = "IDW10115: A signing certificate, which is required for token binding, is missing in loaded credentials.";
         public const string TokenBindingRequiresEnabledAppTokenAcquisition = "IDW10116: Token binding requires enabled app token acquisition.";
+        public const string OpenIdConnectMiddlewareDiagnosticsRequiresDevelopmentEnvironment = "IDW10117: OpenIdConnectMiddlewareDiagnostics logs full protocol messages, including bearer tokens and PII, and must only be enabled when running the code locally.";
 
         // Authorization IDW10200 = "IDW10200:"
         public const string NeitherScopeOrRolesClaimFoundInToken = "IDW10201: Neither scope nor roles claim was found in the bearer token. Authentication scheme used: '{0}'. ";

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.Resource;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -273,7 +274,21 @@ namespace Microsoft.Identity.Web
 
             if (subscribeToOpenIdConnectMiddlewareDiagnosticsEvents)
             {
-                builder.Services.AddSingleton<IOpenIdConnectMiddlewareDiagnostics, OpenIdConnectMiddlewareDiagnostics>();
+                // OpenIdConnectMiddlewareDiagnostics logs full protocol messages, including
+                // bearer tokens and PII, at Debug level. Register a factory so that any caller
+                // resolving the diagnostic (see line 437 below, fired during OIDC option
+                // configuration at host startup) fails fast outside the Development environment.
+                builder.Services.AddSingleton<IOpenIdConnectMiddlewareDiagnostics>(serviceProvider =>
+                {
+                    IHostEnvironment? environment = serviceProvider.GetService<IHostEnvironment>();
+                    if (environment is null || !environment.IsDevelopment())
+                    {
+                        throw new InvalidOperationException(IDWebErrorMessage.OpenIdConnectMiddlewareDiagnosticsRequiresDevelopmentEnvironment);
+                    }
+
+                    return new OpenIdConnectMiddlewareDiagnostics(
+                        serviceProvider.GetRequiredService<ILogger<OpenIdConnectMiddlewareDiagnostics>>());
+                });
             }
 
             if (AppServicesAuthenticationInformation.IsAppServicesAadAuthenticationEnabled)

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -182,6 +182,77 @@ namespace Microsoft.Identity.Web.Test
             AddMicrosoftIdentityWebApp_TestSubscribesToDiagnostics(services, diagnosticsMock, subscribeToDiagnostics);
         }
 
+        [Theory]
+        [InlineData("Development", false)]
+        [InlineData("Staging", true)]
+        [InlineData("Production", true)]
+        [InlineData("", true)]
+        public void AddMicrosoftIdentityWebApp_SubscribeToDiagnostics_ThrowsOutsideDevelopment(string environmentName, bool expectThrow)
+        {
+            // Arrange
+            var configMock = Substitute.For<IConfiguration>();
+            configMock.Configure().GetSection(ConfigSectionName).Returns(_configSection);
+
+            var env = new HostingEnvironment { EnvironmentName = environmentName };
+
+            var services = new ServiceCollection();
+            services.AddSingleton(configMock);
+            services.AddLogging();
+            services.AddDataProtection();
+            services.AddSingleton<IHostEnvironment>(env);
+
+            services.AddAuthentication()
+                .AddMicrosoftIdentityWebApp(
+                    configMock,
+                    ConfigSectionName,
+                    OidcScheme,
+                    CookieScheme,
+                    subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: true);
+
+            using var provider = services.BuildServiceProvider();
+
+            // Act + Assert
+            if (expectThrow)
+            {
+                var ex = Assert.Throws<InvalidOperationException>(
+                    () => provider.GetRequiredService<IOpenIdConnectMiddlewareDiagnostics>());
+                Assert.Contains("IDW10117", ex.Message, StringComparison.Ordinal);
+            }
+            else
+            {
+                var diagnostics = provider.GetRequiredService<IOpenIdConnectMiddlewareDiagnostics>();
+                Assert.NotNull(diagnostics);
+            }
+        }
+
+        [Fact]
+        public void AddMicrosoftIdentityWebApp_SubscribeFalse_DoesNotRegisterDiagnostics()
+        {
+            // Arrange
+            var configMock = Substitute.For<IConfiguration>();
+            configMock.Configure().GetSection(ConfigSectionName).Returns(_configSection);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(configMock);
+            services.AddLogging();
+            services.AddDataProtection();
+            services.AddSingleton((provider) => _env);
+
+            // Act
+            services.AddAuthentication()
+                .AddMicrosoftIdentityWebApp(
+                    configMock,
+                    ConfigSectionName,
+                    OidcScheme,
+                    CookieScheme,
+                    subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: false);
+
+            using var provider = services.BuildServiceProvider();
+
+            // Assert
+            Assert.Null(provider.GetService<IOpenIdConnectMiddlewareDiagnostics>());
+        }
+
         [Fact]
         public Task AddMicrosoftIdentityWebApp_WithConfigAuthority_TestCorrectMetadataAddressAsync()
         {


### PR DESCRIPTION
## Description

The diagnostic is now built by a factory that throws `IDW10117` unless `IHostEnvironment.IsDevelopment()` returns true, so any authentication attempt outside Development fails before the handler can log the message.

Supersedes #3847.
