### PR TITLE
Test: consolidate MI E2E test onto shared Msal_Integration_tests UAMI

### DIFF
--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -561,7 +561,9 @@ namespace TokenAcquirerTests
             // Arrange
             const string scope = "https://vault.azure.net/.default";
             const string baseUrl = "https://vault.azure.net";
-            const string clientId = "5bcd1685-b002-4fd1-8ebd-1ec3e1e4ca4d";
+            // User-assigned managed identity "Msal_Integration_tests" (RG MSAL_MSI, sub c1686c51-b717-4fe0-9af3-24a20a41fb0c).
+            // Shared/consolidated lab UAMI reused across MSAL and Id.Web E2E tests.
+            const string clientId = "45344e7d-c562-4be6-868f-18dac789c021";
             TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest();
             TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
             IServiceProvider serviceProvider = tokenAcquirerFactory.Build();


### PR DESCRIPTION
## What

Switches the `AcquireTokenWithManagedIdentity_UserAssignedAsync` E2E test (`tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs`) from the single-purpose **`Id4STesting`** user-assigned managed identity (clientId `5bcd1685-b002-4fd1-8ebd-1ec3e1e4ca4d`) to the shared/consolidated lab UAMI **`Msal_Integration_tests`** (clientId `45344e7d-c562-4be6-868f-18dac789c021`, RG `MSAL_MSI`, sub `c1686c51-b717-4fe0-9af3-24a20a41fb0c`).

## Why

- `Id4STesting` is a single-purpose identity whose *only* consumer across all repos is this one test. Consolidating onto the already-shared `Msal_Integration_tests` UAMI (also used by MSAL.NET E2E tests) lets us **retire `Id4STesting`** and reduce identity sprawl.
- The test only acquires a token for the generic `https://vault.azure.net/.default` audience and asserts the header is non-empty - it does **not** read from any specific Key Vault. Token issuance happens at Entra, so **no Key Vault permissions are required**. `Msal_Integration_tests` is a permissions superset, so the swap is safe from an authorization standpoint.

## Testing

E2E test runs only on the ADO pipeline (`[OnlyOnAzureDevopsFact]`); validate via the pipeline once the MI is assigned to the agent pool.
