### PR TITLE
Fix token cache builder return XML documentation

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityAppCallingWebApiAuthenticationBuilder.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/MicrosoftIdentityAppCallingWebApiAuthenticationBuilder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="configureOptions"><see cref="MsalMemoryTokenCacheOptions"/> to configure.</param>
         /// <param name="memoryCacheOptions"><see cref="MemoryCacheOptions"/> to configure.</param>
-        /// <returns>the service collection.</returns>
+        /// <returns>The authentication builder to chain.</returns>
         public MicrosoftIdentityAppCallsWebApiAuthenticationBuilder AddInMemoryTokenCaches(
         Action<MsalMemoryTokenCacheOptions>? configureOptions = null,
         Action<MemoryCacheOptions>? memoryCacheOptions = null)
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Web
         /// <summary>
         /// Add distributed token caches.
         /// </summary>
-        /// <returns>the service collection.</returns>
+        /// <returns>The authentication builder to chain.</returns>
         public MicrosoftIdentityAppCallsWebApiAuthenticationBuilder AddDistributedTokenCaches()
         {
             Services.AddDistributedTokenCaches();


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Fix token cache builder return XML docs

## Description

Corrects the `<returns>` XML documentation for token cache builder methods.

The affected methods return `MicrosoftIdentityAppCallsWebApiAuthenticationBuilder`
for chaining, not the service collection.

This is a documentation-only change. No runtime behavior is changed.

Tests are not applicable because this only updates XML documentation.

No linked issue: this is a small documentation correction.
