### PR TITLE
Restore CustomizeHttpRequestMessage to run after the authorization header

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## 4.13.1
+
+### Bug fixes
+- `DownstreamApi`: restored `CustomizeHttpRequestMessage` to its documented timing — it runs after the authorization header (including the `Authorization` header) is set, just before the request is sent. [#3902](https://github.com/AzureAD/microsoft-identity-web/pull/3902) had moved it before header creation (to flow the finalized request for request-binding), which regressed callers that read the header in the callback — they saw `null`. See [#3943](https://github.com/AzureAD/microsoft-identity-web/pull/3943).
+
 ## 4.13.0
 
 ### New features

--- a/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
+++ b/src/Microsoft.Identity.Web.DownstreamApi/DownstreamApi.cs
@@ -734,9 +734,6 @@ namespace Microsoft.Identity.Web
                 httpRequestMessage.RequestUri = uriBuilder.Uri;
             }
 
-            // Opportunity to change the request message before request-binding authorization headers are created.
-            effectiveOptions.CustomizeHttpRequestMessage?.Invoke(httpRequestMessage);
-
             // Obtention of the authorization header (except when calling an anonymous endpoint)
             // which is done by not specifying any scopes or mTLS scheme.
             if (string.Equals(effectiveOptions.ProtocolScheme, Constants.MtlsProtocolScheme, StringComparison.OrdinalIgnoreCase))
@@ -840,6 +837,11 @@ namespace Microsoft.Identity.Web
             {
                 Logger.UnauthenticatedApiCall(_logger, null);
             }
+
+            // Opportunity to change the request message after the authorization header (including the Authorization
+            // header) has been set, just before the request is sent, per CustomizeHttpRequestMessage's documented
+            // contract. #3902 had moved this before header creation, which regressed callers that read the header.
+            effectiveOptions.CustomizeHttpRequestMessage?.Invoke(httpRequestMessage);
 
             return (authorizationHeaderInformation, credential);
         }

--- a/tests/Microsoft.Identity.Web.Test/DownstreamWebApiSupport/DownstreamApiTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/DownstreamWebApiSupport/DownstreamApiTests.cs
@@ -170,10 +170,6 @@ namespace Microsoft.Identity.Web.Tests
                 ExtraQueryParameters = new Dictionary<string, string>
                 {
                     { "fromOptions", "query-value" }
-                },
-                CustomizeHttpRequestMessage = request =>
-                {
-                    request.Headers.TryAddWithoutValidation("X-From-Customizer", "customized");
                 }
             };
 
@@ -185,9 +181,34 @@ namespace Microsoft.Identity.Web.Tests
             Assert.Same(content, authorizationHeaderProvider.CapturedRequest!.Content);
             Assert.Contains("fromOptions=query-value", authorizationHeaderProvider.CapturedRequest.RequestUri!.Query, StringComparison.Ordinal);
             Assert.True(authorizationHeaderProvider.CapturedRequest.Headers.Contains("X-From-Options"));
-            Assert.True(authorizationHeaderProvider.CapturedRequest.Headers.Contains("X-From-Customizer"));
             Assert.False(authorizationHeaderProvider.AuthorizationHeaderPresentWhenCaptured);
             Assert.True(httpRequestMessage.Headers.Contains("Authorization"));
+        }
+
+        [Fact]
+        // Regression test for CustomizeHttpRequestMessage timing: it must run after the authorization header is set
+        // (its documented contract), so a callback that reads the Authorization header observes it. #3902 had moved
+        // it before header creation, so such callbacks saw null.
+        public async Task UpdateRequestAsync_CustomizeHttpRequestMessage_SeesAuthorizationHeaderAsync()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost:44352");
+            var content = new StringContent("test content");
+            string? authorizationHeaderSeenByCustomizer = null;
+            var options = new DownstreamApiOptions
+            {
+                Scopes = ["api://a021aff4-57ad-453a-bae8-e4192e5860f3/.default"],
+                BaseUrl = "https://localhost:44352",
+                RelativePath = "/WeatherForecast",
+                RequestAppToken = true,
+                CustomizeHttpRequestMessage = request => authorizationHeaderSeenByCustomizer = request.Headers.Authorization?.Parameter,
+            };
+
+            // Act
+            await _input.UpdateRequestWithCertificateAsync(httpRequestMessage, content, options, appToken: true, new ClaimsPrincipal(), CancellationToken.None);
+
+            // Assert - the customizer runs after the header is set, so it observes the Authorization header.
+            Assert.Equal("ey", authorizationHeaderSeenByCustomizer);
         }
 
         [Theory]


### PR DESCRIPTION
## Problem

`CustomizeHttpRequestMessage` is documented to run **after** the message is formed — "including the Authorization header, and just before the message is sent." [#3902](https://github.com/AzureAD/microsoft-identity-web/pull/3902) moved it **before** authorization-header creation (to flow the finalized request for request-binding), which violated that contract and regressed callers that read the header in the callback — they saw a `null` `Authorization` header.

## Fix

Move **only** the `CustomizeHttpRequestMessage` invocation back to after the header is set. The request-flow plumbing that #3902/request-binding relies on (options material applied before header creation + `SetHttpRequestMessage`) is left untouched, so this is a minimal, targeted regression fix.

## Test

Adds `UpdateRequestAsync_CustomizeHttpRequestMessage_SeesAuthorizationHeaderAsync`, asserting the callback observes the `Authorization` header. Also updated the existing flow test, which had asserted the callback flowed to the provider (no longer true now that it runs after).

## Notes

- No new API; no dependency bump — safe to ship immediately.
- A follow-up PR adds explicit `OnBeforeAuthHeaderCreation` / `OnAfterAuthHeaderCreation` hooks (Abstractions AzureAD/microsoft-identity-abstractions-for-dotnet#262) so request-binding callers can shape the signed request without overloading `CustomizeHttpRequestMessage`.