### PR TITLE
Bump Microsoft.Identity.Abstractions from 12.4.0 to 12.5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,7 +82,7 @@
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.19.1</MicrosoftIdentityModelVersion>
     <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.86.0</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.86.0</MicrosoftIdentityClientKeyAttestationVersion>
-    <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.4.0</MicrosoftIdentityAbstractionsVersion>
+    <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.5.0</MicrosoftIdentityAbstractionsVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## 4.13.2
+
+### Dependencies updates
+- Bump `Microsoft.Identity.Abstractions` from 12.4.0 to 12.5.0 (adds the `OnBeforeAuthHeaderCreation` / `OnAfterAuthHeaderCreation` request hooks). See [#3947](https://github.com/AzureAD/microsoft-identity-web/pull/3947).
+
 ## 4.13.1
 
 ### Bug fixes

--- a/tests/E2E Tests/Sidecar.Tests/DownstreamApiOptionsMergeTests.cs
+++ b/tests/E2E Tests/Sidecar.Tests/DownstreamApiOptionsMergeTests.cs
@@ -688,6 +688,8 @@ public class DownstreamApiOptionsMergeTests
             // Properties intentionally not merged (they use CustomizeHttpRequestMessage pattern or are clone-only)
             "Clone",
             "CustomizeHttpRequestMessage",
+            "OnBeforeAuthHeaderCreation",
+            "OnAfterAuthHeaderCreation",
             "Serializer",
             "Deserializer",
             "ProtocolScheme",


### PR DESCRIPTION
Bumps `Microsoft.Identity.Abstractions` `12.4.0` → **`12.5.0`**.

12.5.0 adds `AuthorizationHeaderProviderOptions.OnBeforeAuthHeaderCreation` / `OnAfterAuthHeaderCreation`, which `DownstreamApi` consumes for request-binding (SignedHttpRequest `q`/`h`/`b`) support in #3942. This bump unblocks that PR''s CI (which currently builds against the local Abstractions source).