### PR TITLE
Bump Wilson floor to 8.21.0 for 4.14.1 (fixes IDX00001 downstream)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,7 +79,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Common dependency versions">
-    <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.20.0</MicrosoftIdentityModelVersion>
+    <MicrosoftIdentityModelVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">8.21.0</MicrosoftIdentityModelVersion>
     <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">4.87.0</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityClientKeyAttestationVersion Condition="'$(MicrosoftIdentityClientKeyAttestationVersion)' == ''">4.87.0</MicrosoftIdentityClientKeyAttestationVersion>
     <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">12.6.0</MicrosoftIdentityAbstractionsVersion>


### PR DESCRIPTION
## Summary

`Microsoft.Identity.Web` 4.14.0 floored the `Microsoft.IdentityModel.*` (Wilson) suite at **8.20.0**, and its dependency closure now pulls in `Microsoft.IdentityModel.LoggingExtensions`. That package's `buildTransitive` targets enforce that **every** `Microsoft.IdentityModel.*` / `System.IdentityModel.*` package resolves to a single uniform version.

Downstream consumers (e.g. MISE) that pin a newer Wilson (**8.21.0**) hit `IDX00001` version-mismatch build errors, because the Wilson packages they don't explicitly pin float back down to IdWeb's 8.20.0 floor.

## Fix

Raise IdWeb's single `MicrosoftIdentityModelVersion` property from `8.20.0` → `8.21.0`. Because every Wilson reference in the repo derives from this one property, this lifts the entire Wilson floor uniformly, resolving the mismatch for all downstream consumers without requiring them to pin the full suite.

Ships as **4.14.1** (`MicrosoftIdentityWebVersion` is already 4.14.1 on `master`).

## Validation

- Full-solution `dotnet restore` — no `NU1605` / no conflicts
- `dotnet build -c Release` across net462 / net472 / net6.0 / net8.0 / net9.0 / net10.0 — **0 warnings, 0 errors**
- `Microsoft.Identity.Web.Test` — all pass (44/44 net462, 44/44 net472, 1069 net8.0, 1078 net9.0, 1097 net10.0)
- `Microsoft.Identity.Web.UI.Test` — 46/46 (net8.0), 46/46 (net9.0)

Wilson 8.20.0 → 8.21.0 introduces no transitive-floor changes (identical `System.Text.Json` / `Bcl.Cryptography` / `Cng` floors), so there is no `NU1605` risk from the bump.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: f97b0227-61aa-4f4c-aee8-291a46b45d63
