### PR TITLE
Use Microsoft-hosted windows-2022 pool for PR pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,10 @@ pr:
 jobs:
 - job: "PR_build"
   pool:
-    name: MwWilson1EsHostedPool
+    vmImage: 'windows-2022'
     demands:
     - msbuild
+    - visualstudio
   steps:
     - template: build/template-install-dependencies.yaml
     - template: build/template-run-unit-tests.yaml


### PR DESCRIPTION
## Summary
Align the PR build agent pool with **MSAL.NET (Azure Pipelines)**.

The root `azure-pipelines.yml` PR build job previously ran on the custom `MwWilson1EsHostedPool`. This changes it to the Microsoft-hosted **`windows-2022`** vmImage, matching the pool MSAL.NET uses for its build/test jobs.

## Changes
- `azure-pipelines.yml`: replace `pool.name: MwWilson1EsHostedPool` with `pool.vmImage: 'windows-2022'`.
- Add the `visualstudio` demand alongside `msbuild` to mirror MSAL.NET's Windows build jobs.

## Reference
MSAL.NET `build/template-build-and-run-all-tests.yaml` uses:
```yaml
pool:
    vmImage: 'windows-2022'
    demands:
    - msbuild
    - visualstudio
```