### PR TITLE
Use System.Security.Cryptography.Xml 8.0.4 for net8.0 (in-major CVE fix)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -163,9 +163,9 @@
     <MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>8.0.0</MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>
     <MicrosoftExtensionsCachingMemoryVersion>8.0.1</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftAspNetCoreDataProtectionVersion>8.0.1</MicrosoftAspNetCoreDataProtectionVersion>
-    <!--CVE-2026-47302, CVE-2026-47304, CVE-2026-50525, CVE-2026-50648: no fixed 8.0.x is published on nuget.org (advisory patch 8.0.29 is unreleased), so use the published, patched 9.0.18 servicing line which also targets net8.0. Pkcs must match to avoid an NU1605 downgrade.-->
-    <SystemSecurityCryptographyPkcsVersion>9.0.18</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyXmlVersion>9.0.18</SystemSecurityCryptographyXmlVersion>
+    <!--CVE-2026-47302, CVE-2026-47304, CVE-2026-50525, CVE-2026-50648: fixed in the 8.0.x servicing line by System.Security.Cryptography.Xml 8.0.4 (published 2026-07-14; affected <= 8.0.3). Xml 8.0.4 depends on Pkcs 8.0.1, so keep Pkcs on 8.0.1. This keeps net8.0 on its own servicing line instead of pulling the net9-era 9.x crypto assemblies onto net8.0 targets.-->
+    <SystemSecurityCryptographyPkcsVersion>8.0.1</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyXmlVersion>8.0.4</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>8.0.0</SystemTextEncodingsWebVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## What
Move the **net8.0** `System.Security.Cryptography.Xml` / `.Pkcs` pins from `9.0.18` back to the 8.0.x servicing line: **Xml `8.0.4`**, **Pkcs `8.0.1`**.

## Why
In #3964 the net8.0 crypto pin was raised to `9.0.18` as a **stopgap** — at that time no fixed `8.0.x` was published (the comment noted the advisory patch was unreleased). `System.Security.Cryptography.Xml` **8.0.4** was published **2026-07-14** and remediates the same advisories on the 8.0.x line:

| CVE | Affected | Fixed (net8) |
|-----|----------|--------------|
| CVE-2026-47302, CVE-2026-47304, CVE-2026-50525, CVE-2026-50648 | `<= 8.0.3` | **8.0.4** |

Keeping `9.0.18` on net8.0 ships net9-era crypto assemblies on net8 targets and, via `TokenCache`, forces a `>= 9.0.18` floor onto downstream **net8** consumers (this caused a cascading NU1605 / IDX00001 version-alignment migration in MISE). `8.0.4` fixes the CVEs while keeping net8.0 on its own servicing line. `Pkcs` is set to `8.0.1` because that is exactly what `Xml 8.0.4` depends on (no NU1605), and Pkcs 8.0.x is not in the advisory scope.

net9.0 (`9.0.18`) and net10.0 (`10.0.10`) are unchanged.

## Validation
`Microsoft.Identity.Web` restores clean on `net8.0` (no NU1605/NU1608); resolves `System.Security.Cryptography.Xml 8.0.4` / `System.Security.Cryptography.Pkcs 8.0.1`.
