### PR TITLE
Post-release 4.13.2: bump dev version to 4.13.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- This needs to be greater than or equal to the validation baseline version. The conditional logic around TargetNetNext is there
     to avoid NU5104 for packing a release version library with prerelease deps. By adding preview to it, that warning is avoided.
     -->
-    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">4.13.1</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">4.13.3</MicrosoftIdentityWebVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MicrosoftIdentityWebVersion)</Version>
     <EnablePackageValidation>true</EnablePackageValidation>


### PR DESCRIPTION
## Post-release steps for 4.13.2

4.13.2 has been released. This applies the standard post-release steps.

### Changes
- **Version:** bump the dev version `4.13.1` -> `4.13.3` in `Directory.Build.props` (next patch after the released 4.13.2, matching the #3937 pattern).

### Already in order (no change needed)
- **Changelog:** the `## 4.13.2` section is already present and complete — `DownstreamApi` OnBefore/OnAfter hooks (#3942), `Microsoft.Identity.Abstractions` 12.4.0 -> 12.5.0 (#3947), and the `IAuthorizationHeaderProvider2` declaration cleanup (#3942).
- **Public API (Unshipped -> Shipped):** no-op — every `PublicAPI.Unshipped.txt` is empty. 4.13.2 added no new IdWeb public API surface (the `OnBefore/OnAfterAuthHeaderCreation` hooks are `Microsoft.Identity.Abstractions` API, consumed by IdWeb).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>