### PR TITLE
Post-4.14.0 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- This needs to be greater than or equal to the validation baseline version. The conditional logic around TargetNetNext is there
     to avoid NU5104 for packing a release version library with prerelease deps. By adding preview to it, that warning is avoided.
     -->
-    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">4.13.3</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebVersion Condition="'$(MicrosoftIdentityWebVersion)' == ''">4.14.1</MicrosoftIdentityWebVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MicrosoftIdentityWebVersion)</Version>
     <EnablePackageValidation>true</EnablePackageValidation>

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,20 @@
-## 4.13.3
+## 4.14.0
 
 ### New features
+- Add `MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience` to partition the app token cache by resource/audience. See [#3979](https://github.com/AzureAD/microsoft-identity-web/pull/3979).
+- Expose MSAL's background token-refresh callback through Id.Web via `TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted`. See [#3973](https://github.com/AzureAD/microsoft-identity-web/pull/3973).
+- Add `MicrosoftIdentityOptions.UseFastUnboundedCache`; stop short-circuiting the in-memory token cache serialization provider. See [#3970](https://github.com/AzureAD/microsoft-identity-web/pull/3970).
 - OIDC FIC (`Microsoft.Identity.Web.OidcFIC`) now supports mTLS token binding. `OidcIdpSignedAssertionProvider` reports `SupportsTokenBinding = true` and implements `GetSignedAssertionWithBindingAsync`, propagating the exact binding certificate returned by the inner token acquisition together with the OIDC assertion (as a `ClientSignedAssertion`) — no separate binding-certificate credential is configured. This enables two flows: a final `mtls_pop` token (`AuthorizationHeaderProviderOptions.ProtocolScheme = "MTLS_POP"`) and a final `Bearer` token whose client assertion is `jwt-pop` over mTLS (`UseBoundCredential = true` on the outer OIDC `CustomSignedAssertion` credential). It composes with an inner application using `SignedAssertionFromManagedIdentity` (three-leg MSI → OIDC → final flow). Tracked in [#3851](https://github.com/AzureAD/microsoft-identity-web/issues/3851).
 
 ### Bug fixes
 - Token binding: the confidential-client application (CCA) cache key now distinguishes a bound credential (`UseBoundCredential = true`) — for both signed-assertion and certificate credentials — from its otherwise-identical unbound equivalent, so the two configurations no longer collide on the same cached CCA. The certificate-error retry path for app tokens now invalidates the cache entry for the actual request mode (bearer vs mTLS PoP) instead of always the bearer key.
+- Forward the OpenTelemetry tags enricher onto the inner FIC client-assertion leg (AB#3696484). See [#3968](https://github.com/AzureAD/microsoft-identity-web/pull/3968).
+
+### Dependencies updates
+- Bump `Microsoft.Identity.Client` to 4.87.0. See [#3975](https://github.com/AzureAD/microsoft-identity-web/pull/3975).
+- Bump `Microsoft.Identity.Abstractions` to 12.6.0. See [#3976](https://github.com/AzureAD/microsoft-identity-web/pull/3976).
+- Bump `System.Security.Cryptography.Xml` / `System.Security.Cryptography.Pkcs` to patched versions (CVE-2026-47302, -47304, -50525, -50648). See [#3964](https://github.com/AzureAD/microsoft-identity-web/pull/3964).
+- Bump the notsecurity group with 1 update. See [#3965](https://github.com/AzureAD/microsoft-identity-web/pull/3965).
 
 ## 4.13.2
 

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetCore/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetCore/PublicAPI.Shipped.txt
@@ -127,6 +127,8 @@ Microsoft.Identity.Web.MicrosoftIdentityOptions.Instance.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.LegacyCacheCompatibilityEnabled.get -> bool
 Microsoft.Identity.Web.MicrosoftIdentityOptions.LegacyCacheCompatibilityEnabled.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.MicrosoftIdentityOptions() -> void
+Microsoft.Identity.Web.MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience.get -> bool
+Microsoft.Identity.Web.MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.ResetPasswordPath.get -> Microsoft.AspNetCore.Http.PathString?
 Microsoft.Identity.Web.MicrosoftIdentityOptions.ResetPasswordPath.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.ResetPasswordPolicyId.get -> string?
@@ -141,6 +143,8 @@ Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCertificates.get 
 Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCertificates.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCredentials.get -> System.Collections.Generic.IEnumerable<Microsoft.Identity.Abstractions.CredentialDescription!>?
 Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCredentials.set -> void
+Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.get -> bool
+Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.UserAssignedManagedIdentityClientId.get -> string?
 Microsoft.Identity.Web.MicrosoftIdentityOptions.UserAssignedManagedIdentityClientId.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.WithSpaAuthCode.get -> bool
@@ -180,6 +184,8 @@ Microsoft.Identity.Web.TokenAcquirerFactory.ServiceProvider.set -> void
 Microsoft.Identity.Web.TokenAcquirerFactory.Services.get -> Microsoft.Extensions.DependencyInjection.ServiceCollection!
 Microsoft.Identity.Web.TokenAcquirerFactory.TokenAcquirerFactory() -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions
+Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.get -> System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult!, System.Threading.Tasks.Task!>?
+Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeOnBehalfOfInitialized -> Microsoft.Identity.Web.BeforeOnBehalfOfInitialized?
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeOnBehalfOfInitializedAsync -> Microsoft.Identity.Web.BeforeOnBehalfOfInitializedAsync?
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForApp -> Microsoft.Identity.Web.BeforeTokenAcquisitionForApp?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetCore/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetCore/PublicAPI.Unshipped.txt
@@ -1,7 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience.get -> bool
-Microsoft.Identity.Web.MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience.set -> void
-Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.get -> bool
-Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.set -> void
-Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.get -> System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult!, System.Threading.Tasks.Task!>?
-Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.set -> void

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetFramework/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetFramework/PublicAPI.Shipped.txt
@@ -119,6 +119,8 @@ Microsoft.Identity.Web.MicrosoftIdentityOptions.Instance.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.LegacyCacheCompatibilityEnabled.get -> bool
 Microsoft.Identity.Web.MicrosoftIdentityOptions.LegacyCacheCompatibilityEnabled.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.MicrosoftIdentityOptions() -> void
+Microsoft.Identity.Web.MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience.get -> bool
+Microsoft.Identity.Web.MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.ResetPasswordPath.get -> string?
 Microsoft.Identity.Web.MicrosoftIdentityOptions.ResetPasswordPath.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.ResetPasswordPolicyId.get -> string?
@@ -133,6 +135,8 @@ Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCertificates.get 
 Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCertificates.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCredentials.get -> System.Collections.Generic.IEnumerable<Microsoft.Identity.Abstractions.CredentialDescription!>?
 Microsoft.Identity.Web.MicrosoftIdentityOptions.TokenDecryptionCredentials.set -> void
+Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.get -> bool
+Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.UserAssignedManagedIdentityClientId.get -> string?
 Microsoft.Identity.Web.MicrosoftIdentityOptions.UserAssignedManagedIdentityClientId.set -> void
 Microsoft.Identity.Web.MicrosoftIdentityOptions.WithSpaAuthCode.get -> bool
@@ -180,6 +184,8 @@ Microsoft.Identity.Web.TokenAcquirerFactory.ServiceProvider.set -> void
 Microsoft.Identity.Web.TokenAcquirerFactory.Services.get -> Microsoft.Extensions.DependencyInjection.ServiceCollection!
 Microsoft.Identity.Web.TokenAcquirerFactory.TokenAcquirerFactory() -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions
+Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.get -> System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult!, System.Threading.Tasks.Task!>?
+Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.set -> void
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeOnBehalfOfInitialized -> Microsoft.Identity.Web.BeforeOnBehalfOfInitialized?
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeOnBehalfOfInitializedAsync -> Microsoft.Identity.Web.BeforeOnBehalfOfInitializedAsync?
 Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBeforeTokenAcquisitionForApp -> Microsoft.Identity.Web.BeforeTokenAcquisitionForApp?

--- a/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetFramework/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/PublicAPI/NetFramework/PublicAPI.Unshipped.txt
@@ -1,7 +1,1 @@
 #nullable enable
-Microsoft.Identity.Web.MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience.get -> bool
-Microsoft.Identity.Web.MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience.set -> void
-Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.get -> bool
-Microsoft.Identity.Web.MicrosoftIdentityOptions.UseFastUnboundedCache.set -> void
-Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.get -> System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult!, System.Threading.Tasks.Task!>?
-Microsoft.Identity.Web.TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted.set -> void


### PR DESCRIPTION
Post-release housekeeping for **Microsoft.Identity.Web 4.14.0** (published to nuget.org + IDDP).

## Changes
- **changelog.md**: added the `4.14.0` section — new features, bug fixes, and dependency bumps.
- **PublicAPI**: promoted the 3 new `TokenAcquisition` public APIs from Unshipped to Shipped (NetCore + NetFramework):
  - `MicrosoftIdentityOptions.PartitionAppTokenCacheByAudience`
  - `MicrosoftIdentityOptions.UseFastUnboundedCache`
  - `TokenAcquisitionExtensionOptions.OnBackgroundTokenRefreshCompleted`
- **Directory.Build.props**: bumped default `MicrosoftIdentityWebVersion` 4.13.3 → 4.14.1.

## Release facts
- Build: `ID4S-Libraries-OneBranch-Official` #20260727.4 (retained)
- Release run: `ID4S-releases-20260727.2` (GA, public)
- All 16 packages verified: signed, 4.14.0, dependency versions consistent (MSAL 4.87.0, Wilson 8.20.0)
- Released commit: dc242d6
