### PR TITLE
Pin OIDC sign-in Authority precedence (parity with MSAL conflict tests)

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsAuthorityConflictTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsAuthorityConflictTests.cs
@@ -1,0 +1,455 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web.Test.Common;
+using NSubstitute;
+using NSubstitute.Extensions;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    /// <summary>
+    /// Pinning tests for the OIDC sign-in code path in
+    /// <see cref="MicrosoftIdentityWebAppAuthenticationBuilderExtensions"/> when Authority
+    /// is configured alongside Instance/TenantId/Domain/SignUpSignInPolicyId. OIDC counterpart
+    /// of <see cref="MergedOptionsAuthorityConflictTests"/>; see each test for parity notes.
+    /// </summary>
+    public class WebAppExtensionsAuthorityConflictTests
+    {
+        private const string OidcScheme = "OpenIdConnect-Custom";
+        private const string CookieScheme = "Cookies-Custom";
+        private const string ConfigSectionName = "AzureAd-Custom";
+
+        // All-zeros GUID lets failures fail loudly: if Authority ever stops winning,
+        // this value would not appear in OpenIdConnectOptions.Authority.
+        private const string BogusTenantGuid = "00000000-0000-0000-0000-000000000000";
+
+        private const string BogusAadAuthority = "https://login.microsoftonline.com/" + BogusTenantGuid + "/v2.0";
+        private const string BogusB2CAuthority = "https://fakeb2c.b2clogin.com/" + BogusTenantGuid + "/b2c_1_bogus";
+        private const string BogusCiamAuthority = "https://fakeciam.ciamlogin.com/" + BogusTenantGuid;
+
+        private readonly IHostEnvironment _env = new HostingEnvironment { EnvironmentName = Environments.Development };
+
+        // ----- AAD: precedence (behavior pinning) -----
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstance_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
+            var options = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: null);
+
+            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndTenantId_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndTenantId_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
+            var options = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: null,
+                tenantId: TestConstants.TenantIdAsGuid);
+
+            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstanceAndTenantId_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
+            var options = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: TestConstants.TenantIdAsGuid);
+
+            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain(TestConstants.TenantIdAsGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityOnly_PropagatesAuthorityAsIs()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityOnly_LogsAuthorityUsedHint. Divergence: MSAL parses Authority + logs EventId 501; OIDC propagates Authority verbatim.
+            var options = BuildAndGetOidcOptions(
+                authority: TestConstants.AuthorityWithTenantSpecifiedWithV2,
+                instance: null,
+                tenantId: null);
+
+            Assert.Equal(TestConstants.AuthorityWithTenantSpecifiedWithV2, options.Authority);
+        }
+
+        [Fact]
+        public void OidcSignIn_InstanceAndTenantIdOnly_ComposesAuthorityFromInstanceTenantId()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_InstanceAndTenantIdOnly_NoWarning. Same outcome on both paths (no Authority -> Instance+TenantId compose).
+            var options = BuildAndGetOidcOptions(
+                authority: null,
+                instance: TestConstants.AadInstance,
+                tenantId: TestConstants.TenantIdAsGuid);
+
+            Assert.Contains(TestConstants.TenantIdAsGuid, options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        // ----- B2C: precedence (behavior pinning) -----
+
+        [Fact]
+        public void OidcSignIn_B2CAuthorityAndInstance_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_B2CAuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
+            var options = BuildAndGetOidcOptions(
+                authority: BogusB2CAuthority,
+                instance: TestConstants.B2CInstance,
+                tenantId: null,
+                domain: TestConstants.B2CTenant,
+                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow);
+
+            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain(TestConstants.B2CTenant, options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_B2CInstanceAndDomain_ComposesAuthorityFromInstanceDomainUserFlow()
+        {
+            // No MSAL counterpart; control: BuildAuthority composes "Instance/Domain/UserFlow/v2.0".
+            var options = BuildAndGetOidcOptions(
+                authority: null,
+                instance: TestConstants.B2CInstance,
+                tenantId: null,
+                domain: TestConstants.B2CTenant,
+                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow);
+
+            Assert.Contains(TestConstants.B2CTenant, options.Authority, StringComparison.Ordinal);
+            Assert.Contains(TestConstants.B2CSignUpSignInUserFlow, options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        // ----- CIAM: precedence (behavior pinning) -----
+
+        [Fact]
+        public void OidcSignIn_CiamAuthorityAndInstance_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_CiamAuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority (BuildCiamAuthorityIfNeeded preserves it).
+            var options = BuildAndGetOidcOptions(
+                authority: BogusCiamAuthority,
+                instance: TestConstants.CIAMInstance,
+                tenantId: null);
+
+            Assert.Contains("fakeciam", options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain("catsareawesome", options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_CiamAuthorityOnly_PropagatesAuthorityThroughCiamHelper()
+        {
+            // No MSAL counterpart; control: BuildCiamAuthorityIfNeeded preserves Authority, EnsureAuthorityIsV2 appends /v2.0.
+            var options = BuildAndGetOidcOptions(
+                authority: TestConstants.CIAMAuthorityV2,
+                instance: null,
+                tenantId: null);
+
+            Assert.Contains("ciamlogin.com", options.Authority, StringComparison.Ordinal);
+            Assert.Contains(TestConstants.CIAMTenant, options.Authority, StringComparison.Ordinal);
+        }
+
+        // ----- Log assertions (the bug evidence) -----
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: null,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.Message.Contains("is being ignored", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndTenantId_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndTenantId_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: null,
+                tenantId: TestConstants.TenantIdAsGuid,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstanceAndTenantId_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: TestConstants.TenantIdAsGuid,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityOnly_DoesNotLogAuthorityUsedHint()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityOnly_LogsAuthorityUsedHint (EventId 501, 1P hint). Divergence: OIDC never surfaces this hint.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: TestConstants.AuthorityWithTenantSpecifiedWithV2,
+                instance: null,
+                tenantId: null,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 501);
+        }
+
+        [Fact]
+        public void OidcSignIn_InstanceAndTenantIdOnly_DoesNotLogAnyAuthorityWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_InstanceAndTenantIdOnly_NoWarning. Same outcome on both paths (no Authority -> no warnings).
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: null,
+                instance: TestConstants.AadInstance,
+                tenantId: TestConstants.TenantIdAsGuid,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500 || e.EventId.Id == 501);
+        }
+
+        [Fact]
+        public void OidcSignIn_B2CAuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_B2CAuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusB2CAuthority,
+                instance: TestConstants.B2CInstance,
+                tenantId: null,
+                domain: TestConstants.B2CTenant,
+                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+        }
+
+        [Fact]
+        public void OidcSignIn_CiamAuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_CiamAuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusCiamAuthority,
+                instance: TestConstants.CIAMInstance,
+                tenantId: null,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+        }
+
+        // ----- Robustness -----
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstance_DoesNotThrowWhenNoLoggerRegistered()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_NoLogger_NoException. Same intent: no exception when no logger is registered.
+            var ex = Record.Exception(() => BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: null,
+                loggerProvider: null));
+
+            Assert.Null(ex);
+        }
+
+        // ----- Helpers -----
+
+        /// <summary>
+        /// Builds AddMicrosoftIdentityWebApp from a synthetic config section and returns the
+        /// resolved OpenIdConnectOptions. Pass a loggerProvider to capture log entries.
+        /// </summary>
+        private OpenIdConnectOptions BuildAndGetOidcOptions(
+            string? authority,
+            string? instance,
+            string? tenantId,
+            string? domain = null,
+            string? signUpSignInPolicyId = null,
+            TestLoggerProvider? loggerProvider = null)
+        {
+            var configSection = BuildConfigSection(
+                ConfigSectionName,
+                authority: authority,
+                instance: instance,
+                tenantId: tenantId,
+                domain: domain,
+                signUpSignInPolicyId: signUpSignInPolicyId,
+                clientId: TestConstants.ClientId);
+
+            var configMock = Substitute.For<IConfiguration>();
+            configMock.Configure().GetSection(ConfigSectionName).Returns(configSection);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(configMock);
+            services.AddDataProtection();
+            services.AddSingleton(_env);
+
+            if (loggerProvider is not null)
+            {
+                services.AddLogging(b =>
+                {
+                    b.SetMinimumLevel(LogLevel.Trace);
+                    b.AddProvider(loggerProvider);
+                });
+            }
+
+            services.AddAuthentication()
+                .AddMicrosoftIdentityWebApp(
+                    configMock,
+                    ConfigSectionName,
+                    OidcScheme,
+                    CookieScheme,
+                    subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: false);
+
+            using var provider = services.BuildServiceProvider();
+            return provider.GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>().Get(OidcScheme);
+        }
+
+        /// <summary>
+        /// In-memory IConfigurationSection populated only with non-null keys; ClientId is required
+        /// to satisfy MergedOptionsValidation. Omitting keys leaves MergedOptions properties null,
+        /// which is what selects the precedence branches under test.
+        /// </summary>
+        private static IConfigurationSection BuildConfigSection(
+            string configSectionName,
+            string? authority,
+            string? instance,
+            string? tenantId,
+            string? domain,
+            string? signUpSignInPolicyId,
+            string clientId)
+        {
+            var configAsDictionary = new Dictionary<string, string?>
+            {
+                { configSectionName, null },
+                { $"{configSectionName}:ClientId", clientId },
+            };
+
+            if (authority is not null)
+            {
+                configAsDictionary[$"{configSectionName}:Authority"] = authority;
+            }
+
+            if (instance is not null)
+            {
+                configAsDictionary[$"{configSectionName}:Instance"] = instance;
+            }
+
+            if (tenantId is not null)
+            {
+                configAsDictionary[$"{configSectionName}:TenantId"] = tenantId;
+            }
+
+            if (domain is not null)
+            {
+                configAsDictionary[$"{configSectionName}:Domain"] = domain;
+            }
+
+            if (signUpSignInPolicyId is not null)
+            {
+                configAsDictionary[$"{configSectionName}:SignUpSignInPolicyId"] = signUpSignInPolicyId;
+            }
+
+            var memoryConfigSource = new MemoryConfigurationSource { InitialData = configAsDictionary };
+
+            var configBuilder = new ConfigurationBuilder();
+            configBuilder.Add(memoryConfigSource);
+
+            return configBuilder.Build().GetSection(configSectionName);
+        }
+
+        /// <summary>Single captured log entry.</summary>
+        private sealed record TestLogEntry(LogLevel LogLevel, EventId EventId, string Message, string Category);
+
+        /// <summary>
+        /// ILogger that captures every call into a shared list (always enabled, all levels).
+        /// </summary>
+        private sealed class TestLogger : ILogger
+        {
+            private readonly string _category;
+            public List<TestLogEntry> Entries { get; }
+
+            public TestLogger(string category, List<TestLogEntry> entries)
+            {
+                _category = category;
+                Entries = entries;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                Entries.Add(new TestLogEntry(logLevel, eventId, formatter(state, exception), _category));
+            }
+        }
+
+        /// <summary>
+        /// ILoggerProvider routing every category-specific logger into a single shared
+        /// TestLogger so tests can assert across categories via <see cref="Logger"/>.
+        /// </summary>
+        private sealed class TestLoggerProvider : ILoggerProvider
+        {
+            private readonly List<TestLogEntry> _entries = new();
+
+            public TestLogger Logger { get; }
+
+            public TestLoggerProvider()
+            {
+                Logger = new TestLogger(category: "(aggregate)", entries: _entries);
+            }
+
+            public ILogger CreateLogger(string categoryName) => new TestLogger(categoryName, _entries);
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add 17 pinning tests for the OIDC sign-in code path with parity to the MSAL conflict suite.

## Description

`MergedOptionsAuthorityConflictTests` covers the MSAL token-acquisition path when `Authority` is configured alongside `Instance`, `TenantId`, `Domain`, or `SignUpSignInPolicyId`. There is currently no equivalent coverage for the OIDC sign-in path in `MicrosoftIdentityWebAppAuthenticationBuilderExtensions`, and the two paths exhibit **different** precedence and logging semantics today:

| Scenario | Token-acquisition (`MergedOptions.ParseAuthorityIfNecessary`) | OIDC sign-in (`AddMicrosoftIdentityWebApp` -> `Configure<OpenIdConnectOptions>`) |
|---|---|---|
| `Authority` + `Instance`/`TenantId`/both | `Instance`+`TenantId` win; `Authority` ignored; logs `AuthorityIgnored` (EventId 500) | `Authority` wins verbatim; `Instance`/`TenantId` are dead config; no warning |
| `Authority` only | Parses `Authority` into `Instance`+`TenantId`; logs `AuthorityUsedConsiderInstanceTenantId` (EventId 501) | Propagates `Authority` verbatim (after `EnsureAuthorityIsV2`); no parsing, no hint |
| `Instance`+`TenantId` only | No warning; values unchanged | `AuthorityHelpers.BuildAuthority` composes `Instance/TenantId/v2.0` |

This divergence is observable to library users and isn't documented anywhere we can find. The downstream docs (and PR #3617) describe the `Instance`+`TenantId`-wins precedence as if it were universal, but it only holds for the token-acquisition path.

## When each code path runs in a sample app

A typical ASP.NET Core web app that signs users in and calls a downstream API exercises both paths -- but at different times.

### OIDC sign-in path (Authority wins, no warning)

Triggered on every sign-in challenge by the ASP.NET Core authentication middleware.

```
Program.cs
  services.AddAuthentication(...)
        .AddMicrosoftIdentityWebApp(config, "AzureAd", ...)   // registers Configure<OpenIdConnectOptions>
        .EnableTokenAcquisitionToCallDownstreamApi(...)
        .AddInMemoryTokenCaches();

Request to a [Authorize] action
  AuthenticationMiddleware
   -> CookieAuthenticationHandler  (no auth cookie)
   -> OpenIdConnectHandler.HandleChallengeAsync
       -> IOptionsMonitor<OpenIdConnectOptions>.Get(scheme)
           -> runs the Configure<OpenIdConnectOptions> callback registered by
              MicrosoftIdentityWebAppAuthenticationBuilderExtensions
              (src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs:310)
               -> if mergedOptions.Authority != null:
                      AuthorityHelpers.GetAuthorityWithoutQueryIfNeeded
                      AuthorityHelpers.BuildCiamAuthorityIfNeeded
                      PopulateOpenIdOptionsFromMergedOptions    // options.Authority <- mergedOptions.Authority
                  // else (Authority blank): options.Authority = AuthorityHelpers.BuildAuthority(mergedOptions)
                  options.Authority = AuthorityHelpers.EnsureAuthorityIsV2(options.Authority)
       -> redirect to options.Authority/oauth2/v2.0/authorize
```

No call to `ParseAuthorityIfNecessary` anywhere on this path; no EventId 500 / 501 ever fires.

### MSAL token-acquisition path (Instance+TenantId wins, EventId 500 logged on conflict)

Triggered later, only when the app actually asks for an access token.

```
Controller action
  await _tokenAcquisition.GetAccessTokenForUserAsync(scopes)
   (or via _downstreamApi.CallApiForUserAsync(...))
   -> TokenAcquisition.GetAuthenticationResultForUserAsync
       (src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs)
       -> _tokenAcquisitionHost.GetOptions(scheme, out _)
           -> TokenAcquisitionAspnetCoreHost.GetOptions
              (src/Microsoft.Identity.Web.TokenAcquisition/AspNetCore/TokenAcquisitionAspnetCoreHost.cs:54)
               -> _mergedOptionsMonitor.Get(scheme)
               -> MergedOptions.ParseAuthorityIfNecessary(mergedOptions)   // <-- the only call site
                   - if Authority AND (Instance OR TenantId) configured:
                       overwrites mergedOptions.Authority with Instance/TenantId/v2.0
                       logs MergedOptionsLogging.AuthorityIgnored (EventId 500)
                   - if Authority only:
                       parses Authority into mergedOptions.Instance + TenantId
                       logs AuthorityUsedConsiderInstanceTenantId (EventId 501)
       -> GetOrBuildConfidentialClientApplicationAsync(mergedOptions)
           -> ConfidentialClientApplicationBuilder.WithAuthority(mergedOptions.Authority)
```

`ParseAuthorityIfNecessary` is called from three hosts in the same way: `TokenAcquisitionAspnetCoreHost.cs:61`, `DefaultTokenAcquisitionHost.cs:54`, and `OwinTokenAcquisitionHost.cs:56`.

### Net effect

For an app configured with both `Authority` and `Instance`+`TenantId`:

- Sign-in goes to the IdP encoded in `Authority` (OIDC path).
- The downstream-API token is requested from the IdP encoded in `Instance`+`TenantId` (MSAL path) -- silently, with EventId 500 in the logs only if you have Information-level logging enabled.

If those two values disagree, the user signs in against one tenant and gets tokens for another. That mismatch is what these tests pin.

### What this PR adds

A single new test class `WebAppExtensionsAuthorityConflictTests` (455 lines, 17 tests) covering:

- **AAD precedence (5):** `Authority`+`Instance`, `Authority`+`TenantId`, `Authority`+both, `Authority`-only (control), `Instance`+`TenantId`-only (control)
- **B2C precedence (2):** `Authority`+`Instance`+`Domain`+`SignUpSignInPolicyId` conflict, plus `Instance`+`Domain`+`UserFlow` composition control
- **CIAM precedence (2):** `Authority`+`Instance` conflict, plus `Authority`-only-through-`BuildCiamAuthorityIfNeeded` control
- **Log assertions (7):** explicit `DoesNotContain(EventId.Id == 500)` / `== 501` checks for each conflict scenario across AAD/B2C/CIAM -- the strongest single piece of evidence that the divergence is real
- **Robustness (1):** mirrors MSAL's `NoLogger_NoException` -- builds a `ServiceProvider` with no `AddLogging()` registered and asserts no exception

Every test carries a comment of one of three shapes so the file can be skim-reviewed against the MSAL suite:
- `// MSAL parity: <MethodName>. Divergence: ...` (11 tests)
- `// MSAL parity: <MethodName>. Same outcome on both paths.` (3 control / robustness tests)
- `// No MSAL counterpart; ...` (the 2 OIDC-only tests)
