### PR TITLE
Add GetAuthorizationHeaderProvider2() to OWIN controllers

### DIFF
--- a/src/Microsoft.Identity.Web.OWIN/ApiControllerExtensions.cs
+++ b/src/Microsoft.Identity.Web.OWIN/ApiControllerExtensions.cs
@@ -43,6 +43,20 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
+        /// Get the authorization header provider, exposing the richer <see cref="IAuthorizationHeaderProvider2"/> surface.
+        /// </summary>
+        /// <returns></returns>
+        public static IAuthorizationHeaderProvider2 GetAuthorizationHeaderProvider2(this ApiController _)
+        {
+            IAuthorizationHeaderProvider2? headerProvider = TokenAcquirerFactory.GetDefaultInstance().ServiceProvider?.GetService(typeof(IAuthorizationHeaderProvider2)) as IAuthorizationHeaderProvider2;
+            if (headerProvider == null)
+            {
+                throw new ConfigurationErrorsException("Cannot find IAuthorizationHeaderProvider2. Did you create an OwinTokenAcquirerFactory in Startup_Auth.cs?. See https://aka.ms/ms-id-web/owin. ");
+            }
+            return headerProvider;
+        }
+
+        /// <summary>
         /// Get the downstream API service from an ApiController.
         /// </summary>
         /// <returns></returns>

--- a/src/Microsoft.Identity.Web.OWIN/ControllerBaseExtensions.cs
+++ b/src/Microsoft.Identity.Web.OWIN/ControllerBaseExtensions.cs
@@ -43,6 +43,20 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
+        /// Get the authorization header provider, exposing the richer <see cref="IAuthorizationHeaderProvider2"/> surface.
+        /// </summary>
+        /// <returns></returns>
+        public static IAuthorizationHeaderProvider2 GetAuthorizationHeaderProvider2(this ControllerBase _)
+        {
+            IAuthorizationHeaderProvider2? headerProvider = TokenAcquirerFactory.GetDefaultInstance().ServiceProvider?.GetService(typeof(IAuthorizationHeaderProvider2)) as IAuthorizationHeaderProvider2;
+            if (headerProvider == null)
+            {
+                throw new ConfigurationErrorsException("Cannot find IAuthorizationHeaderProvider2. Did you create an OwinTokenAcquirerFactory in Startup_Auth.cs?. See https://aka.ms/ms-id-web/owin. ");
+            }
+            return headerProvider;
+        }
+
+        /// <summary>
         /// Get the downstream API service from an ApiController.
         /// </summary>
         /// <returns></returns>

--- a/src/Microsoft.Identity.Web.OWIN/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OWIN/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Identity.Web.ApiControllerExtensions.GetAuthorizationHeaderProvider2(this System.Web.Http.ApiController! _) -> Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider2!
+static Microsoft.Identity.Web.ControllerBaseExtensions.GetAuthorizationHeaderProvider2(this System.Web.Mvc.ControllerBase! _) -> Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider2!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/ServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Identity.Web
             ServiceDescriptor? ccaProviderService = services.FirstOrDefault(s => s.ServiceType == typeof(IConfidentialClientApplicationProvider));
             ServiceDescriptor? tokenAcquisitionhost = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquisitionHost));
             ServiceDescriptor? authenticationHeaderCreator = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthorizationHeaderProvider));
+            ServiceDescriptor? authenticationHeaderCreator2 = services.FirstOrDefault(s => s.ServiceType == typeof(IAuthorizationHeaderProvider2));
             ServiceDescriptor? tokenAcquirerFactory = services.FirstOrDefault(s => s.ServiceType == typeof(ITokenAcquirerFactory));
             ServiceDescriptor? authSchemeInfoProvider = services.FirstOrDefault(s => s.ServiceType == typeof(Abstractions.IAuthenticationSchemeInformationProvider));
             ServiceDescriptor? credentialsProviderService = services.FirstOrDefault(s => s.ServiceType == typeof(ICredentialsProvider));
@@ -90,6 +91,11 @@ namespace Microsoft.Identity.Web
                     services.Remove(tokenAcquisitionhost);
                     services.Remove(authenticationHeaderCreator);
                     services.Remove(authSchemeInfoProvider);
+
+                    if (authenticationHeaderCreator2 != null)
+                    {
+                        services.Remove(authenticationHeaderCreator2);
+                    }
 
                     if (ccaProviderService != null)
                     {
@@ -148,6 +154,8 @@ namespace Microsoft.Identity.Web
                 services.AddSingleton<Abstractions.IAuthenticationSchemeInformationProvider>(sp =>
                     sp.GetRequiredService<ITokenAcquisitionHost>());
                 services.AddSingleton<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
+                // Expose the same instance as IAuthorizationHeaderProvider2 so it can be resolved directly.
+                services.AddSingleton(s => (IAuthorizationHeaderProvider2)s.GetRequiredService<IAuthorizationHeaderProvider>());
                 if (!HasImplementationType(services, typeof(CredentialsProvider)))
                 {
                     services.TryAddSingleton<ICredentialsProvider, CredentialsProvider>();
@@ -183,6 +191,8 @@ namespace Microsoft.Identity.Web
                 services.AddScoped<Abstractions.IAuthenticationSchemeInformationProvider>(sp =>
                     sp.GetRequiredService<ITokenAcquisitionHost>());
                 services.AddScoped<IAuthorizationHeaderProvider, DefaultAuthorizationHeaderProvider>();
+                // Expose the same instance as IAuthorizationHeaderProvider2 so it can be resolved directly.
+                services.AddScoped(s => (IAuthorizationHeaderProvider2)s.GetRequiredService<IAuthorizationHeaderProvider>());
                 if (!HasImplementationType(services, typeof(CredentialsProvider)))
                 {
                     services.TryAddScoped<ICredentialsProvider, CredentialsProvider>();

--- a/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ServiceCollectionExtensionsTests.cs
@@ -75,6 +75,14 @@ namespace Microsoft.Identity.Web.Test
                 },
                 actual =>
                 {
+                    Assert.Equal(ServiceLifetime.Scoped, actual.Lifetime);
+                    Assert.Equal(typeof(IAuthorizationHeaderProvider2), actual.ServiceType);
+                    Assert.Null(actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.NotNull(actual.ImplementationFactory);
+                },
+                actual =>
+                {
                     Assert.Equal(typeof(ICredentialsLoader), actual.ServiceType);
                     Assert.Equal(typeof(DefaultCertificateLoader), actual.ImplementationType);
                     Assert.Null(actual.ImplementationInstance);
@@ -155,7 +163,7 @@ namespace Microsoft.Identity.Web.Test
             services.AddTokenAcquisition();
 
             // Verify the number of services added by AddTokenAcquisition (ignoring the service we added here).
-            Assert.Equal(14, services.Count(t => t.ServiceType != typeof(ServiceCollectionExtensionsTests)));
+            Assert.Equal(15, services.Count(t => t.ServiceType != typeof(ServiceCollectionExtensionsTests)));
         }
 #endif
 
@@ -208,6 +216,43 @@ namespace Microsoft.Identity.Web.Test
             // Assert
             Assert.Same(tokenAcquisition, confidentialClientApplicationProvider);
             Assert.IsAssignableFrom<TokenAcquisition>(confidentialClientApplicationProvider);
+        }
+
+        [Fact]
+        public void AddTokenAcquisition_RegistersIAuthorizationHeaderProvider2()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddTokenAcquisition();
+
+            // Assert
+            ServiceDescriptor serviceDescriptor = Assert.Single(services, s => s.ServiceType == typeof(IAuthorizationHeaderProvider2));
+            Assert.Equal(ServiceLifetime.Scoped, serviceDescriptor.Lifetime);
+            Assert.Null(serviceDescriptor.ImplementationType);
+            Assert.Null(serviceDescriptor.ImplementationInstance);
+            Assert.NotNull(serviceDescriptor.ImplementationFactory);
+        }
+
+        [Fact]
+        public void AddTokenAcquisition_ResolvesIAuthorizationHeaderProvider2ToSameInstanceAsV1()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddTokenAcquisition();
+            services.AddInMemoryTokenCaches();
+            services.AddHttpClient();
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            using IServiceScope serviceScope = serviceProvider.CreateScope();
+
+            // Act
+            var headerProvider = serviceScope.ServiceProvider.GetRequiredService<IAuthorizationHeaderProvider>();
+            var headerProvider2 = serviceScope.ServiceProvider.GetRequiredService<IAuthorizationHeaderProvider2>();
+
+            // Assert
+            Assert.Same(headerProvider, headerProvider2);
+            Assert.IsType<DefaultAuthorizationHeaderProvider>(headerProvider2);
         }
 
         [Fact]
@@ -275,6 +320,14 @@ namespace Microsoft.Identity.Web.Test
                     Assert.Equal(typeof(DefaultAuthorizationHeaderProvider), actual.ImplementationType);
                     Assert.Null(actual.ImplementationInstance);
                     Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IAuthorizationHeaderProvider2), actual.ServiceType);
+                    Assert.Null(actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.NotNull(actual.ImplementationFactory);
                 },
                 actual =>
                 {


### PR DESCRIPTION
OWIN controllers already have a one-liner for the v1 `IAuthorizationHeaderProvider`. This adds the same convenience for `IAuthorizationHeaderProvider2` on both `ApiController` and `ControllerBase`, resolving it from the OWIN `TokenAcquirerFactory` service provider (same pattern/error message as the v1 helper).

Depends on #3927 (which registers `IAuthorizationHeaderProvider2` in DI) - stacked on that branch, so please review it after #3927. Opening separately for team discussion on whether we want the OWIN convenience overload.
