### PR TITLE
Expose MSAL's OnBackgroundTokenRefreshCompleted callback through Id.Web

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetCore/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetCore/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.get -> bool
 Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.set -> void
+Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.get -> System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult!, System.Threading.Tasks.Task!>?
+Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.set -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetFramework/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetFramework/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.get -> bool
 Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.set -> void
+Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.get -> System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult!, System.Threading.Tasks.Task!>?
+Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.set -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.ManagedIdentity.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.ManagedIdentity.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Web.TestOnly;
 using Microsoft.IdentityModel.LoggingExtensions;
 using Microsoft.IdentityModel.Tokens;
@@ -101,6 +103,7 @@ namespace Microsoft.Identity.Web
         {
             ManagedIdentityApplicationBuilder miBuilder = ManagedIdentityApplicationBuilder
                 .Create(managedIdentityId)
+                .WithExperimentalFeatures()
                 .WithLogging(
                     new IdentityLoggerAdapter(_logger),
                     enablePiiLogging: enablePiiLogging);
@@ -113,6 +116,15 @@ namespace Microsoft.Identity.Web
             if (_miHttpFactory != null)
             {
                 miBuilder.WithHttpClientFactory(_miHttpFactory.Create());
+            }
+
+            // Wire up the app-level background (proactive) token-refresh completion callback, if configured.
+            // Experimental features are enabled above, satisfying MSAL's experimental gate for this callback.
+            Func<ExecutionResult, Task>? onBackgroundTokenRefreshCompleted =
+                tokenAcquisitionExtensionOptionsMonitor?.CurrentValue?.OnBackgroundTokenRefreshCompleted;
+            if (onBackgroundTokenRefreshCompleted != null)
+            {
+                miBuilder.OnBackgroundTokenRefreshCompleted(onBackgroundTokenRefreshCompleted);
             }
 
             return miBuilder.Build();

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -1571,6 +1571,15 @@ namespace Microsoft.Identity.Web
                         isTokenBinding);
                 }
 
+                // Wire up the app-level background (proactive) token-refresh completion callback, if configured.
+                // The CCA builder already enabled experimental features above, satisfying MSAL's experimental gate.
+                Func<ExecutionResult, Task>? onBackgroundTokenRefreshCompleted =
+                    tokenAcquisitionExtensionOptionsMonitor?.CurrentValue?.OnBackgroundTokenRefreshCompleted;
+                if (onBackgroundTokenRefreshCompleted != null)
+                {
+                    builder.OnBackgroundTokenRefreshCompleted(onBackgroundTokenRefreshCompleted);
+                }
+
                 IConfidentialClientApplication app = builder.Build();
 
                 // Initialize the token cache provider so its serialization callbacks (including the

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisitionExtensionOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisitionExtensionOptions.cs
@@ -7,6 +7,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensibility;
 
 namespace Microsoft.Identity.Web
 {
@@ -16,6 +17,22 @@ namespace Microsoft.Identity.Web
     /// </summary>
     public partial class TokenAcquisitionExtensionOptions
     {
+        /// <summary>
+        /// Callback invoked when a fire-and-forget background (proactive) token refresh completes, for confidential
+        /// client and managed identity applications. Proactive refresh runs on a background thread after the caller
+        /// has already received a valid cached token, so its outcome (latency, failures) is otherwise unobservable;
+        /// this callback surfaces it, for example to emit telemetry.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="ExecutionResult"/> carries the refreshed token on success
+        /// (<see cref="ExecutionResult.Result"/>) or the exception on failure (<see cref="ExecutionResult.Exception"/>),
+        /// whose <see cref="MsalException.AuthenticationResultMetadata"/> exposes the failed attempt's HTTP duration.
+        /// The callback is invoked on a background thread; exceptions it throws are caught and logged by MSAL so they
+        /// cannot disrupt the refresh. Set once; the same delegate is applied to every confidential client and managed
+        /// identity application built by Microsoft.Identity.Web.
+        /// </remarks>
+        public Func<ExecutionResult, Task>? OnBackgroundTokenRefreshCompleted { get; set; }
+
         /// <summary>
         /// Event fired when a client credential flow request is being built.
         /// </summary>        

--- a/tests/Microsoft.Identity.Web.Test/ManagedIdentityCaeTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/ManagedIdentityCaeTests.cs
@@ -71,6 +71,38 @@ namespace Microsoft.Identity.Web.Tests.Certificateless
         }
 
         [Fact]
+        public async Task ManagedIdentity_WithBackgroundRefreshCallback_BuildsAndAcquiresToken()
+        {
+            TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest();
+            var factory = TokenAcquirerFactory.GetDefaultInstance();
+
+            var mockHttp = new MockHttpClientFactory();
+            mockHttp.AddMockHandler(
+                MockHttpCreator.CreateMsiTokenHandler(accessToken: MockToken));
+
+            factory.Services.AddSingleton<IManagedIdentityTestHttpClientFactory>(
+                _ => new TestManagedIdentityHttpFactory(mockHttp));
+
+            // Configure the background (proactive) token-refresh completion callback. The managed-identity
+            // build path must enable experimental features before applying it, otherwise MSAL throws when
+            // OnBackgroundTokenRefreshCompleted is set - this test guards that wiring.
+            factory.Services.Configure<TokenAcquisitionExtensionOptions>(
+                options => options.OnBackgroundTokenRefreshCompleted = _ => Task.CompletedTask);
+
+            var tokenAcquirer = factory.Build()
+                                       .GetRequiredService<ITokenAcquisition>();
+
+            var result = await tokenAcquirer.GetAuthenticationResultForAppAsync(
+                Scope,
+                tokenAcquisitionOptions: new TokenAcquisitionOptions
+                {
+                    ManagedIdentity = new ManagedIdentityOptions { UserAssignedClientId = UamiClientId },
+                });
+
+            Assert.Equal(MockToken, result.AccessToken);
+        }
+
+        [Fact]
         public async Task ManagedIdentity_WithClaims_HeaderBypassesCache()
         {
             // Arrange

--- a/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/TokenAcquisitionAuthorityTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Web.Test.Common.Mocks;
 using Microsoft.Identity.Web.Test.Common.TestHelpers;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
@@ -34,6 +35,7 @@ namespace Microsoft.Identity.Web.Test
         private IOptionsMonitor<ConfidentialClientApplicationOptions> _applicationOptionsMonitor;
         private IOptionsMonitor<MicrosoftIdentityOptions> _microsoftIdentityOptionsMonitor;
         private ICredentialsLoader _credentialsLoader;
+        private Func<ExecutionResult, Task>? _backgroundRefreshCallback;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         private void InitializeTokenAcquisitionObjects()
@@ -61,6 +63,8 @@ namespace Microsoft.Identity.Web.Test
             services.AddTransient(
                 provider => _applicationOptionsMonitor);
             services.Configure<MergedOptions>(options => { });
+            services.Configure<TokenAcquisitionExtensionOptions>(
+                options => options.OnBackgroundTokenRefreshCompleted = _backgroundRefreshCallback);
             services.AddHttpClient();
             services.AddInMemoryTokenCaches();
             services.AddTokenAcquisition();
@@ -180,6 +184,38 @@ namespace Microsoft.Identity.Web.Test
             {
                 Assert.Equal("https://IdentityDotNetSDKAutomation/", app.AppConfig.RedirectUri);
             }
+        }
+
+        [Fact]
+        public async Task GetOrBuildConfidentialClientApplication_WithBackgroundRefreshCallback_BuildsApp()
+        {
+            _microsoftIdentityOptionsMonitor = new TestOptionsMonitor<MicrosoftIdentityOptions>(new MicrosoftIdentityOptions
+            {
+                Authority = TC.AuthorityCommonTenant,
+                ClientId = TC.ConfidentialClientId,
+                CallbackPath = string.Empty,
+            });
+
+            _applicationOptionsMonitor = new TestOptionsMonitor<ConfidentialClientApplicationOptions>(new ConfidentialClientApplicationOptions
+            {
+                Instance = TC.AadInstance,
+                ClientSecret = TC.ClientSecret,
+            });
+
+            // Configure the background (proactive) token-refresh completion callback. The CCA build path
+            // must apply it via the experimental OnBackgroundTokenRefreshCompleted extension without MSAL throwing.
+            _backgroundRefreshCallback = _ => Task.CompletedTask;
+
+            BuildTheRequiredServices();
+            MergedOptions mergedOptions = _provider.GetRequiredService<IMergedOptionsStore>().Get(OpenIdConnectDefaults.AuthenticationScheme);
+            MergedOptions.UpdateMergedOptionsFromMicrosoftIdentityOptions(_microsoftIdentityOptionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme), mergedOptions);
+            MergedOptions.UpdateMergedOptionsFromConfidentialClientApplicationOptions(_applicationOptionsMonitor.Get(OpenIdConnectDefaults.AuthenticationScheme), mergedOptions);
+
+            InitializeTokenAcquisitionObjects();
+
+            IConfidentialClientApplication app = await _tokenAcquisition.GetOrBuildConfidentialClientApplicationAsync(mergedOptions, isTokenBinding: false);
+
+            Assert.NotNull(app);
         }
 
         [Fact]


### PR DESCRIPTION
## What

Exposes MSAL's `OnBackgroundTokenRefreshCompleted` proactive-refresh callback through Id.Web, for **both** confidential client and managed identity apps.

- New `TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted` (`Func<ExecutionResult, Task>?`). It's a code-configured delegate (not JSON-bindable), consistent with the other extensibility hooks on this type.
- Wired onto the CCA builder (`BuildConfidentialClientApplicationAsync`) and the managed identity builder (`BuildManagedIdentityApplication`). The MI builder now calls `WithExperimentalFeatures()` so MSAL's experimental gate for the callback is satisfied (the CCA builder already did).

## Why

Proactive (background) token refresh runs on a fire-and-forget thread after the caller already received a cached token, so its outcome — latency, failures, and token-acquisition metadata — is otherwise unobservable. This surfaces it for telemetry. Requested for SEAL 21 outbound telemetry.

## Metadata parity (MI == CCA)

No MSAL change needed. `ManagedIdentityAuthRequest : RequestBase` inherits foreground metadata population, and MI uses the same `SilentRequestHelper.ProcessFetchInBackground`, so the `ExecutionResult` carries metadata on both success and failure for MI exactly as for CCA.

## Tests

- `GetOrBuildConfidentialClientApplication_WithBackgroundRefreshCallback_BuildsApp` — CCA build path wires the callback without MSAL throwing.
- `ManagedIdentity_WithBackgroundRefreshCallback_BuildsAndAcquiresToken` — MI acquires a token with the callback configured; guards the `WithExperimentalFeatures()` requirement.
- 51/51 pass across affected classes; net8.0 + net472 build clean (PublicAPI analyzer green).

## Related

- MSAL callback (consumed here): AzureAD/microsoft-authentication-library-for-dotnet#6096 (shipped in MSAL 4.86.0)
- Work item: 3697080
