### PR TITLE
Fix duplicate logging of MsalUiRequiredException

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -389,8 +389,7 @@ namespace Microsoft.Identity.Web
             catch (MsalUiRequiredException ex)
             {
                 // GetAccessTokenForUserAsync is an abstraction that can be called from a web app or a web API
-                Logger.TokenAcquisitionError(_logger, ex.Message, ex);
-
+                // MsalUiRequiredException is already logged by MSAL. Re-logging here would produce duplicates.
                 // Case of the web app: we let the MsalUiRequiredException be caught by the
                 // AuthorizeForScopesAttribute exception filter so that the user can consent, do 2FA, etc ...
                 throw new MicrosoftIdentityWebChallengeUserException(ex, scopes.ToArray(), userFlow);
@@ -1430,12 +1429,9 @@ namespace Microsoft.Identity.Web
 
                 return null;
             }
-            catch (MsalUiRequiredException ex)
+            catch (MsalUiRequiredException)
             {
-                Logger.TokenAcquisitionError(
-                    _logger,
-                    LogMessages.ErrorAcquiringTokenForDownstreamWebApi + ex.Message,
-                    ex);
+                // MsalUiRequiredException is already logged by MSAL. Re-logging here would produce duplicates.
                 throw;
             }
         }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -1272,168 +1272,160 @@ namespace Microsoft.Identity.Web
            MergedOptions mergedOptions,
            ClaimsPrincipal? userHint)
         {
-            try
+            // In web API, validatedToken will not be null
+            SecurityToken? validatedToken = userHint?.GetBootstrapToken() ?? _tokenAcquisitionHost.GetTokenUsedToCallWebAPI();
+
+            // In the case the token is a JWE (encrypted token), we use the decrypted token.
+            string? tokenUsedToCallTheWebApi = GetActualToken(validatedToken);
+            string? originalTokenToCallWebApi = tokenUsedToCallTheWebApi;
+
+            AcquireTokenOnBehalfOfParameterBuilder? builder = null;
+            TokenAcquisitionExtensionOptions? addInOptions = tokenAcquisitionExtensionOptionsMonitor?.CurrentValue;
+
+            // Case of web APIs: we need to do an on-behalf-of flow, with the token used to call the API
+            if (tokenUsedToCallTheWebApi != null)
             {
-                // In web API, validatedToken will not be null
-                SecurityToken? validatedToken = userHint?.GetBootstrapToken() ?? _tokenAcquisitionHost.GetTokenUsedToCallWebAPI();
-
-                // In the case the token is a JWE (encrypted token), we use the decrypted token.
-                string? tokenUsedToCallTheWebApi = GetActualToken(validatedToken);
-                string? originalTokenToCallWebApi = tokenUsedToCallTheWebApi;
-
-                AcquireTokenOnBehalfOfParameterBuilder? builder = null;
-                TokenAcquisitionExtensionOptions? addInOptions = tokenAcquisitionExtensionOptionsMonitor?.CurrentValue;
-
-                // Case of web APIs: we need to do an on-behalf-of flow, with the token used to call the API
-                if (tokenUsedToCallTheWebApi != null)
+                if (addInOptions != null && addInOptions.InvokeOnBeforeOnBehalfOfInitializedAsync != null)
                 {
-                    if (addInOptions != null && addInOptions.InvokeOnBeforeOnBehalfOfInitializedAsync != null)
+                    var oboInitEventArgs = new OnBehalfOfEventArgs
                     {
-                        var oboInitEventArgs = new OnBehalfOfEventArgs
-                        {
-                            UserAssertionToken = tokenUsedToCallTheWebApi,
-                            User = userHint
-                        };
-                        await addInOptions.InvokeOnBeforeOnBehalfOfInitializedAsync(oboInitEventArgs).ConfigureAwait(false);
+                        UserAssertionToken = tokenUsedToCallTheWebApi,
+                        User = userHint
+                    };
+                    await addInOptions.InvokeOnBeforeOnBehalfOfInitializedAsync(oboInitEventArgs).ConfigureAwait(false);
 
-                        if (oboInitEventArgs.UserAssertionToken != null)
-                        {
-                            tokenUsedToCallTheWebApi = oboInitEventArgs.UserAssertionToken;
-                        }
-                    }
-
-                    if (string.IsNullOrEmpty(tokenAcquisitionOptions?.LongRunningWebApiSessionKey))
+                    if (oboInitEventArgs.UserAssertionToken != null)
                     {
-                        builder = application
-                                        .AcquireTokenOnBehalfOf(
-                                            scopes.Except(_scopesRequestedByMsal),
-                                            new UserAssertion(tokenUsedToCallTheWebApi));
-                    }
-                    else
-                    {
-                        string? sessionKey = tokenAcquisitionOptions!.LongRunningWebApiSessionKey;
-                        if (sessionKey == Abstractions.AcquireTokenOptions.LongRunningWebApiSessionKeyAuto)
-                        {
-                            sessionKey = null;
-                        }
-
-                        builder = (application as ILongRunningWebApi)?
-                                       .InitiateLongRunningProcessInWebApi(
-                                           scopes.Except(_scopesRequestedByMsal),
-                                           tokenUsedToCallTheWebApi,
-                                           ref sessionKey);
-                        tokenAcquisitionOptions.LongRunningWebApiSessionKey = sessionKey;
+                        tokenUsedToCallTheWebApi = oboInitEventArgs.UserAssertionToken;
                     }
                 }
-                else if (!string.IsNullOrEmpty(tokenAcquisitionOptions?.LongRunningWebApiSessionKey))
+
+                if (string.IsNullOrEmpty(tokenAcquisitionOptions?.LongRunningWebApiSessionKey))
                 {
-                    string sessionKey = tokenAcquisitionOptions!.LongRunningWebApiSessionKey!;
+                    builder = application
+                                    .AcquireTokenOnBehalfOf(
+                                        scopes.Except(_scopesRequestedByMsal),
+                                        new UserAssertion(tokenUsedToCallTheWebApi));
+                }
+                else
+                {
+                    string? sessionKey = tokenAcquisitionOptions!.LongRunningWebApiSessionKey;
+                    if (sessionKey == Abstractions.AcquireTokenOptions.LongRunningWebApiSessionKeyAuto)
+                    {
+                        sessionKey = null;
+                    }
+
                     builder = (application as ILongRunningWebApi)?
-                                   .AcquireTokenInLongRunningProcess(
+                                   .InitiateLongRunningProcessInWebApi(
                                        scopes.Except(_scopesRequestedByMsal),
-                                       sessionKey);
+                                       tokenUsedToCallTheWebApi,
+                                       ref sessionKey);
+                    tokenAcquisitionOptions.LongRunningWebApiSessionKey = sessionKey;
                 }
-
-                if (builder != null)
-                {
-                    builder.WithSendX5C(mergedOptions.SendX5C);
-
-                    ClaimsPrincipal? userForCcsRouting = _tokenAcquisitionHost.GetUserFromRequest();
-                    var userTenant = string.Empty;
-                    if (userForCcsRouting != null)
-                    {
-                        userTenant = userForCcsRouting.GetTenantId();
-                        builder.WithCcsRoutingHint(userForCcsRouting.GetObjectId(), userTenant);
-                    }
-                    if (!string.IsNullOrEmpty(tenantId))
-                    {
-                        builder.WithTenantId(tenantId);
-                    }
-                    else
-                    {
-                        if (!string.IsNullOrEmpty(userTenant))
-                        {
-                            builder.WithTenantId(userTenant);
-                        }
-                    }
-                    if (tokenAcquisitionOptions != null)
-                    {
-                        if (addInOptions != null && addInOptions.InvokeOnBeforeTokenAcquisitionForOnBehalfOfAsync != null)
-                        {
-                            var eventArgs = new OnBehalfOfEventArgs
-                            {
-                                User = userHint,
-                                UserAssertionToken = originalTokenToCallWebApi
-                            };
-
-                            await addInOptions.InvokeOnBeforeTokenAcquisitionForOnBehalfOfAsync(builder, tokenAcquisitionOptions, eventArgs).ConfigureAwait(false);
-                        }
-
-                        AddFmiPathForSignedAssertionIfNeeded(tokenAcquisitionOptions, builder);
-
-                        var dict = MergeExtraQueryParameters(mergedOptions, tokenAcquisitionOptions);
-                        if (dict != null)
-                        {
-                            const string assertionConstant = "assertion";
-                            const string subAssertionConstant = "sub_assertion";
-
-                            // Special case when the OBO inbound token is composite (for instance PFT)
-                            if (dict.ContainsKey(assertionConstant) && dict.ContainsKey(subAssertionConstant))
-                            {
-                                string assertion = dict[assertionConstant].value;
-                                string subAssertion = dict[subAssertionConstant].value;
-
-                                // Check assertion and sub_assertion passed from merging extra query parameters to ensure they do not contain unsupported character(s).
-                                CheckAssertionsForInjectionAttempt(assertion, subAssertion);
-
-                                builder.OnBeforeTokenRequest((data) =>
-                                {
-                                    // Replace the assertion and adds sub_assertion with the values from the extra query parameters
-                                    data.BodyParameters[assertionConstant] = assertion;
-                                    data.BodyParameters.Add(subAssertionConstant, subAssertion);
-                                    return Task.CompletedTask;
-                                });
-
-                                // Remove the assertion and sub_assertion from the extra query parameters
-                                // as they are already handled as body parameters.
-                                dict.Remove(assertionConstant);
-                                dict.Remove(subAssertionConstant);
-                            }
-
-                            builder.WithExtraQueryParameters(dict);
-                        }
-                        if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
-                        {
-                            builder.WithExtraHttpHeaders(tokenAcquisitionOptions.ExtraHeadersParameters);
-                        }
-                        if (tokenAcquisitionOptions.CorrelationId != null)
-                        {
-                            builder.WithCorrelationId(tokenAcquisitionOptions.CorrelationId.Value);
-                        }
-                        builder.WithForceRefresh(tokenAcquisitionOptions.ForceRefresh);
-                        builder.WithClaims(tokenAcquisitionOptions.Claims);
-                        var clientClaims = GetClientClaimsIfExist(tokenAcquisitionOptions);
-                        if (clientClaims != null)
-                        {
-                            builder.WithExtraClientAssertionClaims(clientClaims);
-                        }
-                        if (tokenAcquisitionOptions.PoPConfiguration != null)
-                        {
-                            builder.WithSignedHttpRequestProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);
-                        }
-                    }
-
-                    return await builder.ExecuteAsync(tokenAcquisitionOptions != null ? tokenAcquisitionOptions.CancellationToken : CancellationToken.None)
-                                        .ConfigureAwait(false);
-                }
-
-                return null;
             }
-            catch (MsalUiRequiredException)
+            else if (!string.IsNullOrEmpty(tokenAcquisitionOptions?.LongRunningWebApiSessionKey))
             {
-                // MsalUiRequiredException is already logged by MSAL. Re-logging here would produce duplicates.
-                throw;
+                string sessionKey = tokenAcquisitionOptions!.LongRunningWebApiSessionKey!;
+                builder = (application as ILongRunningWebApi)?
+                               .AcquireTokenInLongRunningProcess(
+                                   scopes.Except(_scopesRequestedByMsal),
+                                   sessionKey);
             }
+
+            if (builder != null)
+            {
+                builder.WithSendX5C(mergedOptions.SendX5C);
+
+                ClaimsPrincipal? userForCcsRouting = _tokenAcquisitionHost.GetUserFromRequest();
+                var userTenant = string.Empty;
+                if (userForCcsRouting != null)
+                {
+                    userTenant = userForCcsRouting.GetTenantId();
+                    builder.WithCcsRoutingHint(userForCcsRouting.GetObjectId(), userTenant);
+                }
+                if (!string.IsNullOrEmpty(tenantId))
+                {
+                    builder.WithTenantId(tenantId);
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(userTenant))
+                    {
+                        builder.WithTenantId(userTenant);
+                    }
+                }
+                if (tokenAcquisitionOptions != null)
+                {
+                    if (addInOptions != null && addInOptions.InvokeOnBeforeTokenAcquisitionForOnBehalfOfAsync != null)
+                    {
+                        var eventArgs = new OnBehalfOfEventArgs
+                        {
+                            User = userHint,
+                            UserAssertionToken = originalTokenToCallWebApi
+                        };
+
+                        await addInOptions.InvokeOnBeforeTokenAcquisitionForOnBehalfOfAsync(builder, tokenAcquisitionOptions, eventArgs).ConfigureAwait(false);
+                    }
+
+                    AddFmiPathForSignedAssertionIfNeeded(tokenAcquisitionOptions, builder);
+
+                    var dict = MergeExtraQueryParameters(mergedOptions, tokenAcquisitionOptions);
+                    if (dict != null)
+                    {
+                        const string assertionConstant = "assertion";
+                        const string subAssertionConstant = "sub_assertion";
+
+                        // Special case when the OBO inbound token is composite (for instance PFT)
+                        if (dict.ContainsKey(assertionConstant) && dict.ContainsKey(subAssertionConstant))
+                        {
+                            string assertion = dict[assertionConstant].value;
+                            string subAssertion = dict[subAssertionConstant].value;
+
+                            // Check assertion and sub_assertion passed from merging extra query parameters to ensure they do not contain unsupported character(s).
+                            CheckAssertionsForInjectionAttempt(assertion, subAssertion);
+
+                            builder.OnBeforeTokenRequest((data) =>
+                            {
+                                // Replace the assertion and adds sub_assertion with the values from the extra query parameters
+                                data.BodyParameters[assertionConstant] = assertion;
+                                data.BodyParameters.Add(subAssertionConstant, subAssertion);
+                                return Task.CompletedTask;
+                            });
+
+                            // Remove the assertion and sub_assertion from the extra query parameters
+                            // as they are already handled as body parameters.
+                            dict.Remove(assertionConstant);
+                            dict.Remove(subAssertionConstant);
+                        }
+
+                        builder.WithExtraQueryParameters(dict);
+                    }
+                    if (tokenAcquisitionOptions.ExtraHeadersParameters != null)
+                    {
+                        builder.WithExtraHttpHeaders(tokenAcquisitionOptions.ExtraHeadersParameters);
+                    }
+                    if (tokenAcquisitionOptions.CorrelationId != null)
+                    {
+                        builder.WithCorrelationId(tokenAcquisitionOptions.CorrelationId.Value);
+                    }
+                    builder.WithForceRefresh(tokenAcquisitionOptions.ForceRefresh);
+                    builder.WithClaims(tokenAcquisitionOptions.Claims);
+                    var clientClaims = GetClientClaimsIfExist(tokenAcquisitionOptions);
+                    if (clientClaims != null)
+                    {
+                        builder.WithExtraClientAssertionClaims(clientClaims);
+                    }
+                    if (tokenAcquisitionOptions.PoPConfiguration != null)
+                    {
+                        builder.WithSignedHttpRequestProofOfPossession(tokenAcquisitionOptions.PoPConfiguration);
+                    }
+                }
+
+                return await builder.ExecuteAsync(tokenAcquisitionOptions != null ? tokenAcquisitionOptions.CancellationToken : CancellationToken.None)
+                                    .ConfigureAwait(false);
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionTests.cs
@@ -4,15 +4,18 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Web.Extensibility;
 using Microsoft.Identity.Web.Test.Common;
 using Microsoft.Identity.Web.Test.Common.Mocks;
 using Microsoft.Identity.Web.TestOnly;
+using NSubstitute;
 using Xunit;
 
 
@@ -158,6 +161,44 @@ namespace Microsoft.Identity.Web.Test
             // Assert
             Assert.NotNull(result);
             Assert.Equal("Bearer header.payload.signature", result);
+        }
+
+        /// <summary>
+        /// Tests that a caught <see cref="MsalUiRequiredException"/> is not re-logged by Microsoft.Identity.Web,
+        /// since MSAL.NET already logs it. Re-logging produced duplicate log entries.
+        /// This addresses issue #3528.
+        /// </summary>
+        [Fact]
+        public async Task GetAuthenticationResultForUserAsync_DoesNotDuplicateLog_WhenMsalUiRequiredExceptionIsThrown()
+        {
+            // Arrange
+            var tokenAcquirerFactory = InitTokenAcquirerFactory();
+
+            var innerLogger = Substitute.For<ILogger<TokenAcquisition>>();
+            innerLogger.IsEnabled(Arg.Any<Microsoft.Extensions.Logging.LogLevel>()).Returns(true);
+            tokenAcquirerFactory.Services.AddSingleton<ILogger<TokenAcquisition>>(
+                new LoggerMock<TokenAcquisition>(innerLogger));
+
+            IServiceProvider serviceProvider = tokenAcquirerFactory.Build();
+            IAuthorizationHeaderProvider authorizationHeaderProvider = serviceProvider.GetRequiredService<IAuthorizationHeaderProvider>();
+
+            // No account/login-hint claims, so MSAL's AcquireTokenSilent throws MsalUiRequiredException
+            // synchronously (the exact scenario reported in issue #3528).
+            var user = new ClaimsPrincipal(new Microsoft.IdentityModel.Tokens.CaseSensitiveClaimsIdentity());
+
+            // Act & Assert
+            await Assert.ThrowsAsync<MicrosoftIdentityWebChallengeUserException>(() =>
+                authorizationHeaderProvider.CreateAuthorizationHeaderForUserAsync(
+                    new[] { "https://graph.microsoft.com/.default" },
+                    authorizationHeaderProviderOptions: null,
+                    claimsPrincipal: user));
+
+            innerLogger.DidNotReceive().Log(
+                Microsoft.Extensions.Logging.LogLevel.Information,
+                Arg.Is<EventId>(e => e.Id == 300), // LoggingEventId.TokenAcquisitionError
+                Arg.Any<object>(),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>());
         }
 
         private TokenAcquirerFactory InitTokenAcquirerFactory()


### PR DESCRIPTION
# Fix duplicate logging of MsalUiRequiredException
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Stop double-logging MsalUiRequiredException


## Description

MsalUiRequiredException is already logged internally by MSAL.NET at error
level. Microsoft.Identity.Web additionally logged the same exception via
`Logger.TokenAcquisitionError` in two places in TokenAcquisition.cs, both
of which only rethrow/wrap the exception (no recovery logic depends on the
log call). This produced two log entries for a single MsalUiRequiredException,
as described in the issue.

This PR removes the redundant logging calls in those two catch blocks and
adds a comment explaining why nothing is logged there. All other
Logger.TokenAcquisitionError call sites (which handle exceptions MSAL does
not already log, e.g. certificate retry) are unchanged.

Added a unit test that reproduces the scenario from the issue (AcquireTokenSilent
called with no account/login hint, which MSAL throws MsalUiRequiredException for
synchronously) and asserts the log is not emitted.

Fixes #3528

