### PR TITLE
Prevent Dependabot from proposing major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     ignore:
         # We do not want this leaving 5.5.0 since we don't use it and it could break customers
       - dependency-name: "Microsoft.IdentityModel.Protocols.WsFederation"
+        # Pinned to the 5.x line via IdentityModelV5Version; block major bumps (e.g. 5.x -> 8.x)
+      - dependency-name: "Microsoft.IdentityModel.Tokens.Saml"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependabot"
       - "dependencies"


### PR DESCRIPTION
## Summary

Adds an `ignore` rule to `.github/dependabot.yml` so Dependabot no longer proposes **major** version bumps for `Microsoft.IdentityModel.Tokens.Saml`.

## Motivation

Dependabot keeps opening PRs (e.g. [#3957](https://github.com/AzureAD/microsoft-identity-web/pull/3957)) that bump `Microsoft.IdentityModel.Tokens.Saml` from `5.7.1` to `8.19.2`. This is unwanted: `src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj` intentionally pins this dependency to the 5.x line via the `IdentityModelV5Version` property. Simply closing the PR causes Dependabot to reopen it on the next run.

## Change

Added an ignore entry scoped to major updates only, so 5.x patch/minor updates (including security fixes) still flow:

```yaml
    ignore:
        # We do not want this leaving 5.5.0 since we don't use it and it could break customers
      - dependency-name: "Microsoft.IdentityModel.Protocols.WsFederation"
        # Pinned to the 5.x line via IdentityModelV5Version; block major bumps (e.g. 5.x -> 8.x)
      - dependency-name: "Microsoft.IdentityModel.Tokens.Saml"
        update-types: ["version-update:semver-major"]
```

## Follow-up

After this merges, close PR [#3957](https://github.com/AzureAD/microsoft-identity-web/pull/3957) — it will stay closed.