### PR TITLE
Run missing unit test projects in the ADO PR build

### DIFF
--- a/build/template-test-unit.yaml
+++ b/build/template-test-unit.yaml
@@ -7,7 +7,12 @@ steps:
   displayName: 'Run unit tests'
   inputs:
     testSelector: 'testAssemblies'
-    testAssemblyVer2: 'tests\Microsoft.Identity.Web.Test\bin\**\Microsoft.Identity.Web.Test.dll'
+    testAssemblyVer2: |
+        tests\Microsoft.Identity.Web.Test\bin\**\Microsoft.Identity.Web.Test.dll
+        tests\Microsoft.Identity.Web.UI.Test\bin\**\Microsoft.Identity.Web.UI.Test.dll
+        tests\E2E Tests\Sidecar.Tests\bin\**\Sidecar.Tests.dll
+        tests\E2E Tests\OidcIdPSignedAssertionProviderTests\bin\**\OidcIdpSignedAssertionProviderTests.dll
+        tests\E2E Tests\CustomSignedAssertionProviderTests\bin\**\CustomSignedAssertionProviderTests.dll
     searchFolder: '$(System.DefaultWorkingDirectory)'
     runInParallel: true
     codeCoverageEnabled: true

--- a/build/template-test-unit.yaml
+++ b/build/template-test-unit.yaml
@@ -14,6 +14,9 @@ steps:
         tests\E2E Tests\OidcIdPSignedAssertionProviderTests\bin\**\OidcIdpSignedAssertionProviderTests.dll
         tests\E2E Tests\CustomSignedAssertionProviderTests\bin\**\CustomSignedAssertionProviderTests.dll
     searchFolder: '$(System.DefaultWorkingDirectory)'
+    # Match the GitHub Action: Sidecar.Tests ships E2E/integration classes that
+    # need a live sidecar and are excluded there. Skip the same ones here.
+    testFiltercriteria: 'FullyQualifiedName!~SidecarEndpointsE2ETests&FullyQualifiedName!~SidecarIntegrationTests'
     runInParallel: true
     codeCoverageEnabled: true
     failOnMinTestsNotRun: true


### PR DESCRIPTION
The ADO PR build's unit-test step only globbed `Microsoft.Identity.Web.Test.dll`, so four unit test projects that the `dotnetcore.yml` GitHub Action already runs were never executed in the ADO run:

| Project | Tests |
|---|---|
| `Microsoft.Identity.Web.UI.Test` (net8/net9) | 16 |
| `Sidecar.Tests` (net10) | 126 |
| `OidcIdpSignedAssertionProviderTests` (net9) | 3 |
| `CustomSignedAssertionProviderTests` (net9) | 1 |

All four are part of `Microsoft.Identity.Web.sln` and are already built by the Build stage's full multi-TFM build, so this just adds them to the unit-test `testAssemblyVer2` glob. No new build steps.
