### PR TITLE
Throw on Authority vs Instance/TenantId conflict (OIDC + MSAL parity)

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -86,13 +86,23 @@ namespace Microsoft.Identity.Web
             set { if (value) _authorityExplicitlyConfigured = true; }
         }
 
+        // Latch: once true, never reverts to false. Distinguishes user-configured
+        // Instance/TenantId from values derived by ParseAuthorityIfNecessary.
+        private bool _instanceOrTenantIdExplicitlyConfigured;
+        internal bool InstanceOrTenantIdExplicitlyConfigured
+        {
+            get => _instanceOrTenantIdExplicitlyConfigured;
+            set { if (value) _instanceOrTenantIdExplicitlyConfigured = true; }
+        }
+
         // Set after ParseAuthorityIfNecessary runs; makes subsequent calls no-op.
         private bool _authorityParsed;
 
-        // Throws if the user explicitly configured Authority AND Instance/TenantId.
+        // Throws if the user explicitly configured BOTH Authority AND Instance/TenantId.
         internal void ThrowIfAuthorityConflict()
         {
             if (AuthorityExplicitlyConfigured &&
+                InstanceOrTenantIdExplicitlyConfigured &&
                 !string.IsNullOrEmpty(Authority) &&
                 (!string.IsNullOrEmpty(Instance) || !string.IsNullOrEmpty(TenantId)))
             {
@@ -307,6 +317,7 @@ namespace Microsoft.Identity.Web
             if (string.IsNullOrEmpty(mergedOptions.Instance) && !string.IsNullOrEmpty(microsoftIdentityOptions.Instance))
             {
                 mergedOptions.Instance = microsoftIdentityOptions.Instance;
+                mergedOptions.InstanceOrTenantIdExplicitlyConfigured = true;
             }
 
             if (microsoftIdentityOptions.ResetPasswordPath != Constants.ResetPasswordPath)
@@ -366,6 +377,7 @@ namespace Microsoft.Identity.Web
             if (string.IsNullOrEmpty(mergedOptions.TenantId) && !string.IsNullOrEmpty(microsoftIdentityOptions.TenantId))
             {
                 mergedOptions.TenantId = microsoftIdentityOptions.TenantId;
+                mergedOptions.InstanceOrTenantIdExplicitlyConfigured = true;
             }
 
             mergedOptions.TokenDecryptionCertificates ??= microsoftIdentityOptions.TokenDecryptionCertificates;
@@ -420,6 +432,7 @@ namespace Microsoft.Identity.Web
             if (string.IsNullOrEmpty(mergedOptions.Instance) && !string.IsNullOrEmpty(confidentialClientApplicationOptions.Instance))
             {
                 mergedOptions.Instance = confidentialClientApplicationOptions.Instance;
+                mergedOptions.InstanceOrTenantIdExplicitlyConfigured = true;
             }
 
             mergedOptions.IsDefaultPlatformLoggingEnabled |= confidentialClientApplicationOptions.IsDefaultPlatformLoggingEnabled;
@@ -434,6 +447,7 @@ namespace Microsoft.Identity.Web
             if (string.IsNullOrEmpty(mergedOptions.TenantId) && !string.IsNullOrEmpty(confidentialClientApplicationOptions.TenantId))
             {
                 mergedOptions.TenantId = confidentialClientApplicationOptions.TenantId;
+                mergedOptions.InstanceOrTenantIdExplicitlyConfigured = true;
             }
 
             mergedOptions._confidentialClientApplicationOptions = null;

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -77,6 +77,18 @@ namespace Microsoft.Identity.Web
          */
         internal bool PreserveAuthority { get; set; }
 
+        // Latch: once true, never reverts to false. Distinguishes user-configured Authority
+        // from the synthetic value computed by MicrosoftEntraApplicationOptions.Authority getter.
+        private bool _authorityExplicitlyConfigured;
+        internal bool AuthorityExplicitlyConfigured
+        {
+            get => _authorityExplicitlyConfigured;
+            set { if (value) _authorityExplicitlyConfigured = true; }
+        }
+
+        // Set after ParseAuthorityIfNecessary runs; makes subsequent calls no-op.
+        private bool _authorityParsed;
+
         /// <summary>
         /// Id Web will modify the instance so that it can be used by MSAL.
         /// This modifies this property so that the original value is not changed.
@@ -298,6 +310,7 @@ namespace Microsoft.Identity.Web
             if (string.IsNullOrEmpty(mergedOptions.Authority) && !string.IsNullOrEmpty(microsoftIdentityOptions.Authority))
             {
                 mergedOptions.Authority = microsoftIdentityOptions.Authority;
+                mergedOptions.AuthorityExplicitlyConfigured = true;
             }
 
             mergedOptions.ClientCredentials ??= microsoftIdentityOptions.ClientCredentials;
@@ -473,22 +486,26 @@ namespace Microsoft.Identity.Web
          */
         internal static void ParseAuthorityIfNecessary(MergedOptions mergedOptions, IdWebLogger.ILogger? logger = null)
         {
-            // Check if Authority is configured but being ignored due to Instance/TenantId taking precedence
-            if (!string.IsNullOrEmpty(mergedOptions.Authority) &&
-                (!string.IsNullOrEmpty(mergedOptions.Instance) || !string.IsNullOrEmpty(mergedOptions.TenantId)))
-            {
-                // Log warning that Authority is being ignored
-                if (logger != null)
-                {
-                    MergedOptionsLogging.AuthorityIgnored(
-                        logger,
-                        mergedOptions.Authority!,
-                        mergedOptions.Instance ?? string.Empty,
-                        mergedOptions.TenantId ?? string.Empty);
-                }
-                // Authority is ignored; Instance and TenantId take precedence
-                return;
-            }
+           if (mergedOptions._authorityParsed)
+           {
+               return;
+           }
+
+           if (!string.IsNullOrEmpty(mergedOptions.Authority) &&
+               (!string.IsNullOrEmpty(mergedOptions.Instance) || !string.IsNullOrEmpty(mergedOptions.TenantId)))
+           {
+               if (mergedOptions.AuthorityExplicitlyConfigured)
+               {
+                   throw new InvalidOperationException(
+                       $"[MsIdWeb] Both 'Authority' ('{mergedOptions.Authority}') and 'Instance'/TenantId' " +
+                       $"('{mergedOptions.Instance ?? string.Empty}', '{mergedOptions.TenantId ?? string.Empty}') are configured. " +
+                       "These settings conflict. Remove either 'Authority' or 'Instance'/'TenantId' from the configuration.");
+               }
+
+               // Authority was synthesized (e.g. by MicrosoftEntraApplicationOptions computed getter) -- not a real conflict.
+               mergedOptions._authorityParsed = true;
+               return;
+           }
 
             if (string.IsNullOrEmpty(mergedOptions.TenantId) && string.IsNullOrEmpty(mergedOptions.Instance) && !string.IsNullOrEmpty(mergedOptions.Authority))
             {
@@ -543,6 +560,8 @@ namespace Microsoft.Identity.Web
                     mergedOptions.Instance = mergedOptions.PreserveAuthority ? mergedOptions.Authority! : authoritySpan.Slice(0, indexTenant).ToString();
                     mergedOptions.TenantId = mergedOptions.PreserveAuthority ? null : authoritySpan.Slice(indexTenant + 1, indexEndOfTenant - indexTenant - 1).ToString();
                 }
+
+                mergedOptions._authorityParsed = true;
             }
         }
 
@@ -552,6 +571,7 @@ namespace Microsoft.Identity.Web
             if (string.IsNullOrEmpty(mergedOptions.Authority) && !string.IsNullOrEmpty(jwtBearerOptions.Authority))
             {
                 mergedOptions.Authority = jwtBearerOptions.Authority;
+                mergedOptions.AuthorityExplicitlyConfigured = true;
             }
         }
 #endif

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MergedOptions.cs
@@ -89,6 +89,20 @@ namespace Microsoft.Identity.Web
         // Set after ParseAuthorityIfNecessary runs; makes subsequent calls no-op.
         private bool _authorityParsed;
 
+        // Throws if the user explicitly configured Authority AND Instance/TenantId.
+        internal void ThrowIfAuthorityConflict()
+        {
+            if (AuthorityExplicitlyConfigured &&
+                !string.IsNullOrEmpty(Authority) &&
+                (!string.IsNullOrEmpty(Instance) || !string.IsNullOrEmpty(TenantId)))
+            {
+                throw new InvalidOperationException(
+                    $"[MsIdWeb] Both 'Authority' ('{Authority}') and 'Instance'/'TenantId' " +
+                    $"('{Instance ?? string.Empty}', '{TenantId ?? string.Empty}') are configured. " +
+                    "These settings conflict. Remove either 'Authority' or 'Instance'/'TenantId' from the configuration.");
+            }
+        }
+
         /// <summary>
         /// Id Web will modify the instance so that it can be used by MSAL.
         /// This modifies this property so that the original value is not changed.
@@ -494,13 +508,7 @@ namespace Microsoft.Identity.Web
            if (!string.IsNullOrEmpty(mergedOptions.Authority) &&
                (!string.IsNullOrEmpty(mergedOptions.Instance) || !string.IsNullOrEmpty(mergedOptions.TenantId)))
            {
-               if (mergedOptions.AuthorityExplicitlyConfigured)
-               {
-                   throw new InvalidOperationException(
-                       $"[MsIdWeb] Both 'Authority' ('{mergedOptions.Authority}') and 'Instance'/TenantId' " +
-                       $"('{mergedOptions.Instance ?? string.Empty}', '{mergedOptions.TenantId ?? string.Empty}') are configured. " +
-                       "These settings conflict. Remove either 'Authority' or 'Instance'/'TenantId' from the configuration.");
-               }
+               mergedOptions.ThrowIfAuthorityConflict();
 
                // Authority was synthesized (e.g. by MicrosoftEntraApplicationOptions computed getter) -- not a real conflict.
                mergedOptions._authorityParsed = true;

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -323,15 +323,7 @@ namespace Microsoft.Identity.Web
                     MergedOptionsValidation.Validate(mergedOptions);
 
                     // Throw early if Authority conflicts with Instance/TenantId (same check as MSAL path).
-                    if (mergedOptions.AuthorityExplicitlyConfigured &&
-                        !string.IsNullOrEmpty(mergedOptions.Authority) &&
-                        (!string.IsNullOrEmpty(mergedOptions.Instance) || !string.IsNullOrEmpty(mergedOptions.TenantId)))
-                    {
-                        throw new InvalidOperationException(
-                            $"[MsIdWeb] Both 'Authority' ('{mergedOptions.Authority}') and 'Instance'/TenantId' " +
-                            $"('{mergedOptions.Instance ?? string.Empty}', '{mergedOptions.TenantId ?? string.Empty}') are configured. " +
-                            "These settings conflict. Remove either 'Authority' or 'Instance'/'TenantId' from the configuration.");
-                    }
+                    mergedOptions.ThrowIfAuthorityConflict();
 
                     if (mergedOptions.Authority != null)
                     {

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilderExtensions.cs
@@ -322,6 +322,17 @@ namespace Microsoft.Identity.Web
 
                     MergedOptionsValidation.Validate(mergedOptions);
 
+                    // Throw early if Authority conflicts with Instance/TenantId (same check as MSAL path).
+                    if (mergedOptions.AuthorityExplicitlyConfigured &&
+                        !string.IsNullOrEmpty(mergedOptions.Authority) &&
+                        (!string.IsNullOrEmpty(mergedOptions.Instance) || !string.IsNullOrEmpty(mergedOptions.TenantId)))
+                    {
+                        throw new InvalidOperationException(
+                            $"[MsIdWeb] Both 'Authority' ('{mergedOptions.Authority}') and 'Instance'/TenantId' " +
+                            $"('{mergedOptions.Instance ?? string.Empty}', '{mergedOptions.TenantId ?? string.Empty}') are configured. " +
+                            "These settings conflict. Remove either 'Authority' or 'Instance'/'TenantId' from the configuration.");
+                    }
+
                     if (mergedOptions.Authority != null)
                     {
                         mergedOptions.Authority = AuthorityHelpers.GetAuthorityWithoutQueryIfNeeded(mergedOptions);

--- a/tests/Microsoft.Identity.Web.Test/MergedOptionsAuthorityConflictTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MergedOptionsAuthorityConflictTests.cs
@@ -4,7 +4,10 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Client;
 using Xunit;
+
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Microsoft.Identity.Web.Test
 {
@@ -221,6 +224,148 @@ namespace Microsoft.Identity.Web.Test
             // Act & Assert - no exception
             var ex = Record.Exception(() => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger));
             Assert.Null(ex);
+        }
+
+        // ----- Higher-level: config objects -> UpdateMergedOptions* -> ParseAuthorityIfNecessary -----
+        // These prove the latches are set correctly through the real merge pipeline.
+
+        [Fact]
+        public void FromConfigObjects_AuthorityAndInstance_ThrowsOnConflict()
+        {
+            // Arrange -- simulate what DI does: Identity options carry Authority,
+            // CCA options carry Instance. Both merge into MergedOptions.
+            var identityOptions = new MicrosoftIdentityOptions
+            {
+                Authority = "https://login.microsoftonline.com/common",
+                ClientId = "test-client-id"
+            };
+            var ccaOptions = new ConfidentialClientApplicationOptions
+            {
+                Instance = "https://login.microsoftonline.com/",
+                ClientId = "test-client-id"
+            };
+
+            var merged = new MergedOptions();
+            MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(identityOptions, merged);
+            MergedOptions.UpdateMergedOptionsFromConfidentialClientApplicationOptions(ccaOptions, merged);
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(merged, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void FromConfigObjects_AuthorityAndTenantId_ThrowsOnConflict()
+        {
+            var identityOptions = new MicrosoftIdentityOptions
+            {
+                Authority = "https://login.microsoftonline.com/common",
+                TenantId = "organizations",
+                ClientId = "test-client-id"
+            };
+
+            var merged = new MergedOptions();
+            MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(identityOptions, merged);
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(merged, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void FromConfigObjects_AuthorityAndInstanceAndTenantId_ThrowsOnConflict()
+        {
+            var identityOptions = new MicrosoftIdentityOptions
+            {
+                Authority = "https://login.microsoftonline.com/common",
+                Instance = "https://login.microsoftonline.com/",
+                TenantId = "organizations",
+                ClientId = "test-client-id"
+            };
+
+            var merged = new MergedOptions();
+            MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(identityOptions, merged);
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(merged, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void FromConfigObjects_InstanceAndTenantIdOnly_NoThrow()
+        {
+            var identityOptions = new MicrosoftIdentityOptions
+            {
+                Instance = "https://login.microsoftonline.com/",
+                TenantId = "organizations",
+                ClientId = "test-client-id"
+            };
+
+            var merged = new MergedOptions();
+            MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(identityOptions, merged);
+
+            var ex = Record.Exception(
+                () => MergedOptions.ParseAuthorityIfNecessary(merged, _testLogger));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void FromConfigObjects_AuthorityOnly_NoThrow()
+        {
+            var identityOptions = new MicrosoftIdentityOptions
+            {
+                Authority = "https://login.microsoftonline.com/common",
+                ClientId = "test-client-id"
+            };
+
+            var merged = new MergedOptions();
+            MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(identityOptions, merged);
+
+            var ex = Record.Exception(
+                () => MergedOptions.ParseAuthorityIfNecessary(merged, _testLogger));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void FromConfigObjects_B2CAuthorityAndInstance_ThrowsOnConflict()
+        {
+            var identityOptions = new MicrosoftIdentityOptions
+            {
+                Authority = "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
+                Instance = "https://fabrikamb2c.b2clogin.com/",
+                ClientId = "test-client-id"
+            };
+
+            var merged = new MergedOptions();
+            MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(identityOptions, merged);
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(merged, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void FromConfigObjects_CiamAuthorityAndInstance_ThrowsOnConflict()
+        {
+            var identityOptions = new MicrosoftIdentityOptions
+            {
+                Authority = "https://contoso.ciamlogin.com/contoso.onmicrosoft.com",
+                Instance = "https://contoso.ciamlogin.com/",
+                ClientId = "test-client-id"
+            };
+
+            var merged = new MergedOptions();
+            MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(identityOptions, merged);
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(merged, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         // Test helper class to capture log messages

--- a/tests/Microsoft.Identity.Web.Test/MergedOptionsAuthorityConflictTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MergedOptionsAuthorityConflictTests.cs
@@ -18,49 +18,45 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
-        public void ParseAuthorityIfNecessary_AuthorityAndInstance_LogsWarning()
+        public void ParseAuthorityIfNecessary_AuthorityAndInstance_ThrowsOnConflict()
         {
             // Arrange
             var mergedOptions = new MergedOptions
             {
                 Authority = "https://login.microsoftonline.com/common",
                 Instance = "https://login.microsoftonline.com/",
+                AuthorityExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
-            // Act
-            MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger);
-
-            // Assert
-            Assert.Single(_testLogger.LogMessages);
-            Assert.Contains("Authority", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("ignored", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(LogLevel.Warning, _testLogger.LogLevel);
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void ParseAuthorityIfNecessary_AuthorityAndTenantId_LogsWarning()
+        public void ParseAuthorityIfNecessary_AuthorityAndTenantId_ThrowsOnConflict()
         {
             // Arrange
             var mergedOptions = new MergedOptions
             {
                 Authority = "https://login.microsoftonline.com/common",
                 TenantId = "organizations",
+                AuthorityExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
-            // Act
-            MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger);
-
-            // Assert
-            Assert.Single(_testLogger.LogMessages);
-            Assert.Contains("Authority", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("ignored", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(LogLevel.Warning, _testLogger.LogLevel);
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_LogsWarning()
+        public void ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_ThrowsOnConflict()
         {
             // Arrange
             var mergedOptions = new MergedOptions
@@ -68,17 +64,15 @@ namespace Microsoft.Identity.Web.Test
                 Authority = "https://login.microsoftonline.com/common",
                 Instance = "https://login.microsoftonline.com/",
                 TenantId = "organizations",
+                AuthorityExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
-            // Act
-            MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger);
-
-            // Assert
-            Assert.Single(_testLogger.LogMessages);
-            Assert.Contains("Authority", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("ignored", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(LogLevel.Warning, _testLogger.LogLevel);
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -131,49 +125,45 @@ namespace Microsoft.Identity.Web.Test
         }
 
         [Fact]
-        public void ParseAuthorityIfNecessary_B2CAuthorityAndInstance_LogsWarning()
+        public void ParseAuthorityIfNecessary_B2CAuthorityAndInstance_ThrowsOnConflict()
         {
             // Arrange - B2C scenario
             var mergedOptions = new MergedOptions
             {
                 Authority = "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
                 Instance = "https://fabrikamb2c.b2clogin.com/",
+                AuthorityExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
-            // Act
-            MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger);
-
-            // Assert
-            Assert.Single(_testLogger.LogMessages);
-            Assert.Contains("Authority", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("ignored", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(LogLevel.Warning, _testLogger.LogLevel);
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void ParseAuthorityIfNecessary_CiamAuthorityAndInstance_LogsWarning()
+        public void ParseAuthorityIfNecessary_CiamAuthorityAndInstance_ThrowsOnConflict()
         {
             // Arrange - CIAM scenario
             var mergedOptions = new MergedOptions
             {
                 Authority = "https://contoso.ciamlogin.com/contoso.onmicrosoft.com",
                 Instance = "https://contoso.ciamlogin.com/",
+                AuthorityExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
-            // Act
-            MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger);
-
-            // Assert
-            Assert.Single(_testLogger.LogMessages);
-            Assert.Contains("Authority", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("ignored", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(LogLevel.Warning, _testLogger.LogLevel);
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void ParseAuthorityIfNecessary_CiamPreservedAuthorityWithInstance_LogsWarning()
+        public void ParseAuthorityIfNecessary_CiamPreservedAuthorityWithInstance_ThrowsOnConflict()
         {
             // Arrange - CIAM with PreserveAuthority flag
             var mergedOptions = new MergedOptions
@@ -181,31 +171,49 @@ namespace Microsoft.Identity.Web.Test
                 Authority = "https://custom.contoso.com/contoso.onmicrosoft.com",
                 Instance = "https://custom.contoso.com/",
                 PreserveAuthority = true,
+                AuthorityExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
-            // Act
-            MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger);
-
-            // Assert - Warning should still be logged even with PreserveAuthority
-            Assert.Single(_testLogger.LogMessages);
-            Assert.Contains("Authority", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("ignored", _testLogger.LogMessages[0], StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(LogLevel.Warning, _testLogger.LogLevel);
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger));
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void ParseAuthorityIfNecessary_NoLogger_NoException()
+        public void ParseAuthorityIfNecessary_NoLogger_StillThrowsOnConflict()
         {
             // Arrange
             var mergedOptions = new MergedOptions
             {
                 Authority = "https://login.microsoftonline.com/common",
                 Instance = "https://login.microsoftonline.com/",
+                AuthorityExplicitlyConfigured = true,
             };
 
-            // Act & Assert - Should not throw when logger is null
-            MergedOptions.ParseAuthorityIfNecessary(mergedOptions, logger: null);
+            // Act & Assert - Throws regardless of logger presence
+            Assert.Throws<InvalidOperationException>(
+                () => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, logger: null));
+        }
+
+        [Fact]
+        public void ParseAuthorityIfNecessary_SyntheticAuthority_NoThrow()
+        {
+            // When Authority was backfilled by the computed getter (latch not set),
+            // there is no real conflict -- should not throw.
+            var mergedOptions = new MergedOptions
+            {
+                Authority = "https://login.microsoftonline.com/common",
+                Instance = "https://login.microsoftonline.com/",
+                // AuthorityExplicitlyConfigured intentionally NOT set
+                Logger = _testLogger
+            };
+
+            // Act & Assert - no exception
+            var ex = Record.Exception(() => MergedOptions.ParseAuthorityIfNecessary(mergedOptions, _testLogger));
+            Assert.Null(ex);
         }
 
         // Test helper class to capture log messages

--- a/tests/Microsoft.Identity.Web.Test/MergedOptionsAuthorityConflictTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/MergedOptionsAuthorityConflictTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Identity.Web.Test
                 Authority = "https://login.microsoftonline.com/common",
                 Instance = "https://login.microsoftonline.com/",
                 AuthorityExplicitlyConfigured = true,
+                InstanceOrTenantIdExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
@@ -45,6 +46,7 @@ namespace Microsoft.Identity.Web.Test
                 Authority = "https://login.microsoftonline.com/common",
                 TenantId = "organizations",
                 AuthorityExplicitlyConfigured = true,
+                InstanceOrTenantIdExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
@@ -65,6 +67,7 @@ namespace Microsoft.Identity.Web.Test
                 Instance = "https://login.microsoftonline.com/",
                 TenantId = "organizations",
                 AuthorityExplicitlyConfigured = true,
+                InstanceOrTenantIdExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
@@ -133,6 +136,7 @@ namespace Microsoft.Identity.Web.Test
                 Authority = "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
                 Instance = "https://fabrikamb2c.b2clogin.com/",
                 AuthorityExplicitlyConfigured = true,
+                InstanceOrTenantIdExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
@@ -152,6 +156,7 @@ namespace Microsoft.Identity.Web.Test
                 Authority = "https://contoso.ciamlogin.com/contoso.onmicrosoft.com",
                 Instance = "https://contoso.ciamlogin.com/",
                 AuthorityExplicitlyConfigured = true,
+                InstanceOrTenantIdExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
@@ -172,6 +177,7 @@ namespace Microsoft.Identity.Web.Test
                 Instance = "https://custom.contoso.com/",
                 PreserveAuthority = true,
                 AuthorityExplicitlyConfigured = true,
+                InstanceOrTenantIdExplicitlyConfigured = true,
                 Logger = _testLogger
             };
 
@@ -191,6 +197,7 @@ namespace Microsoft.Identity.Web.Test
                 Authority = "https://login.microsoftonline.com/common",
                 Instance = "https://login.microsoftonline.com/",
                 AuthorityExplicitlyConfigured = true,
+                InstanceOrTenantIdExplicitlyConfigured = true,
             };
 
             // Act & Assert - Throws regardless of logger presence

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -158,7 +158,6 @@ namespace Microsoft.Identity.Web.Test
 
             _applicationOptionsMonitor = new TestOptionsMonitor<ConfidentialClientApplicationOptions>(new ConfidentialClientApplicationOptions
             {
-                Instance = TC.AadInstance,
                 RedirectUri = redirectUri,
                 ClientSecret = TC.ClientSecret,
             });
@@ -194,7 +193,6 @@ namespace Microsoft.Identity.Web.Test
 
             _applicationOptionsMonitor = new TestOptionsMonitor<ConfidentialClientApplicationOptions>(new ConfidentialClientApplicationOptions
             {
-                Instance = TC.AadInstance,
                 RedirectUri = "http://localhost:1729/",
                 ClientSecret = TC.ClientSecret,
             });

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -240,7 +240,6 @@ namespace Microsoft.Identity.Web.Test
 
             _applicationOptionsMonitor = new TestOptionsMonitor<ConfidentialClientApplicationOptions>(new ConfidentialClientApplicationOptions
             {
-                Instance = TC.AadInstance,
                 RedirectUri = "http://localhost:1729/",
                 ClientSecret = TC.ClientSecret,
             });
@@ -284,7 +283,6 @@ namespace Microsoft.Identity.Web.Test
 
             _applicationOptionsMonitor = new TestOptionsMonitor<ConfidentialClientApplicationOptions>(new ConfidentialClientApplicationOptions
             {
-                Instance = TC.AadInstance,
                 RedirectUri = "http://localhost:1729/",
                 ClientSecret = TC.ClientSecret,
             });

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsAuthorityConflictTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsAuthorityConflictTests.cs
@@ -1,0 +1,455 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web.Test.Common;
+using NSubstitute;
+using NSubstitute.Extensions;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    /// <summary>
+    /// Pinning tests for the OIDC sign-in code path in
+    /// <see cref="MicrosoftIdentityWebAppAuthenticationBuilderExtensions"/> when Authority
+    /// is configured alongside Instance/TenantId/Domain/SignUpSignInPolicyId. OIDC counterpart
+    /// of <see cref="MergedOptionsAuthorityConflictTests"/>; see each test for parity notes.
+    /// </summary>
+    public class WebAppExtensionsAuthorityConflictTests
+    {
+        private const string OidcScheme = "OpenIdConnect-Custom";
+        private const string CookieScheme = "Cookies-Custom";
+        private const string ConfigSectionName = "AzureAd-Custom";
+
+        // All-zeros GUID lets failures fail loudly: if Authority ever stops winning,
+        // this value would not appear in OpenIdConnectOptions.Authority.
+        private const string BogusTenantGuid = "00000000-0000-0000-0000-000000000000";
+
+        private const string BogusAadAuthority = "https://login.microsoftonline.com/" + BogusTenantGuid + "/v2.0";
+        private const string BogusB2CAuthority = "https://fakeb2c.b2clogin.com/" + BogusTenantGuid + "/b2c_1_bogus";
+        private const string BogusCiamAuthority = "https://fakeciam.ciamlogin.com/" + BogusTenantGuid;
+
+        private readonly IHostEnvironment _env = new HostingEnvironment { EnvironmentName = Environments.Development };
+
+        // ----- AAD: precedence (behavior pinning) -----
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstance_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
+            var options = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: null);
+
+            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndTenantId_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndTenantId_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
+            var options = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: null,
+                tenantId: TestConstants.TenantIdAsGuid);
+
+            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstanceAndTenantId_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
+            var options = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: TestConstants.TenantIdAsGuid);
+
+            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain(TestConstants.TenantIdAsGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityOnly_PropagatesAuthorityAsIs()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityOnly_LogsAuthorityUsedHint. Divergence: MSAL parses Authority + logs EventId 501; OIDC propagates Authority verbatim.
+            var options = BuildAndGetOidcOptions(
+                authority: TestConstants.AuthorityWithTenantSpecifiedWithV2,
+                instance: null,
+                tenantId: null);
+
+            Assert.Equal(TestConstants.AuthorityWithTenantSpecifiedWithV2, options.Authority);
+        }
+
+        [Fact]
+        public void OidcSignIn_InstanceAndTenantIdOnly_ComposesAuthorityFromInstanceTenantId()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_InstanceAndTenantIdOnly_NoWarning. Same outcome on both paths (no Authority -> Instance+TenantId compose).
+            var options = BuildAndGetOidcOptions(
+                authority: null,
+                instance: TestConstants.AadInstance,
+                tenantId: TestConstants.TenantIdAsGuid);
+
+            Assert.Contains(TestConstants.TenantIdAsGuid, options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        // ----- B2C: precedence (behavior pinning) -----
+
+        [Fact]
+        public void OidcSignIn_B2CAuthorityAndInstance_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_B2CAuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
+            var options = BuildAndGetOidcOptions(
+                authority: BogusB2CAuthority,
+                instance: TestConstants.B2CInstance,
+                tenantId: null,
+                domain: TestConstants.B2CTenant,
+                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow);
+
+            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain(TestConstants.B2CTenant, options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_B2CInstanceAndDomain_ComposesAuthorityFromInstanceDomainUserFlow()
+        {
+            // No MSAL counterpart; control: BuildAuthority composes "Instance/Domain/UserFlow/v2.0".
+            var options = BuildAndGetOidcOptions(
+                authority: null,
+                instance: TestConstants.B2CInstance,
+                tenantId: null,
+                domain: TestConstants.B2CTenant,
+                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow);
+
+            Assert.Contains(TestConstants.B2CTenant, options.Authority, StringComparison.Ordinal);
+            Assert.Contains(TestConstants.B2CSignUpSignInUserFlow, options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+        }
+
+        // ----- CIAM: precedence (behavior pinning) -----
+
+        [Fact]
+        public void OidcSignIn_CiamAuthorityAndInstance_PinsAuthorityWins()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_CiamAuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority (BuildCiamAuthorityIfNeeded preserves it).
+            var options = BuildAndGetOidcOptions(
+                authority: BogusCiamAuthority,
+                instance: TestConstants.CIAMInstance,
+                tenantId: null);
+
+            Assert.Contains("fakeciam", options.Authority, StringComparison.Ordinal);
+            Assert.DoesNotContain("catsareawesome", options.Authority, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OidcSignIn_CiamAuthorityOnly_PropagatesAuthorityThroughCiamHelper()
+        {
+            // No MSAL counterpart; control: BuildCiamAuthorityIfNeeded preserves Authority, EnsureAuthorityIsV2 appends /v2.0.
+            var options = BuildAndGetOidcOptions(
+                authority: TestConstants.CIAMAuthorityV2,
+                instance: null,
+                tenantId: null);
+
+            Assert.Contains("ciamlogin.com", options.Authority, StringComparison.Ordinal);
+            Assert.Contains(TestConstants.CIAMTenant, options.Authority, StringComparison.Ordinal);
+        }
+
+        // ----- Log assertions (the bug evidence) -----
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: null,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.Message.Contains("is being ignored", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndTenantId_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndTenantId_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: null,
+                tenantId: TestConstants.TenantIdAsGuid,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstanceAndTenantId_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: TestConstants.TenantIdAsGuid,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+        }
+
+        [Fact]
+        public void OidcSignIn_AuthorityOnly_DoesNotLogAuthorityUsedHint()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityOnly_LogsAuthorityUsedHint (EventId 501, 1P hint). Divergence: OIDC never surfaces this hint.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: TestConstants.AuthorityWithTenantSpecifiedWithV2,
+                instance: null,
+                tenantId: null,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 501);
+        }
+
+        [Fact]
+        public void OidcSignIn_InstanceAndTenantIdOnly_DoesNotLogAnyAuthorityWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_InstanceAndTenantIdOnly_NoWarning. Same outcome on both paths (no Authority -> no warnings).
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: null,
+                instance: TestConstants.AadInstance,
+                tenantId: TestConstants.TenantIdAsGuid,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500 || e.EventId.Id == 501);
+        }
+
+        [Fact]
+        public void OidcSignIn_B2CAuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_B2CAuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusB2CAuthority,
+                instance: TestConstants.B2CInstance,
+                tenantId: null,
+                domain: TestConstants.B2CTenant,
+                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+        }
+
+        [Fact]
+        public void OidcSignIn_CiamAuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_CiamAuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
+            var loggerProvider = new TestLoggerProvider();
+
+            _ = BuildAndGetOidcOptions(
+                authority: BogusCiamAuthority,
+                instance: TestConstants.CIAMInstance,
+                tenantId: null,
+                loggerProvider: loggerProvider);
+
+            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
+        }
+
+        // ----- Robustness -----
+
+        [Fact]
+        public void OidcSignIn_AuthorityAndInstance_DoesNotThrowWhenNoLoggerRegistered()
+        {
+            // MSAL parity: ParseAuthorityIfNecessary_NoLogger_NoException. Same intent: no exception when no logger is registered.
+            var ex = Record.Exception(() => BuildAndGetOidcOptions(
+                authority: BogusAadAuthority,
+                instance: TestConstants.AadInstance,
+                tenantId: null,
+                loggerProvider: null));
+
+            Assert.Null(ex);
+        }
+
+        // ----- Helpers -----
+
+        /// <summary>
+        /// Builds AddMicrosoftIdentityWebApp from a synthetic config section and returns the
+        /// resolved OpenIdConnectOptions. Pass a loggerProvider to capture log entries.
+        /// </summary>
+        private OpenIdConnectOptions BuildAndGetOidcOptions(
+            string? authority,
+            string? instance,
+            string? tenantId,
+            string? domain = null,
+            string? signUpSignInPolicyId = null,
+            TestLoggerProvider? loggerProvider = null)
+        {
+            var configSection = BuildConfigSection(
+                ConfigSectionName,
+                authority: authority,
+                instance: instance,
+                tenantId: tenantId,
+                domain: domain,
+                signUpSignInPolicyId: signUpSignInPolicyId,
+                clientId: TestConstants.ClientId);
+
+            var configMock = Substitute.For<IConfiguration>();
+            configMock.Configure().GetSection(ConfigSectionName).Returns(configSection);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(configMock);
+            services.AddDataProtection();
+            services.AddSingleton(_env);
+
+            if (loggerProvider is not null)
+            {
+                services.AddLogging(b =>
+                {
+                    b.SetMinimumLevel(LogLevel.Trace);
+                    b.AddProvider(loggerProvider);
+                });
+            }
+
+            services.AddAuthentication()
+                .AddMicrosoftIdentityWebApp(
+                    configMock,
+                    ConfigSectionName,
+                    OidcScheme,
+                    CookieScheme,
+                    subscribeToOpenIdConnectMiddlewareDiagnosticsEvents: false);
+
+            using var provider = services.BuildServiceProvider();
+            return provider.GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>().Get(OidcScheme);
+        }
+
+        /// <summary>
+        /// In-memory IConfigurationSection populated only with non-null keys; ClientId is required
+        /// to satisfy MergedOptionsValidation. Omitting keys leaves MergedOptions properties null,
+        /// which is what selects the precedence branches under test.
+        /// </summary>
+        private static IConfigurationSection BuildConfigSection(
+            string configSectionName,
+            string? authority,
+            string? instance,
+            string? tenantId,
+            string? domain,
+            string? signUpSignInPolicyId,
+            string clientId)
+        {
+            var configAsDictionary = new Dictionary<string, string?>
+            {
+                { configSectionName, null },
+                { $"{configSectionName}:ClientId", clientId },
+            };
+
+            if (authority is not null)
+            {
+                configAsDictionary[$"{configSectionName}:Authority"] = authority;
+            }
+
+            if (instance is not null)
+            {
+                configAsDictionary[$"{configSectionName}:Instance"] = instance;
+            }
+
+            if (tenantId is not null)
+            {
+                configAsDictionary[$"{configSectionName}:TenantId"] = tenantId;
+            }
+
+            if (domain is not null)
+            {
+                configAsDictionary[$"{configSectionName}:Domain"] = domain;
+            }
+
+            if (signUpSignInPolicyId is not null)
+            {
+                configAsDictionary[$"{configSectionName}:SignUpSignInPolicyId"] = signUpSignInPolicyId;
+            }
+
+            var memoryConfigSource = new MemoryConfigurationSource { InitialData = configAsDictionary };
+
+            var configBuilder = new ConfigurationBuilder();
+            configBuilder.Add(memoryConfigSource);
+
+            return configBuilder.Build().GetSection(configSectionName);
+        }
+
+        /// <summary>Single captured log entry.</summary>
+        private sealed record TestLogEntry(LogLevel LogLevel, EventId EventId, string Message, string Category);
+
+        /// <summary>
+        /// ILogger that captures every call into a shared list (always enabled, all levels).
+        /// </summary>
+        private sealed class TestLogger : ILogger
+        {
+            private readonly string _category;
+            public List<TestLogEntry> Entries { get; }
+
+            public TestLogger(string category, List<TestLogEntry> entries)
+            {
+                _category = category;
+                Entries = entries;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                Entries.Add(new TestLogEntry(logLevel, eventId, formatter(state, exception), _category));
+            }
+        }
+
+        /// <summary>
+        /// ILoggerProvider routing every category-specific logger into a single shared
+        /// TestLogger so tests can assert across categories via <see cref="Logger"/>.
+        /// </summary>
+        private sealed class TestLoggerProvider : ILoggerProvider
+        {
+            private readonly List<TestLogEntry> _entries = new();
+
+            public TestLogger Logger { get; }
+
+            public TestLoggerProvider()
+            {
+                Logger = new TestLogger(category: "(aggregate)", entries: _entries);
+            }
+
+            public ILogger CreateLogger(string categoryName) => new TestLogger(categoryName, _entries);
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsAuthorityConflictTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsAuthorityConflictTests.cs
@@ -46,40 +46,42 @@ namespace Microsoft.Identity.Web.Test
         // ----- AAD: precedence (behavior pinning) -----
 
         [Fact]
-        public void OidcSignIn_AuthorityAndInstance_PinsAuthorityWins()
+        public void OidcSignIn_AuthorityAndInstance_ThrowsOnConflict()
         {
-            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
-            var options = BuildAndGetOidcOptions(
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstance_LogsWarning. Now both paths throw.
+            var ex = Assert.Throws<InvalidOperationException>(() => BuildAndGetOidcOptions(
                 authority: BogusAadAuthority,
                 instance: TestConstants.AadInstance,
-                tenantId: null);
+                tenantId: null));
 
-            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void OidcSignIn_AuthorityAndTenantId_PinsAuthorityWins()
+        public void OidcSignIn_AuthorityAndTenantId_ThrowsOnConflict()
         {
-            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndTenantId_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
-            var options = BuildAndGetOidcOptions(
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndTenantId_LogsWarning. Now both paths throw.
+            var ex = Assert.Throws<InvalidOperationException>(() => BuildAndGetOidcOptions(
                 authority: BogusAadAuthority,
                 instance: null,
-                tenantId: TestConstants.TenantIdAsGuid);
+                tenantId: TestConstants.TenantIdAsGuid));
 
-            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void OidcSignIn_AuthorityAndInstanceAndTenantId_PinsAuthorityWins()
+        public void OidcSignIn_AuthorityAndInstanceAndTenantId_ThrowsOnConflict()
         {
-            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
-            var options = BuildAndGetOidcOptions(
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_LogsWarning. Now both paths throw.
+            var ex = Assert.Throws<InvalidOperationException>(() => BuildAndGetOidcOptions(
                 authority: BogusAadAuthority,
                 instance: TestConstants.AadInstance,
-                tenantId: TestConstants.TenantIdAsGuid);
+                tenantId: TestConstants.TenantIdAsGuid));
 
-            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
-            Assert.DoesNotContain(TestConstants.TenantIdAsGuid, options.Authority, StringComparison.Ordinal);
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -110,18 +112,18 @@ namespace Microsoft.Identity.Web.Test
         // ----- B2C: precedence (behavior pinning) -----
 
         [Fact]
-        public void OidcSignIn_B2CAuthorityAndInstance_PinsAuthorityWins()
+        public void OidcSignIn_B2CAuthorityAndInstance_ThrowsOnConflict()
         {
-            // MSAL parity: ParseAuthorityIfNecessary_B2CAuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority.
-            var options = BuildAndGetOidcOptions(
+            // MSAL parity: ParseAuthorityIfNecessary_B2CAuthorityAndInstance_LogsWarning. Now both paths throw.
+            var ex = Assert.Throws<InvalidOperationException>(() => BuildAndGetOidcOptions(
                 authority: BogusB2CAuthority,
                 instance: TestConstants.B2CInstance,
                 tenantId: null,
                 domain: TestConstants.B2CTenant,
-                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow);
+                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow));
 
-            Assert.Contains(BogusTenantGuid, options.Authority, StringComparison.Ordinal);
-            Assert.DoesNotContain(TestConstants.B2CTenant, options.Authority, StringComparison.Ordinal);
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -143,16 +145,16 @@ namespace Microsoft.Identity.Web.Test
         // ----- CIAM: precedence (behavior pinning) -----
 
         [Fact]
-        public void OidcSignIn_CiamAuthorityAndInstance_PinsAuthorityWins()
+        public void OidcSignIn_CiamAuthorityAndInstance_ThrowsOnConflict()
         {
-            // MSAL parity: ParseAuthorityIfNecessary_CiamAuthorityAndInstance_LogsWarning. Divergence: MSAL ignores Authority + logs EventId 500; OIDC honors Authority (BuildCiamAuthorityIfNeeded preserves it).
-            var options = BuildAndGetOidcOptions(
+            // MSAL parity: ParseAuthorityIfNecessary_CiamAuthorityAndInstance_LogsWarning. Now both paths throw.
+            var ex = Assert.Throws<InvalidOperationException>(() => BuildAndGetOidcOptions(
                 authority: BogusCiamAuthority,
                 instance: TestConstants.CIAMInstance,
-                tenantId: null);
+                tenantId: null));
 
-            Assert.Contains("fakeciam", options.Authority, StringComparison.Ordinal);
-            Assert.DoesNotContain("catsareawesome", options.Authority, StringComparison.Ordinal);
+            Assert.Contains("Authority", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("conflict", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -168,58 +170,12 @@ namespace Microsoft.Identity.Web.Test
             Assert.Contains(TestConstants.CIAMTenant, options.Authority, StringComparison.Ordinal);
         }
 
-        // ----- Log assertions (the bug evidence) -----
-
-        [Fact]
-        public void OidcSignIn_AuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
-        {
-            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
-            var loggerProvider = new TestLoggerProvider();
-
-            _ = BuildAndGetOidcOptions(
-                authority: BogusAadAuthority,
-                instance: TestConstants.AadInstance,
-                tenantId: null,
-                loggerProvider: loggerProvider);
-
-            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
-            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.Message.Contains("is being ignored", StringComparison.Ordinal));
-        }
-
-        [Fact]
-        public void OidcSignIn_AuthorityAndTenantId_DoesNotLogAuthorityIgnoredWarning()
-        {
-            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndTenantId_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
-            var loggerProvider = new TestLoggerProvider();
-
-            _ = BuildAndGetOidcOptions(
-                authority: BogusAadAuthority,
-                instance: null,
-                tenantId: TestConstants.TenantIdAsGuid,
-                loggerProvider: loggerProvider);
-
-            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
-        }
-
-        [Fact]
-        public void OidcSignIn_AuthorityAndInstanceAndTenantId_DoesNotLogAuthorityIgnoredWarning()
-        {
-            // MSAL parity: ParseAuthorityIfNecessary_AuthorityAndInstanceAndTenantId_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
-            var loggerProvider = new TestLoggerProvider();
-
-            _ = BuildAndGetOidcOptions(
-                authority: BogusAadAuthority,
-                instance: TestConstants.AadInstance,
-                tenantId: TestConstants.TenantIdAsGuid,
-                loggerProvider: loggerProvider);
-
-            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
-        }
+        // ----- Log assertions (non-conflict scenarios still produce no warnings) -----
 
         [Fact]
         public void OidcSignIn_AuthorityOnly_DoesNotLogAuthorityUsedHint()
         {
-            // MSAL parity: ParseAuthorityIfNecessary_AuthorityOnly_LogsAuthorityUsedHint (EventId 501, 1P hint). Divergence: OIDC never surfaces this hint.
+            // MSAL parity: ParseAuthorityIfNecessary_AuthorityOnly_LogsAuthorityUsedHint (EventId 501, 1P hint). OIDC never surfaces this hint.
             var loggerProvider = new TestLoggerProvider();
 
             _ = BuildAndGetOidcOptions(
@@ -246,51 +202,17 @@ namespace Microsoft.Identity.Web.Test
             Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500 || e.EventId.Id == 501);
         }
 
-        [Fact]
-        public void OidcSignIn_B2CAuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
-        {
-            // MSAL parity: ParseAuthorityIfNecessary_B2CAuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
-            var loggerProvider = new TestLoggerProvider();
-
-            _ = BuildAndGetOidcOptions(
-                authority: BogusB2CAuthority,
-                instance: TestConstants.B2CInstance,
-                tenantId: null,
-                domain: TestConstants.B2CTenant,
-                signUpSignInPolicyId: TestConstants.B2CSignUpSignInUserFlow,
-                loggerProvider: loggerProvider);
-
-            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
-        }
-
-        [Fact]
-        public void OidcSignIn_CiamAuthorityAndInstance_DoesNotLogAuthorityIgnoredWarning()
-        {
-            // MSAL parity: ParseAuthorityIfNecessary_CiamAuthorityAndInstance_LogsWarning (EventId 500). Divergence: OIDC never emits this event.
-            var loggerProvider = new TestLoggerProvider();
-
-            _ = BuildAndGetOidcOptions(
-                authority: BogusCiamAuthority,
-                instance: TestConstants.CIAMInstance,
-                tenantId: null,
-                loggerProvider: loggerProvider);
-
-            Assert.DoesNotContain(loggerProvider.Logger.Entries, e => e.EventId.Id == 500);
-        }
-
         // ----- Robustness -----
 
         [Fact]
-        public void OidcSignIn_AuthorityAndInstance_DoesNotThrowWhenNoLoggerRegistered()
+        public void OidcSignIn_AuthorityAndInstance_ThrowsEvenWhenNoLoggerRegistered()
         {
-            // MSAL parity: ParseAuthorityIfNecessary_NoLogger_NoException. Same intent: no exception when no logger is registered.
-            var ex = Record.Exception(() => BuildAndGetOidcOptions(
+            // Conflict throw does not depend on logger registration.
+            Assert.Throws<InvalidOperationException>(() => BuildAndGetOidcOptions(
                 authority: BogusAadAuthority,
                 instance: TestConstants.AadInstance,
                 tenantId: null,
                 loggerProvider: null));
-
-            Assert.Null(ex);
         }
 
         // ----- Helpers -----

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -256,12 +256,23 @@ namespace Microsoft.Identity.Web.Test
         [Fact]
         public Task AddMicrosoftIdentityWebApp_WithConfigAuthority_TestCorrectMetadataAddressAsync()
         {
-            // Arrange
+            // Arrange - use a minimal config without Instance/TenantId to avoid conflict.
             string authority = "https://login.microsoftonline.com/some-tenant-id/v2.0";
             string appId = "some-client-id";
             string expectedMetadataAddress = $"{authority}/.well-known/openid-configuration?appId={appId}";
+
+            var authorityOnlyConfig = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { ConfigSectionName, null },
+                    { $"{ConfigSectionName}:ClientId", TestConstants.TenantIdAsGuid },
+                    { $"{ConfigSectionName}:Domain", TestConstants.Domain },
+                })
+                .Build()
+                .GetSection(ConfigSectionName);
+
             var configMock = Substitute.For<IConfiguration>();
-            configMock.Configure().GetSection(ConfigSectionName).Returns(_configSection);
+            configMock.Configure().GetSection(ConfigSectionName).Returns(authorityOnlyConfig);
 
             var services = new ServiceCollection()
                 .AddSingleton(configMock)


### PR DESCRIPTION
## Summary

Replaces the silent EventId 500 warning with `InvalidOperationException` when both `Authority` **and** `Instance`/`TenantId` are explicitly configured. Both the OIDC sign-in path and the MSAL token-acquisition path now throw the same exception, resolving the behavioral divergence documented in the pinning tests (#3855).

## Problem

Previously, configuring both `Authority` and `Instance`/`TenantId` produced different outcomes depending on the code path:
- **MSAL path** (ParseAuthorityIfNecessary): logged a warning (EventId 500) and silently ignored Authority
- **OIDC path** (OpenIdConnect middleware): silently honored Authority

Neither path surfaced the conflict to the developer at startup time.

## Solution

### Dual-latch provenance tracking on `MergedOptions`

Two latch properties track whether Authority and Instance/TenantId came from **user config** vs internal derivation:

- **`AuthorityExplicitlyConfigured`** -- set when Authority is written from user config (`MicrosoftIdentityOptions` or `JwtBearerOptions`), NOT when backfilled by `MicrosoftEntraApplicationOptions` computed getter
- **`InstanceOrTenantIdExplicitlyConfigured`** -- set when Instance or TenantId is written from user config (`MicrosoftIdentityOptions` or `ConfidentialClientApplicationOptions`), NOT when derived by `ParseAuthorityIfNecessary` or the computed `Authority` getter

Both latches use a set-only pattern (once true, never reverts to false).

### Conflict detection

- **`ThrowIfAuthorityConflict()`** helper on `MergedOptions` -- throws `InvalidOperationException` only when **both** latches are set and both sides are populated. Shared by MSAL and OIDC paths.
- **`_authorityParsed` flag** -- makes `ParseAuthorityIfNecessary` idempotent (avoids false-positive on repeated calls after Authority is decomposed into Instance+TenantId)

### Merge point coverage

The `InstanceOrTenantIdExplicitlyConfigured` latch is set at 4 user-config merge points:
1. `UpdateMergedOptionsFromMicrosoftIdentityOptions` -- Instance
2. `UpdateMergedOptionsFromMicrosoftIdentityOptions` -- TenantId
3. `UpdateMergedOptionsFromConfidentialClientApplicationOptions` -- Instance
4. `UpdateMergedOptionsFromConfidentialClientApplicationOptions` -- TenantId

Three synthetic merge points intentionally do NOT set the latch:
1. `ParseAuthorityIfNecessary` (decomposes Authority into Instance+TenantId)
2. `UpdateMergedOptionsFromMicrosoftIdentityApplicationOptions` -- Instance (computed getter)
3. `UpdateMergedOptionsFromMicrosoftIdentityApplicationOptions` -- TenantId (computed getter)

## Test changes

- Conflict pinning tests converted to `Assert.Throws<InvalidOperationException>`
- Added `SyntheticAuthority_NoThrow` test (computed getter scenario = no conflict)
- Conflict tests updated to set both latches (`AuthorityExplicitlyConfigured` + `InstanceOrTenantIdExplicitlyConfigured`)
- Fixed 4 existing tests that incidentally created conflicts (redirect URI, regions, metadata address, CCA token-binding)

## E2E validation

Manually tested with a learning app across all config scenarios:
- **Instance+TenantId only**: app starts and works correctly
- **Authority only**: app starts and works correctly (no false positive)
- **Authority + Instance + TenantId (conflict)**: throws `InvalidOperationException` at startup with clear message

Fixes #3869
Builds on #3855

Once this is merged, will improve the docs in #3617 and merge that one