### PR TITLE
Potential fix for code scanning alert no. 35: Missing cross-site request forgery token validation

### DIFF
--- a/tests/DevApps/B2CWebAppCallsWebApi/TodoListService/Controllers/TodoListController.cs
+++ b/tests/DevApps/B2CWebAppCallsWebApi/TodoListService/Controllers/TodoListController.cs
@@ -59,6 +59,7 @@ namespace TodoListService.Controllers
         // POST api/values
         [HttpPost]
         [RequiredScope("write")]
+        [ValidateAntiForgeryToken]
         public IActionResult Post([FromBody] Todo todo)
         {
             int id = TodoStore.Values.OrderByDescending(x => x.Id).FirstOrDefault().Id + 1;


### PR DESCRIPTION
Potential fix for [https://github.com/AzureAD/microsoft-identity-web/security/code-scanning/35](https://github.com/AzureAD/microsoft-identity-web/security/code-scanning/35)

Add ASP.NET Core anti-forgery validation to the POST action by decorating `Post` with `[ValidateAntiForgeryToken]`.  
This is the minimal, targeted fix for the flagged method and does not change business logic.

**File/region to change:**
- `tests/DevApps/B2CWebAppCallsWebApi/TodoListService/Controllers/TodoListController.cs`
- Around the `Post` action attributes (currently `[HttpPost]` and `[RequiredScope("write")]`).

**What is needed:**
- No new imports are required because `ValidateAntiForgeryTokenAttribute` is in `Microsoft.AspNetCore.Mvc`, which is already imported.
- Add one attribute line above `Post`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
