### PR TITLE
Fix net8.0 crypto floor: use patched System.Security.Cryptography.Xml 8.0.4 (not 9.0.18)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -163,9 +163,9 @@
     <MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>8.0.0</MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>
     <MicrosoftExtensionsCachingMemoryVersion>8.0.1</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftAspNetCoreDataProtectionVersion>8.0.1</MicrosoftAspNetCoreDataProtectionVersion>
-    <!--CVE-2026-47302, CVE-2026-47304, CVE-2026-50525, CVE-2026-50648: no fixed 8.0.x is published on nuget.org (advisory patch 8.0.29 is unreleased), so use the published, patched 9.0.18 servicing line which also targets net8.0. Pkcs must match to avoid an NU1605 downgrade.-->
-    <SystemSecurityCryptographyPkcsVersion>9.0.18</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyXmlVersion>9.0.18</SystemSecurityCryptographyXmlVersion>
+    <!--CVE-2026-47302, CVE-2026-47304, CVE-2026-50525, CVE-2026-50648: patched System.Security.Cryptography.Xml for net8.0 is 8.0.4 (advisory affects <=8.0.3; 8.0.29 is the .NET runtime patch, not this OOB package). Xml 8.0.4 depends on Pkcs 8.0.1, so pin Pkcs 8.0.1 to satisfy it without an NU1605 downgrade.-->
+    <SystemSecurityCryptographyPkcsVersion>8.0.1</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyXmlVersion>8.0.4</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>8.0.0</SystemTextEncodingsWebVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Addresses @pmaytak's review: the net8.0 crypto floor should use the **patched 8.0.x** version, not a jump to `9.0.18`.

### Problem
The net8.0 block set `System.Security.Cryptography.Xml`/`Pkcs` to `9.0.18`, with a comment assuming no patched 8.0.x existed (*"8.0.29 is unreleased"*). That conflated the **.NET runtime** patch (`8.0.29`, for `Microsoft.NetCore.App.Runtime.*`) with the **OOB package**. Per [Microsoft Security Advisory CVE-2026-47302](https://github.com/dotnet/announcements/issues/410), `System.Security.Cryptography.Xml` is affected `>= 8.0.0, <= 8.0.3` and **patched in `8.0.4`**.

### Fix (net8.0 block only)
| package | before | after |
|---|---|---|
| System.Security.Cryptography.Xml | 9.0.18 | **8.0.4** (patched) |
| System.Security.Cryptography.Pkcs | 9.0.18 | **8.0.1** |

`Xml 8.0.4` declares a dependency on `Pkcs 8.0.1` (the highest published 8.0.x Pkcs), so pinning Pkcs `8.0.1` satisfies it with **no NU1605**. **net9.0 (9.0.18) and net10.0 (10.0.10) are unchanged** — those are the correct patched versions for their lines.

### Validation
`dotnet restore Microsoft.Identity.Web.sln` → exit 0; net8.0 consumers resolve **Xml 8.0.4 / Pkcs 8.0.1**. Also running the cross-repo compat gate (builds the ID4S family + MISE) against this branch.