### PR TITLE
Post-release 4.13.1: bump dev version to 4.13.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- This needs to be greater than or equal to the validation baseline version. The conditional logic around TargetNetNext is there
     to avoid NU5104 for packing a release version library with prerelease deps. By adding preview to it, that warning is avoided.
     -->
-    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">4.13.1</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">4.13.2</MicrosoftIdentityWebVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MicrosoftIdentityWebVersion)</Version>
     <EnablePackageValidation>true</EnablePackageValidation>


### PR DESCRIPTION
Post-release housekeeping for **4.13.1** (shipped the `CustomizeHttpRequestMessage` regression fix, #3943).

- Bumps the dev version `4.13.1` → **`4.13.2`** for the next release.

No public API entries are pending a shipped move (the 4.13.1 fix added no API; 4.13.0''s API was moved in #3937), and the 4.13.1 changelog section is already present, so this PR is limited to the version bump.