### PR TITLE
Lots of CVE as transitive, just update the root cause not the leaf

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -139,15 +139,14 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <NetTenRuntimeVersion>10.0.0</NetTenRuntimeVersion>
-    <AspNetCoreTenRuntimeVersion>10.0.0</AspNetCoreTenRuntimeVersion>
-    <!--CVE: GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf, DataProtection requires 10.0.7 min instead of 10.0.6, CVE-2026-47302, CVE-2026-47304, CVE-2026-50525, CVE-2026-50648-->
-    <SystemSecurityCryptographyServicingVersion>10.0.10</SystemSecurityCryptographyServicingVersion>
+    <NetTenRuntimeVersion>10.0.10</NetTenRuntimeVersion>
+    <AspNetCoreTenRuntimeVersion>10.0.10</AspNetCoreTenRuntimeVersion>
+    <SystemSecurityCryptographyServicingVersion>$(NetTenRuntimeVersion)</SystemSecurityCryptographyServicingVersion>
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(AspNetCoreTenRuntimeVersion)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>$(AspNetCoreTenRuntimeVersion)</MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>
     <MicrosoftExtensionsCachingMemoryVersion>$(NetTenRuntimeVersion)</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsHostingVersion>$(NetTenRuntimeVersion)</MicrosoftExtensionsHostingVersion>
-    <MicrosoftAspNetCoreDataProtectionVersion>10.0.7</MicrosoftAspNetCoreDataProtectionVersion>
+    <MicrosoftAspNetCoreDataProtectionVersion>$(AspNetCoreTenRuntimeVersion)</MicrosoftAspNetCoreDataProtectionVersion>
     <SystemSecurityCryptographyPkcsVersion>$(SystemSecurityCryptographyServicingVersion)</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyXmlVersion>$(SystemSecurityCryptographyServicingVersion)</SystemSecurityCryptographyXmlVersion>
     <MicrosoftExtensionsLoggingVersion>$(NetTenRuntimeVersion)</MicrosoftExtensionsLoggingVersion>


### PR DESCRIPTION
# Fixes CVE shipped as transitive - Packages are still relying on dotnet and aspnetcore 10.0.0 and 10.0.7 that have CVE

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Fixes CVE as transitive caused but obsolete version of
* Dotnet Runtime
* Aspnetcore Runtime
* Specific Aspnetcore packages

Test: not applicable
Docs: not application (probably, unsure)
Issue: linked

Fixes #3971 (in this specific format)
