### PR TITLE
[do not merge] deliberate break to test cg feature on all SDKs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -122,7 +122,8 @@
     <NetNineRuntimeVersion>9.0.0</NetNineRuntimeVersion>
     <AspNetCoreNineRuntimeVersion>9.0.0</AspNetCoreNineRuntimeVersion>
     <!--CVE: GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf, CVE-2026-47302, CVE-2026-47304, CVE-2026-50525, CVE-2026-50648-->
-    <SystemSecurityCryptographyServicingVersion>9.0.18</SystemSecurityCryptographyServicingVersion>
+    <!-- [DO NOT MERGE] Deliberate break to validate the cross-repo compat gate. Bumps the net9 crypto floor to the next real version (10.0.10) — IdWeb still builds, but downstream MISE (pinned 9.0.18 on net9) hits an NU1605 downgrade. Original: 9.0.18 -->
+    <SystemSecurityCryptographyServicingVersion>10.0.10</SystemSecurityCryptographyServicingVersion>
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>$(AspNetCoreNineRuntimeVersion)</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>$(AspNetCoreNineRuntimeVersion)</MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>
     <MicrosoftExtensionsCachingMemoryVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsCachingMemoryVersion>
@@ -133,7 +134,8 @@
     <MicrosoftExtensionsLoggingVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsConfigurationBinderVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsConfigurationBinderVersion>
-    <SystemFormatsAsn1Version>$(NetNineRuntimeVersion)</SystemFormatsAsn1Version>
+    <!-- [DO NOT MERGE] bumped in lockstep with the crypto floor above so System.Security.Cryptography.Pkcs 10.0.10 can resolve its Asn1 dependency inside IdWeb. Original: $(NetNineRuntimeVersion) -->
+    <SystemFormatsAsn1Version>10.0.10</SystemFormatsAsn1Version>
     <SystemTextJsonVersion>$(NetNineRuntimeVersion)</SystemTextJsonVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>$(NetNineRuntimeVersion)</MicrosoftExtensionsDependencyInjectionVersion>
   </PropertyGroup>


### PR DESCRIPTION
**⚠️ DO NOT MERGE — test artifact only.**

Bumps the **net9** `System.Security.Cryptography` servicing floor in `Directory.Build.props` from `9.0.18` to the **next real published version `10.0.10`** (crypto family + `System.Formats.Asn1` bumped in lockstep so IdWeb stays internally consistent).

**Why this shape:** we want the authentic downstream scenario — **IdWeb builds green, but MISE breaks** — not a self-inflicted IdWeb failure.

**Validated locally:** `dotnet restore Microsoft.Identity.Web.sln` → exit 0; net9 consumers resolve `Xml/Pkcs/Asn1 10.0.10` cleanly (no NU1701/NU1903). So IdWeb ships fine.

**Expected downstream break:** MISE pins `System.Security.Cryptography.Xml 9.0.18` on net9, so consuming this IdWeb build triggers an **NU1605 downgrade** at MISE restore — exactly the class of cross-repo break the gate exists to block.

**Gate under test:** DevEx pipeline def 3112 (`MISE-Compat-Fast.yml`, Id4sBuilds PR #25883), run `20260729.6` (idweb resource → this branch). Expected: chain packs green through IdWeb, then **⛔ GATE: restore MISE goes RED (NU1605)**.

Closed once the gate result is confirmed.