### PR TITLE
Revert #3909: keep OWIN Saml/WsFederation on 5.7.0

### DIFF
--- a/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj
+++ b/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj
@@ -18,7 +18,7 @@
 
   <PropertyGroup>
     <IdentityModelV5Version Condition="'$(IdentityModelV5Version)' == '' and '$(TF_BUILD)' == 'true'">5.7.1</IdentityModelV5Version>
-    <IdentityModelV5Version Condition="'$(IdentityModelV5Version)' == ''">8.19.1</IdentityModelV5Version>
+    <IdentityModelV5Version Condition="'$(IdentityModelV5Version)' == ''">5.7.0</IdentityModelV5Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IdentityModelV5Version)' == '5.7.1'">


### PR DESCRIPTION
Reverts #3909.

That PR (Dependabot) bumped the default `IdentityModelV5Version` in `Microsoft.Identity.Web.OWIN.csproj` from **5.7.0 → 8.19.1**. This property deliberately pins `Microsoft.IdentityModel.Tokens.Saml` and `Microsoft.IdentityModel.Protocols.WsFederation` to the **5.x** line for the net472 OWIN package (an 8.x bump was attempted and explicitly reverted in #3900).

Problems with the bump:
- Only the default branch was changed; the CI path (`TF_BUILD=true`) still resolves **5.7.1**, so local builds (now 8.19.1) diverge from official builds.
- The `MSB3277` warning suppression is still keyed to `'5.7.1'`, so it no longer matches the default value.

Reverting to 5.7.0 until the intent/impact is clarified.