### PR TITLE
Apply reserved-header handling on the request-clone path and cover all X-MS-TOKEN- headers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,9 @@
 - Remove the unused `ConfidentialClientKeyVaultUri` test constant (LabVaultAccessCert cleanup). See [#3898](https://github.com/AzureAD/microsoft-identity-web/pull/3898).
 - Use the Microsoft-hosted `windows-2022` pool for the PR pipeline. See [#3908](https://github.com/AzureAD/microsoft-identity-web/pull/3908).
 
+### Bug fixes
+- Apply reserved-header handling on the request-clone path used for challenge retries and mTLS PoP, consistently with `ExtraHeaderParameters`, and broaden the reserved `X-MS-TOKEN-` prefix to cover the whole `X-MS-TOKEN-*` family rather than only `X-MS-TOKEN-AAD-*`.
+
 ## 4.11.0
 
 ### New features

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## 4.12.3
+
+### Bug fixes
+- Apply reserved-header handling on the request-clone path used for challenge retries and mTLS PoP, consistently with `ExtraHeaderParameters`, and broaden the reserved `X-MS-TOKEN-` prefix to cover the whole `X-MS-TOKEN-*` family rather than only `X-MS-TOKEN-AAD-*`.
+
 ## 4.12.2
 
 ### Bug fixes
@@ -38,9 +43,6 @@
 - Post-release housekeeping: move unshipped Public API entries to `PublicAPI.Shipped.txt` for `Microsoft.Identity.Web.TokenAcquisition`. See [#3907](https://github.com/AzureAD/microsoft-identity-web/pull/3907).
 - Remove the unused `ConfidentialClientKeyVaultUri` test constant (LabVaultAccessCert cleanup). See [#3898](https://github.com/AzureAD/microsoft-identity-web/pull/3898).
 - Use the Microsoft-hosted `windows-2022` pool for the PR pipeline. See [#3908](https://github.com/AzureAD/microsoft-identity-web/pull/3908).
-
-### Bug fixes
-- Apply reserved-header handling on the request-clone path used for challenge retries and mTLS PoP, consistently with `ExtraHeaderParameters`, and broaden the reserved `X-MS-TOKEN-` prefix to cover the whole `X-MS-TOKEN-*` family rather than only `X-MS-TOKEN-AAD-*`.
 
 ## 4.11.0
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityMessageHandler.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityMessageHandler.cs
@@ -813,8 +813,9 @@ namespace Microsoft.Identity.Web
             // Copy headers
             foreach (var header in originalRequest.Headers)
             {
-                // Skip Authorization header as it will be set by the handler
-                if (header.Key != "Authorization")
+                // The Authorization header is set by the handler. Reserved headers are handled
+                // consistently with ExtraHeaderParameters and are not carried over to the clone.
+                if (header.Key != "Authorization" && !ReservedHeaderNames.IsReserved(header.Key))
                 {
                     clonedRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
                 }

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ReservedHeaderNames.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ReservedHeaderNames.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Identity.Web
         private static readonly string[] s_prefixes = new[]
         {
             "X-Forwarded-",
-            "X-MS-TOKEN-AAD-",
+            // Reserve the whole X-MS-TOKEN- family (any X-MS-TOKEN-* header, not only X-MS-TOKEN-AAD-*).
+            "X-MS-TOKEN-",
         };
 
         /// <summary>

--- a/tests/Microsoft.Identity.Web.Test/DownstreamWebApiSupport/DownstreamApiTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/DownstreamWebApiSupport/DownstreamApiTests.cs
@@ -341,6 +341,8 @@ namespace Microsoft.Identity.Web.Tests
         [InlineData("X-MS-TOKEN-AAD-ID-TOKEN")]
         [InlineData("X-MS-TOKEN-AAD-ACCESS-TOKEN")]
         [InlineData("x-ms-token-aad-refresh-token")]
+        [InlineData("X-MS-TOKEN-EXAMPLE-ACCESS-TOKEN")]
+        [InlineData("x-ms-token-example-refresh-token")]
         public async Task UpdateRequestAsync_ExtraHeaderParameters_ReservedPrefixes_AreIgnored(string headerName)
         {
             // Arrange

--- a/tests/Microsoft.Identity.Web.Test/ReservedHeaderCloneTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ReservedHeaderCloneTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    // Verifies reserved headers are dropped when a request is cloned (challenge retry / mTLS PoP),
+    // consistently with ExtraHeaderParameters handling, and that the reserved X-MS-TOKEN- prefix
+    // covers the whole X-MS-TOKEN-* family.
+    public class ReservedHeaderCloneTests
+    {
+        [Theory]
+        // Exact reserved names.
+        [InlineData("Authorization", true)]
+        [InlineData("Cookie", true)]
+        [InlineData("Host", true)]
+        [InlineData("X-MS-CLIENT-PRINCIPAL", true)]
+        [InlineData("x-ms-client-principal-id", true)]
+        // AAD token headers stay reserved.
+        [InlineData("X-MS-TOKEN-AAD-ID-TOKEN", true)]
+        [InlineData("x-ms-token-aad-refresh-token", true)]
+        // Any other X-MS-TOKEN- header is reserved by the broadened prefix.
+        [InlineData("X-MS-TOKEN-EXAMPLE-ACCESS-TOKEN", true)]
+        [InlineData("x-ms-token-example-refresh-token", true)]
+        // Forwarded headers stay reserved.
+        [InlineData("X-Forwarded-For", true)]
+        // Ordinary headers are not reserved.
+        [InlineData("Accept", false)]
+        [InlineData("X-Custom-Header", false)]
+        [InlineData("X-MS-Something-Else", false)]
+        [InlineData("", false)]
+        public void IsReserved_ClassifiesHeaders(string headerName, bool expected)
+        {
+            Assert.Equal(expected, ReservedHeaderNames.IsReserved(headerName));
+        }
+
+        [Fact]
+        public async Task CloneHttpRequestMessageAsync_DropsReservedHeaders_KeepsOrdinaryHeaders()
+        {
+            // Arrange: an original request carrying Authorization, reserved headers, and an ordinary one.
+            var original = new HttpRequestMessage(HttpMethod.Get, "https://example.com/resource");
+            original.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "sample-token");
+            original.Headers.TryAddWithoutValidation("X-MS-CLIENT-PRINCIPAL", "sample-principal");
+            original.Headers.TryAddWithoutValidation("X-MS-TOKEN-EXAMPLE-ACCESS-TOKEN", "sample-token-value");
+            original.Headers.TryAddWithoutValidation("X-Forwarded-For", "10.0.0.1");
+            original.Headers.TryAddWithoutValidation("X-Custom-Header", "keep-me");
+
+            // Act: invoke the private static clone helper.
+            var method = typeof(MicrosoftIdentityMessageHandler).GetMethod(
+                "CloneHttpRequestMessageAsync",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var clone = await (Task<HttpRequestMessage>)method!.Invoke(null, new object[] { original })!;
+
+            // Assert: reserved headers (and Authorization, set later by the handler) are not copied.
+            Assert.False(clone.Headers.Contains("Authorization"));
+            Assert.False(clone.Headers.Contains("X-MS-CLIENT-PRINCIPAL"));
+            Assert.False(clone.Headers.Contains("X-MS-TOKEN-EXAMPLE-ACCESS-TOKEN"));
+            Assert.False(clone.Headers.Contains("X-Forwarded-For"));
+            // Ordinary header survives the clone.
+            Assert.True(clone.Headers.Contains("X-Custom-Header"));
+        }
+    }
+}


### PR DESCRIPTION
Makes reserved-header handling consistent across the DownstreamApi code paths.

- `MicrosoftIdentityMessageHandler` clones the outgoing request for challenge retries and mTLS PoP. The clone now applies the same reserved-header filter already used for `ExtraHeaderParameters`, so reserved headers are handled the same way on every path.
- Broadens the reserved `X-MS-TOKEN-` prefix to cover the whole `X-MS-TOKEN-*` family rather than only `X-MS-TOKEN-AAD-*`.

`ReservedHeaderNames` moves to `Microsoft.Identity.Web.TokenAcquisition` so both it and the DownstreamApi layer share a single definition. It stays internal; no public API change.

Tests: added coverage for `IsReserved` classification, the clone path (reserved and Authorization headers are not copied, ordinary headers are), and the additional `ExtraHeaderParameters` prefix cases. Affected suites pass on net8.0.
