### PR TITLE
Update Microsoft.Identity.Abstractions to 12.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,7 +82,7 @@
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.19.1</MicrosoftIdentityModelVersion>
     <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.85.2</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.85.2</MicrosoftIdentityClientKeyAttestationVersion>
-    <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.3.0</MicrosoftIdentityAbstractionsVersion>
+    <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.4.0</MicrosoftIdentityAbstractionsVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>

--- a/src/Microsoft.Identity.Web.TokenAcquisition/AcquireTokenResultFactory.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/AcquireTokenResultFactory.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Identity.Web
                 DurationInHttpInMs = source.DurationInHttpInMs,
                 DurationInCacheInMs = source.DurationInCacheInMs,
                 RefreshOn = source.RefreshOn,
+                ExpiresOn = result.ExpiresOn,
                 RegionDetails = MapRegionDetails(source.RegionDetails),
             };
         }


### PR DESCRIPTION
Bump the package version from 12.3.0 to 12.4.0 and populate the new `TokenAcquisitionMetadata.ExpiresOn` property in `AcquireTokenResultFactory` from the MSAL `AuthenticationResult.ExpiresOn` value.
