### PR TITLE
Use IIdentityLogger for MSAL logging in TokenAcquisition and ManagedIdentityClientAssertion (#3820)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 
 ### Behavior changes
 - **B2C OpenID Connect event handler: LRU cache for issuer address.** Issuer address lookups in the B2C OIDC event handler are now cached with an LRU cache, improving performance for repeated lookups. See [#3821](https://github.com/AzureAD/microsoft-identity-web/pull/3821).
+- **MSAL logs are now emitted as structured logs.** `TokenAcquisition` and `ManagedIdentityClientAssertion` now route MSAL's internal logging through `IdentityLoggerAdapter` (the `IIdentityLogger` overload) instead of the legacy `LogCallback`, so MSAL log entries flow through `ILogger` with their original log level instead of being flattened into a single unstructured message. See [#3820](https://github.com/AzureAD/microsoft-identity-web/issues/3820).
 
 ### Dependencies updates
 - Update MSAL.NET to 4.84.1. See [#3822](https://github.com/AzureAD/microsoft-identity-web/pull/3822).

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -12,6 +12,7 @@ using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.KeyAttestation;
 using Microsoft.Identity.Web.Certificateless;
 using Microsoft.Identity.Web.TestOnly;
+using Microsoft.IdentityModel.LoggingExtensions;
 
 namespace Microsoft.Identity.Web
 {
@@ -98,7 +99,7 @@ namespace Microsoft.Identity.Web
 
             if (_logger != null)
             {
-                builder = builder.WithLogging(Log, ConvertMicrosoftExtensionsLogLevelToMsal(_logger), enablePiiLogging: false);
+                builder = builder.WithLogging(new IdentityLoggerAdapter(_logger), enablePiiLogging: false);
                 _logger.LogInformation($"ManagedIdentityClientAssertion with tokenExchangeUrl={_tokenExchangeUrl}");
             }
 
@@ -193,62 +194,6 @@ namespace Microsoft.Identity.Web
             return await miBuilder
                 .ExecuteAsync(effectiveCancellationToken)
                 .ConfigureAwait(false);
-        }
-
-        private void Log(
-          Client.LogLevel level,
-          string message,
-          bool containsPii)
-        {
-            if (_logger == null)
-            {
-                return;
-            }
-
-            switch (level)
-            {
-                case Client.LogLevel.Always:
-                    _logger.LogInformation(message);
-                    break;
-                case Client.LogLevel.Error:
-                    _logger.LogError(message);
-                    break;
-                case Client.LogLevel.Warning:
-                    _logger.LogWarning(message);
-                    break;
-                case Client.LogLevel.Info:
-                    _logger.LogInformation(message);
-                    break;
-                case Client.LogLevel.Verbose:
-                    _logger.LogDebug(message);
-                    break;
-            }
-        }
-
-        private Client.LogLevel? ConvertMicrosoftExtensionsLogLevelToMsal(ILogger logger)
-        {
-            if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug)
-                || logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
-            {
-                return Client.LogLevel.Verbose;
-            }
-            else if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Information))
-            {
-                return Client.LogLevel.Info;
-            }
-            else if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Warning))
-            {
-                return Client.LogLevel.Warning;
-            }
-            else if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Error)
-                || logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Critical))
-            {
-                return Client.LogLevel.Error;
-            }
-            else
-            {
-                return null;
-            }
         }
 
     }

--- a/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
+++ b/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens " Version="$(MicrosoftIdentityModelVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.LoggingExtensions" Version="$(MicrosoftIdentityModelVersion)" />
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
     <PackageReference Include="Microsoft.Identity.Client.KeyAttestation" Version="$(MicrosoftIdentityClientKeyAttestationVersion)" />
   </ItemGroup>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.ManagedIdentity.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.ManagedIdentity.cs
@@ -10,6 +10,7 @@ using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Web.TestOnly;
+using Microsoft.IdentityModel.LoggingExtensions;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Identity.Web
@@ -101,8 +102,7 @@ namespace Microsoft.Identity.Web
             ManagedIdentityApplicationBuilder miBuilder = ManagedIdentityApplicationBuilder
                 .Create(managedIdentityId)
                 .WithLogging(
-                    Log,
-                    ConvertMicrosoftExtensionsLogLevelToMsal(_logger),
+                    new IdentityLoggerAdapter(_logger),
                     enablePiiLogging: enablePiiLogging);
 
             if (capabilities?.Any() == true)

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -27,6 +27,7 @@ using Microsoft.Identity.Web.TestOnly;
 using Microsoft.Identity.Web.TokenCacheProviders;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.LoggingExtensions;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Identity.Web
@@ -1124,8 +1125,7 @@ namespace Microsoft.Identity.Web
                         .CreateWithApplicationOptions(mergedOptions.ConfidentialClientApplicationOptions)
                         .WithHttpClientFactory(_httpClientFactory)
                         .WithLogging(
-                            Log,
-                            ConvertMicrosoftExtensionsLogLevelToMsal(_logger),
+                            new IdentityLoggerAdapter(_logger),
                             enablePiiLogging: mergedOptions.ConfidentialClientApplicationOptions.EnablePiiLogging)
                         .WithExperimentalFeatures();
 
@@ -1671,57 +1671,6 @@ namespace Microsoft.Identity.Web
         public string GetEffectiveAuthenticationScheme(string? authenticationScheme)
         {
             return _tokenAcquisitionHost.GetEffectiveAuthenticationScheme(authenticationScheme);
-        }
-
-        private void Log(
-          Client.LogLevel level,
-          string message,
-          bool containsPii)
-        {
-            switch (level)
-            {
-                case Client.LogLevel.Always:
-                    _logger.LogInformation(message);
-                    break;
-                case Client.LogLevel.Error:
-                    _logger.LogError(message);
-                    break;
-                case Client.LogLevel.Warning:
-                    _logger.LogWarning(message);
-                    break;
-                case Client.LogLevel.Info:
-                    _logger.LogInformation(message);
-                    break;
-                case Client.LogLevel.Verbose:
-                    _logger.LogDebug(message);
-                    break;
-            }
-        }
-
-        private Client.LogLevel? ConvertMicrosoftExtensionsLogLevelToMsal(ILogger logger)
-        {
-            if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug)
-                || logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
-            {
-                return Client.LogLevel.Verbose;
-            }
-            else if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Information))
-            {
-                return Client.LogLevel.Info;
-            }
-            else if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Warning))
-            {
-                return Client.LogLevel.Warning;
-            }
-            else if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Error)
-                || logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Critical))
-            {
-                return Client.LogLevel.Error;
-            }
-            else
-            {
-                return null;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes #3820.

`TokenAcquisition` and `ManagedIdentityClientAssertion` configured MSAL's internal logging via the legacy `WithLogging(LogCallback, …)` overload. That callback hands back a single pre-formatted string, so the entire MSAL log line (MSAL version, runtime, OS, correlation id, message) was flattened into one **unstructured** `ILogger` message, and the log-level threshold was computed up front by a hand-rolled `ConvertMicrosoftExtensionsLogLevelToMsal` helper.

This PR switches all MSAL logging configuration to the **`IIdentityLogger`** overload, passing `IdentityLoggerAdapter` from `Microsoft.IdentityModel.LoggingExtensions` — the same adapter IdentityWeb already uses for Wilson logging in `MicrosoftIdentityBaseAuthenticationBuilder`. MSAL now emits each log entry at its proper level and `ILogger` owns the filtering.

## Changes

- `TokenAcquisition.cs` (confidential client build) — use `new IdentityLoggerAdapter(_logger)`.
- `TokenAcquisition.ManagedIdentity.cs` (managed identity build) — use `new IdentityLoggerAdapter(_logger)`.
- `ManagedIdentityClientAssertion.cs` (Certificateless) — use `new IdentityLoggerAdapter(_logger)`; added the `Microsoft.IdentityModel.LoggingExtensions` package reference to the project.
- Removed the now-unused `Log` callbacks and `ConvertMicrosoftExtensionsLogLevelToMsal` helpers from both types.
- Changelog entry under **Behavior changes**.

## Notes / out of scope

- The issue also observes that `ManagedIdentityClientAssertion`'s log entries carry the source context `Microsoft.Identity.Web.DefaultCertificateLoader`. That comes from the `ILogger` category supplied by the **caller** that constructs the assertion, not from the logging API used here, so it is intentionally left out of this change. Happy to follow up separately if a dedicated category is desired.

## Testing

- `Microsoft.Identity.Web.TokenAcquisition` and `Microsoft.Identity.Web.Certificateless` build clean (0 warnings) across all target frameworks.
- `Microsoft.Identity.Web.Test` builds clean; no existing tests referenced the removed private helpers.
