### PR TITLE
Fix CVE-2026-49451: pin Microsoft.OpenApi to patched 2.9.0 in AspireBlazorCallsWebApi DevApp

### DIFF
--- a/tests/DevApps/AspireBlazorCallsWebApi/AspireBlazorCallsWebApi.ApiService/AspireBlazorCallsWebApi.ApiService.csproj
+++ b/tests/DevApps/AspireBlazorCallsWebApi/AspireBlazorCallsWebApi.ApiService/AspireBlazorCallsWebApi.ApiService.csproj
@@ -12,7 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <!-- Pin Microsoft.OpenApi to the centrally-managed patched version (see tests/DevApps/Directory.Build.props) to avoid the vulnerable 2.0.0 pulled in transitively (CVE-2026-49451). -->
+    <PackageReference Include="Microsoft.OpenApi" Version="$(MicrosoftOpenApiVersion)" />
   </ItemGroup>
 
 </Project>

--- a/tests/DevApps/Directory.Build.props
+++ b/tests/DevApps/Directory.Build.props
@@ -20,6 +20,8 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <SystemDrawingCommon>10.0.0-rc.1.25451.107</SystemDrawingCommon>
+    <!--CVE-2026-49451: Microsoft.AspNetCore.OpenApi 10.0.x transitively pulls the High-severity-vulnerable Microsoft.OpenApi 2.0.0; floor to patched 2.9.0-->
+    <MicrosoftOpenApiVersion>2.9.0</MicrosoftOpenApiVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The OneBranch build fails its Component Governance security gate because a demo app transitively pulls the High-severity-vulnerable **Microsoft.OpenApi 2.0.0** (CVE-2026-49451) via **Microsoft.AspNetCore.OpenApi 10.0.x** — fix it by forcing that package to the patched **2.9.0**, the same fix already applied to the Sidecar project.

## Root cause
`tests/DevApps/AspireBlazorCallsWebApi/AspireBlazorCallsWebApi.ApiService` was the last project still on the `Microsoft.AspNetCore.OpenApi` 10.0.x line (10.0.1), which drags in the vulnerable `Microsoft.OpenApi` 2.0.0 transitively. (The Sidecar was already fixed; every other OpenApi DevApp is on 7.0.x/8.0.x and resolves the unaffected 1.4.3.)

`dotnet nuget why` — **before**:
```
[net10.0]
└── Microsoft.AspNetCore.OpenApi (v10.0.1)
    └── Microsoft.OpenApi (v2.0.0)
```

## Fix
- Bump `Microsoft.AspNetCore.OpenApi` 10.0.1 → 10.0.9 and add an explicit `Microsoft.OpenApi` pin (belt-and-suspenders, matching the Sidecar fix).
- Centralize the pinned version as `MicrosoftOpenApiVersion = 2.9.0` in `tests/DevApps/Directory.Build.props` (the props file the DevApps actually inherit — the repo-root `Directory.Build.props` import chain does not reach `tests/DevApps`), with a CVE comment, so the floor lives in one place for net10 DevApps.

`dotnet nuget why` — **after** (vulnerable 2.0.0 gone, no `NU1903`):
```
[net10.0]
├── Microsoft.AspNetCore.OpenApi (v10.0.9)
│   └── Microsoft.OpenApi (v2.9.0)
└── Microsoft.OpenApi (v2.9.0)
```

## Verification
- No other project resolves a vulnerable 2.x: Sidecar + this app → 2.9.0; all other OpenApi DevApps → 1.4.3 (separate, unaffected 1.x major).
- `dotnet restore` + `dotnet build -c Release` succeed with 0 warnings / 0 errors.
- The CG alert is **not** baselined or dismissed — the vulnerable version is removed from the dependency graph.