### PR TITLE
Post-release 4.13.0: changelog and public API shipped move

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- This needs to be greater than or equal to the validation baseline version. The conditional logic around TargetNetNext is there
     to avoid NU5104 for packing a release version library with prerelease deps. By adding preview to it, that warning is avoided.
     -->
-    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">4.12.2</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">4.13.1</MicrosoftIdentityWebVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MicrosoftIdentityWebVersion)</Version>
     <EnablePackageValidation>true</EnablePackageValidation>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+## 4.13.0
+
+### New features
+- Add `GetAuthorizationHeaderProvider2()` extension methods to the OWIN `ApiController` and `ControllerBase`, so OWIN apps can resolve `IAuthorizationHeaderProvider2` (metadata-returning header creation). See [#3928](https://github.com/AzureAD/microsoft-identity-web/pull/3928).
+
+### Bug fixes
+- Register `IAuthorizationHeaderProvider2` in the DI container (both the singleton and scoped registrations) as the same instance already registered for `IAuthorizationHeaderProvider`, so consumers can resolve the v2 interface. See [#3927](https://github.com/AzureAD/microsoft-identity-web/pull/3927).
+
+### Dependencies updates
+- Bump `Microsoft.Identity.Client` (MSAL.NET) and `Microsoft.Identity.Client.KeyAttestation` from 4.85.2 to 4.86.0. See [#3931](https://github.com/AzureAD/microsoft-identity-web/pull/3931).
+
 ## 4.12.2
 
 ### Bug fixes

--- a/src/Microsoft.Identity.Web.OWIN/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.OWIN/PublicAPI/PublicAPI.Shipped.txt
@@ -14,3 +14,5 @@ static Microsoft.Identity.Web.AppBuilderExtension.AddMicrosoftIdentityWebApp(thi
 static Microsoft.Identity.Web.ControllerBaseExtensions.GetAuthorizationHeaderProvider(this System.Web.Mvc.ControllerBase! _) -> Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider!
 static Microsoft.Identity.Web.ControllerBaseExtensions.GetDownstreamApi(this System.Web.Mvc.ControllerBase! _) -> Microsoft.Identity.Abstractions.IDownstreamApi!
 static Microsoft.Identity.Web.ControllerBaseExtensions.GetGraphServiceClient(this System.Web.Mvc.ControllerBase! _) -> Microsoft.Graph.GraphServiceClient!
+static Microsoft.Identity.Web.ApiControllerExtensions.GetAuthorizationHeaderProvider2(this System.Web.Http.ApiController! _) -> Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider2!
+static Microsoft.Identity.Web.ControllerBaseExtensions.GetAuthorizationHeaderProvider2(this System.Web.Mvc.ControllerBase! _) -> Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider2!

--- a/src/Microsoft.Identity.Web.OWIN/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.OWIN/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-static Microsoft.Identity.Web.ApiControllerExtensions.GetAuthorizationHeaderProvider2(this System.Web.Http.ApiController! _) -> Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider2!
-static Microsoft.Identity.Web.ControllerBaseExtensions.GetAuthorizationHeaderProvider2(this System.Web.Mvc.ControllerBase! _) -> Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider2!


### PR DESCRIPTION
Post-release housekeeping for **4.13.0**, following the #3920/#3921 pattern.

- Added the **4.13.0** changelog section: OWIN `GetAuthorizationHeaderProvider2()` (#3928), `IAuthorizationHeaderProvider2` DI registration (#3927), and the MSAL 4.86.0 bump (#3931).
- Moved the OWIN unshipped public API entries (`GetAuthorizationHeaderProvider2`) to shipped.
- Bumped the dev version 4.12.2 → 4.13.1.

No source changes. Build + PublicAPI analyzer pass locally.