### PR TITLE
Bump Microsoft.IdentityModel.* from 8.18.0 to 8.19.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,7 +79,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Common dependency versions">
-    <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.18.0</MicrosoftIdentityModelVersion>
+    <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.19.1</MicrosoftIdentityModelVersion>
     <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.84.2</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.84.2</MicrosoftIdentityClientKeyAttestationVersion>
     <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.1.0</MicrosoftIdentityAbstractionsVersion>


### PR DESCRIPTION
Bump `MicrosoftIdentityModelVersion` from 8.18.0 to 8.19.1 in `Directory.Build.props`.

Recreates the clean single-line version bump from #3877 (which Dependabot closed when it superseded with the cluttered #3878, now also deleted).

Prerequisite: #3875 (System.Formats.Asn1 bump to 10.0.2) already merged.

## Release notes (8.19.0 + 8.19.1)
- ML-DSA (FIPS 204) post-quantum signature support
- DPoP hardening (fail-closed on replay, RFC 3986 htu normalization)
- Custom crypto providers cached in CryptoProviderFactory
- JKU retrieval: automatic redirects disabled on default HttpClient
- IssuerSigningKeyResolverUsingConfiguration priority fix in JwtSecurityTokenHandler
- Various null-handling and buffer-management fixes