### PR TITLE
Skip AcquireTokenWithMtlsPop test: AAD westus3 test slice returns Bearer

### DIFF
--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -428,7 +428,7 @@ namespace TokenAcquirerTests
             Assert.NotNull(result.AccessToken);
         }
 
-        [Fact]
+        [Fact(Skip = "AAD westus3 test-slice mtlsauth endpoint currently returns token_type=Bearer instead of mtls_pop, which is a server-side issue on the test slice (not a Microsoft.Identity.Web or MSAL regression). Re-enable once the AAD test slice is fixed. Tracking: https://github.com/AzureAD/microsoft-identity-web/issues/3891")]
         // [Fact]
         public async Task AcquireTokenWithMtlsPop_WithBindingCertificate_ReturnsMtlsPopToken()
         {


### PR DESCRIPTION
### Problem

The E2E test `AcquireTokenWithMtlsPop_WithBindingCertificate_ReturnsMtlsPopToken` (`tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs`) is failing on the PR pipeline with:

> `MsalClientException: You asked for token type mtls_pop, but receive Bearer.`

### Investigation

Reproduced and root-caused while debugging the same failure in MSAL.NET (AzureAD/microsoft-authentication-library-for-dotnet#6084):

| Endpoint | Result |
|---|---|
| `westus3.mtlsauth.microsoft.com` (test slice — used by this test) | ❌ AAD returns `Bearer` |
| `mtlsauth.microsoft.com` (global — used by a sibling MSAL.NET test) | ✅ Passes |

MSAL is correctly routing to the regional mtlsauth endpoint, sending `token_type=mtls_pop`, and presenting the SNI cert. The AAD westus3 **test slice** is silently downgrading the response. This is not a Microsoft.Identity.Web or MSAL regression.

### Fix

Skip the test via `[Fact(Skip = ""..."")]` — the repo's established pattern for known-broken external-dependency tests (see e.g. `WebAppIntegrationTests.cs`, `TokenAcquirer.cs:268`, `CertificateRotationTest.cs:45`). Remove the skip when AAD test slice is fixed.

### Tracking

- Issue: #3891
- Related MSAL.NET fix: AzureAD/microsoft-authentication-library-for-dotnet#6084