### PR TITLE
Revert "Run PR pipeline on Wilson pool for lab KeyVault access (#3913)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
 jobs:
 - job: "PR_build"
   pool:
-    name: MwWilson1EsHostedPool
+    vmImage: 'windows-2022'
     demands:
     - msbuild
     - visualstudio


### PR DESCRIPTION
Reverts #3913, moving the `PR_build` pool back from `MwWilson1EsHostedPool` to the Microsoft-hosted `windows-2022` image.

We're moving toward running the PR pipeline on standard Microsoft-hosted agents (as MSAL.NET does), rather than the custom Wilson pool. A follow-up will make the integration/E2E tests work on hosted agents by loading the `LabAuth` certificate from the machine cert store (installed by `template-install-dependencies.yaml` via the `AuthSdkResourceManager` service connection) instead of pulling it from KeyVault via `DefaultAzureCredential` — mirroring MSAL.NET's setup.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>