### PR TITLE
Bump System.Formats.Asn1 base version to 10.0.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -92,8 +92,9 @@
     <MicrosoftGraphBetaVersion>4.57.0-preview</MicrosoftGraphBetaVersion>
     <!--CVE-2024-43485-->
     <SystemTextJsonVersion>8.0.6</SystemTextJsonVersion>
-    <!--CVE-2023-29331-->
-    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
+    <!-- Minimum version aligned with Microsoft.Bcl.Cryptography 10.0.2
+         (transitive via Microsoft.IdentityModel.Tokens 8.19.1) -->
+    <SystemFormatsAsn1Version>10.0.2</SystemFormatsAsn1Version>
     <BannedApiAnalyzersVersion>4.14.0</BannedApiAnalyzersVersion>
     <PublicApiAnalyzersVersion>4.14.0</PublicApiAnalyzersVersion>
     <!-- Logging.Abstractions needs a separate version variable because Azure.Core 1.50.0


### PR DESCRIPTION
Bump `System.Formats.Asn1` base version from 8.0.1 to 10.0.2.

`Microsoft.IdentityModel.Tokens` 8.19.1 transitively requires `System.Formats.Asn1 >= 10.0.2` (via `Microsoft.Bcl.Cryptography 10.0.2`). The previous 8.0.1 pin caused NU1605 package downgrade errors on restore.

This unblocks #3877 .

> **Note:** net9.0 and net10.0 TFMs already override this variable to their respective runtime versions, so only net8.0/netstandard/netfx targets are affected.