### PR TITLE
Update Microsoft.Identity.Abstractions to 12.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,7 +82,7 @@
     <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.20.0</MicrosoftIdentityModelVersion>
     <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.87.0</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.87.0</MicrosoftIdentityClientKeyAttestationVersion>
-    <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.5.0</MicrosoftIdentityAbstractionsVersion>
+    <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.6.0</MicrosoftIdentityAbstractionsVersion>
     <FxCopAnalyzersVersion>3.3.0</FxCopAnalyzersVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.6.0</AzureSecurityKeyVaultSecretsVersion>


### PR DESCRIPTION
Bumps `MicrosoftIdentityAbstractionsVersion` 12.5.0 → 12.6.0 in `Directory.Build.props` to pick up the newly released [Microsoft.Identity.Abstractions 12.6.0](https://github.com/AzureAD/microsoft-identity-abstractions-for-dotnet/releases/tag/12.6.0) (adds `TokenAcquisitionFailureDetails.ServiceErrorCodes`).