### PR TITLE
Update Microsoft.Identity.Abstractions to 12.2.0 and MSAL to 4.85.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -80,9 +80,9 @@
 
   <PropertyGroup Label="Common dependency versions">
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.19.1</MicrosoftIdentityModelVersion>
-    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.84.2</MicrosoftIdentityClientVersion>
-    <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.84.2</MicrosoftIdentityClientKeyAttestationVersion>
-    <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.1.0</MicrosoftIdentityAbstractionsVersion>
+    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.85.0</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.85.0</MicrosoftIdentityClientKeyAttestationVersion>
+    <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.2.0</MicrosoftIdentityAbstractionsVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>


### PR DESCRIPTION
## Update Microsoft.Identity.Abstractions and MSAL packages

Bumps the dependency versions in `Directory.Build.props` ahead of consuming the new token-acquisition metadata surface:

| Package | From | To |
| --- | --- | --- |
| `Microsoft.Identity.Client` | 4.84.2 | **4.85.0** |
| `Microsoft.Identity.Client.KeyAttestation` | 4.84.2 | **4.85.0** |
| `Microsoft.Identity.Abstractions` | 12.1.0 | **12.2.0** |

`KeyAttestation` is bumped in lockstep with `Microsoft.Identity.Client` (both shipped 4.85.0).

### Validation
- `dotnet restore` of `Microsoft.Identity.Web` (and transitive `Certificateless` / `TokenAcquisition`) resolves all three new versions cleanly — no NU errors.
- No source references `MsalServiceException.SubError` (renamed to `SubErrorForLogging` in MSAL 4.85.0), so this bump is non-breaking on `master`.
- Both Abstractions 12.1.0 → 12.2.0 and MSAL 4.84.2 → 4.85.0 are additive (no API removals consumed here).