### PR TITLE
Run PR pipeline on Wilson pool so integration/E2E tests can access lab KeyVault

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
 jobs:
 - job: "PR_build"
   pool:
-    vmImage: 'windows-2022'
+    name: MwWilson1EsHostedPool
     demands:
     - msbuild
     - visualstudio


### PR DESCRIPTION
## Problem

After moving the PR pipeline to the Microsoft-hosted `windows-2022` pool, unit tests pass but **integration tests fail** with:

```
IDW10109: No credential could be loaded ... code isn't running on Azure to be able to use Managed Identity ...
Credential CertificateFromKeyVault=https://msidlabs.vault.azure.net/LabAuth;Thumbprint=null failed:
Azure.Identity.CredentialUnavailableException: DefaultAzureCredential failed to retrieve a token
 - ManagedIdentityCredential ... "Identity not found"
```

The integration/E2E test host (`tests/E2E Tests/IntegrationTestService/appsettings.json`) loads its client certificate from the `msidlabs` KeyVault (`SourceType: KeyVault`, `KeyVaultCertificateName: LabAuth`). Microsoft.Identity.Web resolves that via `DefaultAzureCredential`, which on the **ephemeral hosted agent** finds no managed identity (IMDS returns *Identity not found*) and no other credential, so the cert can't be downloaded.

## Why the Wilson pool fixes it

The OneBranch `Tests` job runs on `MwWilson1EsHostedPool`, whose agent VMs are provisioned with a **managed identity that has access to the lab KeyVaults**. There is no credential setup in YAML — `DefaultAzureCredential` transparently uses that managed identity. The hosted pool has no equivalent identity.

## Change

- Revert the `PR_build` pool from `vmImage: windows-2022` back to `name: MwWilson1EsHostedPool`.
- Keep the explicit `template-build.yaml` step and the `visualstudio` demand so the integration/E2E assemblies are built fresh and `VSTest@2` can run (mirrors the OneBranch Wilson `Tests` job, which demands both `msbuild` and `visualstudio`).

## Notes

The alternative (staying on hosted agents) would require injecting an Azure credential into the agent (e.g. `AzureCLI@2` with `addSpnToEnvironment` exporting `AZURE_CLIENT_ID/TENANT_ID/secret`) so `DefaultAzureCredential`'s `EnvironmentCredential` can reach `msidlabs`. Going back to the Wilson pool restores the previously-working setup without that complexity.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>