### PR TITLE
Run PR pipeline on hosted agents with LabAuth cert from store

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,14 @@ pr:
 
 jobs:
 - job: "PR_build"
+  variables:
+    # Load the LabAuth client certificate from the local certificate store
+    # (installed into LocalMachine/My by template-install-dependencies.yaml)
+    # instead of the msidlabs KeyVault. Microsoft-hosted agents have no managed
+    # identity that can read the KeyVault, so DefaultAzureCredential would fail.
+    # The official OneBranch/Wilson pipeline does not set this and keeps using
+    # the KeyVault source.
+    UseLabAuthCertFromStore: true
   pool:
     vmImage: 'windows-2022'
     demands:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
 jobs:
 - job: "PR_build"
   pool:
-    name: MwWilson1EsHostedPool
+    vmImage: 'windows-2022'
     demands:
     - msbuild
     - visualstudio

--- a/tests/E2E Tests/IntegrationTestService/Program.cs
+++ b/tests/E2E Tests/IntegrationTestService/Program.cs
@@ -1,13 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace IntegrationTestService
 {
     public class Program
     {
+        // Opt-in switch. When set to a truthy value, the test host loads the LabAuth
+        // client certificate from the local certificate store instead of the msidlabs
+        // KeyVault. Used on hosted agents that have no managed identity able to read the
+        // KeyVault (the pipeline installs LabAuth into LocalMachine/My). Defaults to the
+        // KeyVault source, so the official (Wilson) pipeline and local dev are unchanged.
+        internal const string UseCertFromStoreEnvVar = "UseLabAuthCertFromStore";
+
         public static void Main(string[] args)
         {
             CreateHostBuilder(args).Build().Run();
@@ -15,9 +25,40 @@ namespace IntegrationTestService
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((context, config) =>
+                {
+                    if (ShouldUseCertFromStore())
+                    {
+                        config.AddInMemoryCollection(LabAuthCertFromStoreOverrides());
+                    }
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+
+        private static bool ShouldUseCertFromStore()
+        {
+            string? value = Environment.GetEnvironmentVariable(UseCertFromStoreEnvVar);
+            return !string.IsNullOrEmpty(value) &&
+                   (value.Equals("true", StringComparison.OrdinalIgnoreCase) || value == "1");
+        }
+
+        // Overrides the KeyVault-sourced client certificate in appsettings.json with the
+        // LabAuth certificate installed in LocalMachine/My (CN=LabAuth.MSIDLab.com), for
+        // both authentication schemes (AzureAd and AzureAd2).
+        private static IEnumerable<KeyValuePair<string, string?>> LabAuthCertFromStoreOverrides()
+        {
+            foreach (string section in new[] { "AzureAd", "AzureAd2" })
+            {
+                string prefix = $"{section}:ClientCertificates:0:";
+                yield return new(prefix + "SourceType", "StoreWithDistinguishedName");
+                yield return new(prefix + "CertificateStorePath", "LocalMachine/My");
+                yield return new(prefix + "CertificateDistinguishedName", "CN=LabAuth.MSIDLab.com");
+                // Clear the KeyVault-specific keys inherited from appsettings.json.
+                yield return new(prefix + "KeyVaultUrl", null);
+                yield return new(prefix + "KeyVaultCertificateName", null);
+            }
+        }
     }
 }


### PR DESCRIPTION
Combines the changes previously split across #3916 and #3917.

## Summary
Move the GitHub PR pipeline back to Microsoft-hosted agents (`windows-2022`) and make the integration tests work there.

## Changes
1. **Revert to hosted pool** — `azure-pipelines.yml` runs on `windows-2022` instead of `MwWilson1EsHostedPool` (reverts #3913).
2. **LabAuth cert from store** — the integration-test host (`IntegrationTestService`) previously loaded its `LabAuth` client certificate from the `msidlabs` KeyVault (`SourceType: KeyVault`), which Microsoft.Identity.Web resolves via `DefaultAzureCredential`. Hosted agents have no managed identity with KeyVault access, so tests failed with `IDW10109: ... ManagedIdentityCredential ... Identity not found`.

   A new opt-in switch (env var `UseLabAuthCertFromStore`, read in `IntegrationTestService/Program.cs`) overrides the client-certificate source for both schemes (`AzureAd`, `AzureAd2`) to load the `LabAuth` cert from the local store (`StoreWithDistinguishedName`, `LocalMachine/My`, `CN=LabAuth.MSIDLab.com`) — which `build/template-install-dependencies.yaml` already installs. The in-process tests use `WebApplicationFactory<Startup>`, which invokes `Program.CreateHostBuilder`, so the override applies.

## Safety
- **Default (unset) = KeyVault**, so the official OneBranch/Wilson pipeline and local dev are unchanged.
- The switch is enabled **only** in the hosted GitHub PR pipeline (`azure-pipelines.yml`); the OneBranch `.pipelines/*.yml` are untouched.

This mirrors how MSAL.NET's integration tests authenticate with the installed cert rather than a managed identity.