### PR TITLE
Fix CVE-2026-48109: Pin MessagePack to patched version 2.5.301

### DIFF
--- a/tests/DevApps/AspireBlazorCallsWebApi/AspireBlazorCallsWebApi.AppHost/AspireBlazorCallsWebApi.AppHost.csproj
+++ b/tests/DevApps/AspireBlazorCallsWebApi/AspireBlazorCallsWebApi.AppHost/AspireBlazorCallsWebApi.AppHost.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Force patched MessagePack to resolve CVE-2026-48109 (transitive via Aspire.Hosting → StackExchange.Redis) -->
+    <PackageReference Include="MessagePack" Version="2.5.301" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AspireBlazorCallsWebApi.ApiService\AspireBlazorCallsWebApi.ApiService.csproj" />
     <ProjectReference Include="..\AspireBlazorCallsWebApi.Web\AspireBlazorCallsWebApi.Web.csproj" />
   </ItemGroup>


### PR DESCRIPTION
# Fix CVE-2026-48109: Pin MessagePack to patched version 2.5.301
 
 - [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
 - [ ] You've included unit or integration tests for your change, where applicable.
 - [ ] You've included inline docs for your change, where applicable.
 - [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
 
 ## Description
 
 The Component Alert flagged **MessagePack 2.5.192** (High severity — CVE-2026-48109) in the Aspire AppHost project.
 
 This package is not referenced directly — it's pulled in transitively via:
 

Aspire.AppHost.Sdk/13.1.2 → Aspire.Hosting.* → StackExchange.Redis → MessagePack 2.5.192

 
 Adding an explicit `<PackageReference Include="MessagePack" Version="2.5.301" />` forces NuGet to resolve the patched version, clearing the alert.
 
 No functional changes — this only affects transitive dependency resolution in a test/dev app.