### PR TITLE
Restore OWIN 5.7.1 packages from internal IDDP feed in PR pipeline

### DIFF
--- a/build/template-build.yaml
+++ b/build/template-build.yaml
@@ -6,22 +6,39 @@
 steps:
 # On ADO agents (TF_BUILD=true) the OWIN project pins Microsoft.IdentityModel
 # WsFederation/Saml to 5.7.1, which is only published to the internal IDDP
-# Azure Artifacts feed (not nuget.org). Add that feed as a package source so
-# restore can resolve it. Credentials are provided by the NuGetAuthenticate@1
-# task that runs earlier in template-install-dependencies.yaml.
+# Azure Artifacts feed (not nuget.org). Route restore exclusively through IDDP,
+# which upstreams nuget.org for all other packages. Credentials are provided by
+# the NuGetAuthenticate@1 task that runs earlier in
+# template-install-dependencies.yaml. This mirrors
+# build/template-restore-build-MSIdentityWeb.yaml.
 - powershell: |
-    $sourceUrl = "https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json"
+    $configFile = "$(Build.SourcesDirectory)/NuGet.Config"
+    $iddpUrl = "https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json"
+
+    Write-Host "Existing NuGet sources:"
+    dotnet nuget list source
+
+    # Remove the public nuget.org source so restore uses IDDP (with upstream) only.
     $existingSources = dotnet nuget list source --format Short
-    if ($existingSources -match [regex]::Escape($sourceUrl)) {
+    if ($existingSources -match [regex]::Escape("https://api.nuget.org/v3/index.json")) {
+        Write-Host "Removing public nuget.org source..."
+        dotnet nuget remove source NuGet --configfile $configFile
+        if (-not $?) { Write-Error "Failed to remove nuget.org source."; exit 1 }
+    }
+
+    # Add the internal IDDP source if not already present.
+    $existingSources = dotnet nuget list source --format Short
+    if ($existingSources -match [regex]::Escape($iddpUrl)) {
         Write-Host "IDDP NuGet source already present. Skipping add."
     } else {
-        Write-Host "Adding IDDP NuGet source to NuGet.Config..."
-        dotnet nuget add source $sourceUrl -n IDDP --configfile "$(Build.SourcesDirectory)/NuGet.Config"
+        Write-Host "Adding IDDP NuGet source..."
+        dotnet nuget add source $iddpUrl -n IDDP --configfile $configFile
         if (-not $?) { Write-Error "Failed to add IDDP NuGet source."; exit 1 }
     }
+
     Write-Host "Final NuGet sources:"
     dotnet nuget list source
-  displayName: 'Add internal IDDP NuGet feed'
+  displayName: 'Use internal IDDP NuGet feed only'
 
 - task: DotNetCoreCLI@2
   displayName: 'Install wasm-tools workload'

--- a/build/template-build.yaml
+++ b/build/template-build.yaml
@@ -4,6 +4,25 @@
 # agents, which start from a clean workspace with no pre-built output.
 
 steps:
+# On ADO agents (TF_BUILD=true) the OWIN project pins Microsoft.IdentityModel
+# WsFederation/Saml to 5.7.1, which is only published to the internal IDDP
+# Azure Artifacts feed (not nuget.org). Add that feed as a package source so
+# restore can resolve it. Credentials are provided by the NuGetAuthenticate@1
+# task that runs earlier in template-install-dependencies.yaml.
+- powershell: |
+    $sourceUrl = "https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json"
+    $existingSources = dotnet nuget list source --format Short
+    if ($existingSources -match [regex]::Escape($sourceUrl)) {
+        Write-Host "IDDP NuGet source already present. Skipping add."
+    } else {
+        Write-Host "Adding IDDP NuGet source to NuGet.Config..."
+        dotnet nuget add source $sourceUrl -n IDDP --configfile "$(Build.SourcesDirectory)/NuGet.Config"
+        if (-not $?) { Write-Error "Failed to add IDDP NuGet source."; exit 1 }
+    }
+    Write-Host "Final NuGet sources:"
+    dotnet nuget list source
+  displayName: 'Add internal IDDP NuGet feed'
+
 - task: DotNetCoreCLI@2
   displayName: 'Install wasm-tools workload'
   inputs:


### PR DESCRIPTION
## Problem

After the ADO PR pipeline started building the solution on the ephemeral `windows-2022` pool (#3911), restore fails with:

```
NU1603: Warning As Error: Microsoft.Identity.Web.OWIN depends on
Microsoft.IdentityModel.Protocols.WsFederation (>= 5.7.1) but 5.7.1 was not found.
6.5.0 was resolved instead.  (same for Microsoft.IdentityModel.Tokens.Saml)
```

`Microsoft.Identity.Web.OWIN.csproj` pins the IdentityModel v5 packages to **5.7.1** when `TF_BUILD=true` (i.e. on any ADO agent), otherwise 5.7.0. Version **5.7.1 is only published to the internal IDDP Azure Artifacts feed**, not nuget.org — the repo `NuGet.Config` only lists nuget.org, so restore can't find it, and repo-wide `TreatWarningsAsErrors` promotes NU1603 to an error.

## Fix

At PR-build time, remove the public nuget.org source and restore exclusively through the internal **IDDP** feed (`identitydivision/_packaging/IDDP`), which upstreams nuget.org for public packages and serves the internal 5.7.1 IdentityModel packages. Credentials come from the existing `NuGetAuthenticate@1` task already run in `template-install-dependencies.yaml`. This mirrors the established pattern in `build/template-restore-build-MSIdentityWeb.yaml`.

- Source changes are applied at pipeline runtime only; the committed `NuGet.Config` is unchanged, so GitHub Actions / public restores are unaffected.
- The remove and add steps are idempotent.

## Notes

This assumes the PR pipeline's build identity can authenticate to the IDDP feed (same identitydivision org). If it cannot, we'd fall back to overriding the OWIN package version to the public 5.7.0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>