### PR TITLE
Build solution in PR pipeline before running tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,4 +16,5 @@ jobs:
     - visualstudio
   steps:
     - template: build/template-install-dependencies.yaml
+    - template: build/template-build.yaml
     - template: build/template-run-unit-tests.yaml

--- a/build/template-build.yaml
+++ b/build/template-build.yaml
@@ -1,0 +1,19 @@
+# template-build.yaml
+# Restore and build the solution so that the test assemblies exist before
+# the VSTest steps run. This is required on Microsoft-hosted (ephemeral)
+# agents, which start from a clean workspace with no pre-built output.
+
+steps:
+- task: DotNetCoreCLI@2
+  displayName: 'Install wasm-tools workload'
+  inputs:
+    command: 'custom'
+    custom: 'workload'
+    arguments: 'install wasm-tools'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build solution (Release)'
+  inputs:
+    command: 'custom'
+    custom: 'msbuild'
+    arguments: 'Microsoft.Identity.Web.sln -r -t:build -verbosity:m -property:Configuration=Release'


### PR DESCRIPTION
## Problem
The PR pipeline reported `##[warning]No test sources found matching the given filter 'tests\Microsoft.Identity.Web.Test\bin\**\Microsoft.Identity.Web.Test.dll'` and **ran zero unit tests**.

Root cause: `azure-pipelines.yml` only ran `template-install-dependencies.yaml` (SDKs, NuGet, KeyVault) and then `template-run-unit-tests.yaml` (`VSTest@2` against **pre-built** `bin` assemblies). **There was no build step.**

- On the old **`MwWilson1EsHostedPool`** (persistent/self-hosted) pool, build output lingered in the workspace between runs, so VSTest found stale assemblies.
- After #3908 moved the job to the Microsoft-hosted **`windows-2022`** pool (clean, ephemeral VM per run), nothing is pre-built → the `bin` glob matches nothing → no tests run.

## Fix
Add `build/template-build.yaml` and run it between dependency install and the test steps:

1. Install the `wasm-tools` workload.
2. `dotnet msbuild Microsoft.Identity.Web.sln -r -t:build -verbosity:m -property:Configuration=Release`.

This mirrors the repo's **GitHub Actions** build command, so the VSTest steps then find the freshly-built `bin\Release\**` assemblies.

## Notes / references
- Structure follows the **MSAL.NET** ADO pipeline (discrete `DotNetCoreCLI@2` restore/build/workload steps).
- Uses the **dotnet-SDK MSBuild** (`dotnet msbuild -r`) rather than `VSBuild@1` (which MSAL.NET uses) because IdWeb multi-targets **net10.0**; the dotnet SDK installed via `UseDotNet` resolves the net10 SDK reliably, whereas VS-bundled MSBuild can struggle with newer SDKs.
- Validation of the Windows/net462/net472 build happens in CI (can't be built on Linux).