### PR TITLE
Tag MSI FIC E2E tests with MI_FIC_E2E category (exclude on non-IMDSv2 pools)

### DIFF
--- a/tests/E2E Tests/TokenAcquirerTests/ManagedIdentityFicTests.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/ManagedIdentityFicTests.cs
@@ -33,7 +33,10 @@ namespace TokenAcquirerTests
     ///           to the same certificate.
     ///
     /// These tests require a VM with an assigned managed identity and Credential Guard, so they run on
-    /// the MISEManagedIdentity pool (Category = MI_E2E), not on Microsoft-hosted agents.
+    /// the MISEManagedIdentity pool, not on Microsoft-hosted agents. They carry the MI_FIC_E2E trait
+    /// (in addition to MI_E2E) so pipelines that run this assembly on a non-IMDSv2 pool (for example
+    /// the Wilson pool used by the id4s-official / nightly builds) can exclude them with
+    /// Category!=MI_FIC_E2E while still running the regular (IMDSv1) managed-identity test.
     ///
     /// Note: the "bearer final token with a bound client assertion" variant (the exact shape of the
     /// MSAL bearer test) requires <c>UseBoundCredential</c> wiring for signed assertions, which is a
@@ -42,6 +45,7 @@ namespace TokenAcquirerTests
     /// </summary>
     [Collection(nameof(TokenAcquirerFactorySingletonProtection))]
     [Trait("Category", TestCategories.ManagedIdentity)]
+    [Trait("Category", TestCategories.ManagedIdentityFic)]
     public class ManagedIdentityFicTests
     {
         private const string TokenExchangeUrl = "api://AzureADTokenExchange";

--- a/tests/Microsoft.Identity.Web.Test.Common/TestCategories.cs
+++ b/tests/Microsoft.Identity.Web.Test.Common/TestCategories.cs
@@ -17,5 +17,14 @@ namespace Microsoft.Identity.Web.Test.Common
         /// agents that have no managed identity, so they are filtered out there.
         /// </summary>
         public const string ManagedIdentity = "MI_E2E";
+
+        /// <summary>
+        /// Tests that additionally require an IMDSv2 managed identity capable of mTLS
+        /// Proof-of-Possession + key attestation (the MSI FIC two-leg tests). These carry both
+        /// this trait and <see cref="ManagedIdentity"/>, and run only on the MISEManagedIdentity
+        /// pool. Pipelines that run the assembly on another pool (for example the Wilson pool used
+        /// by the id4s-official / nightly builds) must exclude them with <c>Category!=MI_FIC_E2E</c>.
+        /// </summary>
+        public const string ManagedIdentityFic = "MI_FIC_E2E";
     }
 }


### PR DESCRIPTION
## Symptom
The DevEx **`Id4s-Libraries-Nightly`** pipeline has failed since **2026-07-21** (build `20260721.1`) with 2 failing tests:
- `ManagedIdentityFicTests.MsiFic_TwoLeg_FinalMtlsPop_UserAssignedManagedIdentityAsync`
- `ManagedIdentityFicTests.MsiFic_TwoLeg_FinalMtlsPop_SystemAssignedManagedIdentityAsync`

## Root cause
These FIC two-leg tests require an **IMDSv2** managed identity (mTLS PoP + key attestation), available only on the **`MISEManagedIdentity`** pool. They already:
- run in IdWeb's **`ManagedIdentityE2E`** stage (`Category=MI_E2E`, `MISEManagedIdentity` pool), and
- are excluded from the hosted **`E2ETests`** stage (`Category!=MI_E2E`).

The break is in the **DevEx nightly** (`Id4sBuilds/.pipelines/ID4S-Libaries-OneBranch-Official.yml`, job `RunThirdPartyLibrariesTests`, pool `MwWilson1EsHostedPool`): its "Run Id web E2E tests" step runs the whole `TokenAcquirerTests` assembly **with no `--filter`** (every other step in that job uses one), so the FIC tests run on the IMDSv1 Wilson pool and fail.

Both the regular MI test and the FIC tests share `Category=MI_E2E`, so a `Category!=MI_E2E` filter can't separate them — it would also drop the regular test that legitimately passes on Wilson.

## Fix
Give the FIC tests a **dedicated `MI_FIC_E2E` trait** (in addition to `MI_E2E`) so a pipeline on a non-IMDSv2 pool can exclude **just** the FIC tests:
- `TestCategories.ManagedIdentityFic = "MI_FIC_E2E"`.
- `[Trait("Category", TestCategories.ManagedIdentityFic)]` on `ManagedIdentityFicTests`.

This changes nothing about where they run today:
- Hosted `E2ETests` (`Category!=MI_E2E`) → still excluded.
- `ManagedIdentityE2E` (`Category=MI_E2E`) → still runs them, unconditionally.

## Companion change (required)
The DevEx nightly step must add `--filter "Category!=MI_FIC_E2E"` so it skips only the FIC tests while keeping the regular MI test. One-line change in the **`Id4sBuilds`** repo (`/.pipelines/ID4S-Libaries-OneBranch-Official.yml`, "Run Id web E2E tests" step) — tracked separately.

## Verification (local, net8.0)
- `--filter "Category=MI_FIC_E2E"` selects **exactly the 2 FIC tests**.
- The regular MI test is not tagged `MI_FIC_E2E`, so `Category!=MI_FIC_E2E` keeps it running.
- Build clean (0 warnings, 0 errors).
