### PR TITLE
Add more tests for TokenAcquisitionMetadata.ExpiresOn from AuthenticationResult

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/AcquireTokenResultFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AcquireTokenResultFactory.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Identity.Web
                 DurationTotalInMs = source.DurationTotalInMs,
                 DurationInHttpInMs = source.DurationInHttpInMs,
                 DurationInCacheInMs = source.DurationInCacheInMs,
+                ExpiresOn = result.ExpiresOn,
                 RefreshOn = source.RefreshOn,
                 ExpiresOn = result.ExpiresOn,
                 RegionDetails = MapRegionDetails(source.RegionDetails),

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AcquireTokenResultFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AcquireTokenResultFactory.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Identity.Web
                 DurationTotalInMs = source.DurationTotalInMs,
                 DurationInHttpInMs = source.DurationInHttpInMs,
                 DurationInCacheInMs = source.DurationInCacheInMs,
-                ExpiresOn = result.ExpiresOn,
                 RefreshOn = source.RefreshOn,
                 ExpiresOn = result.ExpiresOn,
                 RegionDetails = MapRegionDetails(source.RegionDetails),

--- a/tests/Microsoft.Identity.Web.Test/AcquireTokenResultFactoryEnumRoundTripTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AcquireTokenResultFactoryEnumRoundTripTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Region;
@@ -89,6 +90,65 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(
                 System.Enum.GetValues(typeof(RegionOutcome)).Length,
                 System.Enum.GetValues(typeof(Abstractions.AcquiredTokenRegionOutcome)).Length);
+        }
+
+        [Fact]
+        public void GetMetadata_SetsExpiresOn_FromResult_WhenMetadataAvailable()
+        {
+            // Arrange
+            DateTimeOffset expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+            DateTimeOffset extendedExpiresOn = DateTimeOffset.UtcNow.AddHours(2);
+            DateTimeOffset refreshOn = DateTimeOffset.UtcNow.AddMinutes(30);
+            var source = new AuthenticationResultMetadata(TokenSource.IdentityProvider)
+            {
+                RefreshOn = refreshOn,
+            };
+            var result = new AuthenticationResult(
+                "access-token",
+                false,
+                null,
+                expiresOn,
+                extendedExpiresOn,
+                "tenant",
+                null,
+                null,
+                new[] { "scope" },
+                Guid.NewGuid(),
+                source);
+
+            // Act
+            Abstractions.TokenAcquisitionMetadata? metadata = AcquireTokenResultFactory.GetMetadata(result);
+
+            // Assert
+            Assert.NotNull(metadata);
+            Assert.Equal(expiresOn, metadata!.ExpiresOn);
+            // ExpiresOn flows from result.ExpiresOn, distinct from the metadata's RefreshOn hint.
+            Assert.Equal(refreshOn, metadata.RefreshOn);
+        }
+
+        [Fact]
+        public void GetMetadata_ReturnsNull_WhenMetadataAbsent()
+        {
+            // Arrange
+            DateTimeOffset expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+            DateTimeOffset extendedExpiresOn = DateTimeOffset.UtcNow.AddHours(2);
+            var result = new AuthenticationResult(
+                "access-token",
+                false,
+                null,
+                expiresOn,
+                extendedExpiresOn,
+                "tenant",
+                null,
+                null,
+                new[] { "scope" },
+                Guid.NewGuid());
+
+            // Act
+            Abstractions.TokenAcquisitionMetadata? metadata = AcquireTokenResultFactory.GetMetadata(result);
+
+            // Assert
+            Assert.Null(metadata);
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/AcquireTokenResultFactoryEnumRoundTripTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/AcquireTokenResultFactoryEnumRoundTripTests.cs
@@ -150,5 +150,34 @@ namespace Microsoft.Identity.Web.Test
             // Assert
             Assert.Null(metadata);
         }
+
+        [Fact]
+        public void FromMsal_MapsExpiresOn_ToTopLevelAndMetadata()
+        {
+            // Arrange
+            DateTimeOffset expiresOn = DateTimeOffset.UtcNow.AddHours(1);
+            DateTimeOffset extendedExpiresOn = DateTimeOffset.UtcNow.AddHours(2);
+            var source = new AuthenticationResultMetadata(TokenSource.IdentityProvider);
+            var result = new AuthenticationResult(
+                "access-token",
+                false,
+                null,
+                expiresOn,
+                extendedExpiresOn,
+                "tenant",
+                null,
+                null,
+                new[] { "scope" },
+                Guid.NewGuid(),
+                source);
+
+            // Act
+            Abstractions.AcquireTokenResult acquired = AcquireTokenResultFactory.FromMsal(result);
+
+            // Assert — ExpiresOn is surfaced both at the top level and on the metadata surface.
+            Assert.Equal(expiresOn, acquired.ExpiresOn);
+            Assert.NotNull(acquired.Metadata);
+            Assert.Equal(expiresOn, acquired.Metadata!.ExpiresOn);
+        }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/DefaultAuthorizationHeaderProviderV2Tests.cs
+++ b/tests/Microsoft.Identity.Web.Test/DefaultAuthorizationHeaderProviderV2Tests.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(AcquiredTokenSource.Cache, result.Result.Metadata!.TokenSource);
             Assert.Equal(AcquiredTokenCacheLevel.L1Cache, result.Result.Metadata.CacheLevel);
             Assert.Equal(42, result.Result.Metadata.DurationTotalInMs);
+            Assert.Equal(auth.ExpiresOn, result.Result.Metadata.ExpiresOn);
             Assert.NotNull(result.Result.AdditionalResponseParameters);
             Assert.Equal("value", result.Result.AdditionalResponseParameters!["extra"]);
         }


### PR DESCRIPTION
## Summary
Populates `TokenAcquisitionMetadata.ExpiresOn` from `AuthenticationResult.ExpiresOn` in the metadata mapping, so callers of the metadata surface get the access token's absolute expiry on success.

## Changes
- `AcquireTokenResultFactory.MapMetadata`: map `result.ExpiresOn`. Value is surfaced as part of `TokenAcquisitionMetadata`, so it is `null` when no metadata was captured (by design).
- Tests: unit coverage for present/absent metadata + an end-to-end assertion in `DefaultAuthorizationHeaderProviderV2Tests.PropagatesMetadata`.

## Related PRs
- Depends on: AzureAD/microsoft-identity-abstractions-for-dotnet#259 (adds `TokenAcquisitionMetadata.ExpiresOn`).

## Merge note
This can be merged once the Abstractions package (12.4.0, with `ExpiresOn`) is released. CI will be red until then; the Abstractions version floor bump will follow that release.
