### PR TITLE
Update Microsoft.Identity.Client to 4.85.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -80,8 +80,8 @@
 
   <PropertyGroup Label="Common dependency versions">
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.19.1</MicrosoftIdentityModelVersion>
-    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.85.0</MicrosoftIdentityClientVersion>
-    <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.85.0</MicrosoftIdentityClientKeyAttestationVersion>
+    <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.85.1</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.85.1</MicrosoftIdentityClientKeyAttestationVersion>
     <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.2.0</MicrosoftIdentityAbstractionsVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>


### PR DESCRIPTION
## What

Bumps `Microsoft.Identity.Client` (MSAL.NET) and `Microsoft.Identity.Client.KeyAttestation` from `4.85.0` to `4.85.1` via the `MicrosoftIdentityClientVersion` / `MicrosoftIdentityClientKeyAttestationVersion` properties in `Directory.Build.props`.

## Why

Picks up the MSAL 4.85.1 release.
