### PR TITLE
Fix #3895: BlazorAuthenticationChallengeHandler sends a local returnUrl instead of the absolute NavigationManager.Uri

### DIFF
--- a/src/Microsoft.Identity.Web/Blazor/BlazorAuthenticationChallengeHandler.cs
+++ b/src/Microsoft.Identity.Web/Blazor/BlazorAuthenticationChallengeHandler.cs
@@ -72,7 +72,22 @@ public class BlazorAuthenticationChallengeHandler(
     /// </summary>
     public void ChallengeUser(ClaimsPrincipal user, string[]? scopes = null, string? claims = null)
     {
-        var currentUri = navigation.Uri;
+        // NavigationManager.Uri is always absolute, but the /login endpoint mapped by
+        // MapLoginAndLogout validates returnUrl with RedirectUriHelper.IsLocalUrl, which
+        // rejects absolute URLs and falls back to "/" — so passing the absolute URI loses
+        // the user's page after the consent round-trip. Send the app-local PathAndQuery
+        // instead (preserves any path base, drops the fragment — matching the MVC
+        // AccountController.Challenge coercion of same-origin absolute URLs).
+        //
+        // Defensive re-check: PathAndQuery can still begin with "//" or "/\" for a request
+        // path like "//evil.example/x", which a downstream Location header would treat as
+        // protocol-relative. Re-run IsLocalUrl on the coerced value and fall back to "/",
+        // mirroring the endpoint's own validation.
+        var returnUrl = new Uri(navigation.Uri).PathAndQuery;
+        if (!RedirectUriHelper.IsLocalUrl(returnUrl))
+        {
+            returnUrl = "/";
+        }
 
         // Build scopes string (add OIDC scopes)
         var allScopes = (scopes ?? [])
@@ -87,7 +102,7 @@ public class BlazorAuthenticationChallengeHandler(
         var domainHint = Uri.EscapeDataString(GetDomainHint(user));
 
         // Build the challenge URL
-        var challengeUrl = $"/authentication/login?returnUrl={Uri.EscapeDataString(currentUri)}" +
+        var challengeUrl = $"/authentication/login?returnUrl={Uri.EscapeDataString(returnUrl)}" +
                           $"&scope={scopeString}" +
                           $"&loginHint={loginHint}" +
                           $"&domainHint={domainHint}";

--- a/tests/Microsoft.Identity.Web.Test/Blazor/BlazorAuthenticationChallengeHandlerTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/Blazor/BlazorAuthenticationChallengeHandlerTests.cs
@@ -17,6 +17,29 @@ namespace Microsoft.Identity.Web.Test.Blazor
 {
     public class BlazorAuthenticationChallengeHandlerTests
     {
+        /// <summary>
+        /// Concrete <see cref="NavigationManager"/> for unit tests. <c>Uri</c> is driven by
+        /// <see cref="NavigationManager.Initialize(string, string)"/> and navigation is captured
+        /// by overriding <see cref="NavigationManager.NavigateToCore(string, NavigationOptions)"/> —
+        /// the same pattern the ASP.NET Core repo uses to test NavigationManager consumers.
+        /// </summary>
+        private sealed class TestNavigationManager : NavigationManager
+        {
+            public string? LastNavigatedTo { get; private set; }
+            public bool LastForceLoad { get; private set; }
+
+            public TestNavigationManager(string baseUri, string uri)
+            {
+                Initialize(baseUri, uri);
+            }
+
+            protected override void NavigateToCore(string uri, NavigationOptions options)
+            {
+                LastNavigatedTo = uri;
+                LastForceLoad = options.ForceLoad;
+            }
+        }
+
         private readonly NavigationManager _mockNavigationManager;
         private readonly AuthenticationStateProvider _mockAuthStateProvider;
         private readonly IConfiguration _configuration;
@@ -106,7 +129,7 @@ namespace Microsoft.Identity.Web.Test.Blazor
             Assert.False(isAuthenticated);
         }
 
-        [Fact(Skip = "NavigationManager.Uri and NavigationManager.NavigateTo cannot be mocked. Integration tests verify this behavior.")]
+        [Fact]
         public async Task HandleExceptionAsync_DetectsMicrosoftIdentityWebChallengeUserException()
         {
             // Arrange
@@ -119,8 +142,12 @@ namespace Microsoft.Identity.Web.Test.Blazor
             var authState = new AuthenticationState(user);
             _mockAuthStateProvider.GetAuthenticationStateAsync().Returns(authState);
 
+            var navigation = new TestNavigationManager(
+                "https://app.contoso.com/",
+                "https://app.contoso.com/weather?day=2");
+
             var handler = new BlazorAuthenticationChallengeHandler(
-                _mockNavigationManager,
+                navigation,
                 _mockAuthStateProvider,
                 _configuration);
 
@@ -128,14 +155,18 @@ namespace Microsoft.Identity.Web.Test.Blazor
             var msalException = new MsalUiRequiredException("error_code", "error_message");
             var challengeException = new MicrosoftIdentityWebChallengeUserException(msalException, scopes);
 
-            // Act & Assert
-            // Note: Since NavigationManager.NavigateTo is not virtual, actual navigation behavior
-            // is tested in integration tests. Here we verify exception detection logic.
+            // Act
             var handled = await handler.HandleExceptionAsync(challengeException);
+
+            // Assert
             Assert.True(handled);
+            Assert.NotNull(navigation.LastNavigatedTo);
+            Assert.True(navigation.LastForceLoad);
+            Assert.Contains("scope=", navigation.LastNavigatedTo, StringComparison.Ordinal);
+            Assert.Contains(Uri.EscapeDataString("user.read"), navigation.LastNavigatedTo, StringComparison.Ordinal);
         }
 
-        [Fact(Skip = "NavigationManager.Uri and NavigationManager.NavigateTo cannot be mocked. Integration tests verify this behavior.")]
+        [Fact]
         public async Task HandleExceptionAsync_DetectsMicrosoftIdentityWebChallengeUserExceptionAsInnerException()
         {
             // Arrange
@@ -148,8 +179,12 @@ namespace Microsoft.Identity.Web.Test.Blazor
             var authState = new AuthenticationState(user);
             _mockAuthStateProvider.GetAuthenticationStateAsync().Returns(authState);
 
+            var navigation = new TestNavigationManager(
+                "https://app.contoso.com/",
+                "https://app.contoso.com/weather?day=2");
+
             var handler = new BlazorAuthenticationChallengeHandler(
-                _mockNavigationManager,
+                navigation,
                 _mockAuthStateProvider,
                 _configuration);
 
@@ -158,9 +193,96 @@ namespace Microsoft.Identity.Web.Test.Blazor
             var challengeException = new MicrosoftIdentityWebChallengeUserException(msalException, scopes);
             var outerException = new InvalidOperationException("Outer exception", challengeException);
 
-            // Act & Assert
+            // Act
             var handled = await handler.HandleExceptionAsync(outerException);
+
+            // Assert
             Assert.True(handled);
+            Assert.NotNull(navigation.LastNavigatedTo);
+        }
+
+        // -----------------------------------------------------------------------------
+        // returnUrl shape (issue #3895): the /login endpoint mapped by MapLoginAndLogout
+        // validates returnUrl with RedirectUriHelper.IsLocalUrl, which rejects absolute
+        // URLs and falls back to "/". ChallengeUser must therefore send the app-local
+        // PathAndQuery of the current page — not NavigationManager.Uri verbatim — or the
+        // user loses their page after the consent round-trip.
+        // -----------------------------------------------------------------------------
+
+        [Fact]
+        public void ChallengeUser_SendsLocalReturnUrl_PreservingPathAndQuery()
+        {
+            // Arrange
+            var navigation = new TestNavigationManager(
+                "https://app.contoso.com/",
+                "https://app.contoso.com/admin/reports?tab=2");
+
+            var handler = new BlazorAuthenticationChallengeHandler(
+                navigation,
+                _mockAuthStateProvider,
+                _configuration);
+
+            // Act
+            handler.ChallengeUser(new ClaimsPrincipal(new CaseSensitiveClaimsIdentity()), new[] { "user.read" });
+
+            // Assert
+            Assert.NotNull(navigation.LastNavigatedTo);
+            Assert.StartsWith(
+                $"/authentication/login?returnUrl={Uri.EscapeDataString("/admin/reports?tab=2")}",
+                navigation.LastNavigatedTo,
+                StringComparison.Ordinal);
+            Assert.True(navigation.LastForceLoad);
+        }
+
+        [Fact]
+        public void ChallengeUser_LocalReturnUrl_PreservesPathBase()
+        {
+            // Arrange — app hosted under a path base ("/app"). PathAndQuery keeps it;
+            // NavigationManager.ToBaseRelativePath would lose it.
+            var navigation = new TestNavigationManager(
+                "https://host.contoso.com/app/",
+                "https://host.contoso.com/app/page?x=1");
+
+            var handler = new BlazorAuthenticationChallengeHandler(
+                navigation,
+                _mockAuthStateProvider,
+                _configuration);
+
+            // Act
+            handler.ChallengeUser(new ClaimsPrincipal(new CaseSensitiveClaimsIdentity()));
+
+            // Assert
+            Assert.NotNull(navigation.LastNavigatedTo);
+            Assert.StartsWith(
+                $"/authentication/login?returnUrl={Uri.EscapeDataString("/app/page?x=1")}",
+                navigation.LastNavigatedTo,
+                StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ChallengeUser_ProtocolRelativePathShape_CoercedToRoot()
+        {
+            // Arrange — PathAndQuery of "https://host//evil.example/x" is "//evil.example/x":
+            // a protocol-relative shape that a downstream Location header would follow off-origin.
+            // The handler must re-check IsLocalUrl on the coerced value and fall back to "/".
+            var navigation = new TestNavigationManager(
+                "https://host.contoso.com/",
+                "https://host.contoso.com//evil.example/x");
+
+            var handler = new BlazorAuthenticationChallengeHandler(
+                navigation,
+                _mockAuthStateProvider,
+                _configuration);
+
+            // Act
+            handler.ChallengeUser(new ClaimsPrincipal(new CaseSensitiveClaimsIdentity()));
+
+            // Assert
+            Assert.NotNull(navigation.LastNavigatedTo);
+            Assert.StartsWith(
+                $"/authentication/login?returnUrl={Uri.EscapeDataString("/")}",
+                navigation.LastNavigatedTo,
+                StringComparison.Ordinal);
         }
 
         [Fact]
@@ -185,9 +307,10 @@ namespace Microsoft.Identity.Web.Test.Blazor
             Assert.False(handled);
         }
 
-        // Note: Additional tests for ChallengeUser, GetLoginHint, and GetDomainHint
-        // behavior are covered in integration tests since NavigationManager.NavigateTo()
-        // and NavigationManager.Uri are not virtual and cannot be mocked.
-        // These tests validate URL construction and parameter passing through real Blazor components.
+        // Note: NavigationManager.Uri and NavigateTo ARE unit-testable via a concrete
+        // subclass that calls Initialize() and overrides NavigateToCore (see
+        // TestNavigationManager above) — the same pattern the ASP.NET Core repo uses.
+        // End-to-end URL construction through real Blazor components remains covered
+        // by integration tests.
     }
 }


### PR DESCRIPTION
Fixes #3895.

## Problem

`BlazorAuthenticationChallengeHandler.ChallengeUser` passes `NavigationManager.Uri` — always an absolute URL — as the `returnUrl` query parameter of the `/authentication/login` endpoint mapped by `MapLoginAndLogout()`. That endpoint validates `returnUrl` with `RedirectUriHelper.IsLocalUrl`, which (correctly) rejects absolute URLs and falls back to `/`. Net effect: every incremental-consent or Conditional Access round-trip in Blazor Server drops the user on the app root instead of returning them to the page they were on.

The two halves of the flow ship in the same assembly and are documented as a pair, but they disagree about the shape of `returnUrl`.

## Why fix the sender, not the validator

The strict local-only validation in `GetAuthProperties` is a deliberate hardening: its regression tests pin that absolute URLs must be coerced to `/` (the earlier behaviour of coercing absolutes via `PathAndQuery` at the endpoint was removed as part of the open-redirect hardening). Relaxing the validator would reopen that surface. The sender, by contrast, can trivially produce the local form — it *is* the current page's URI.

This also mirrors what the MVC path already does: `AccountController.Challenge` accepts same-origin absolute URLs by coercing them to `PathAndQuery` (with an `IsLocalUrl` re-check on the coerced value), explicitly because the consent handler passes `NavigationManager.Uri`. This PR gives the Blazor Minimal-API path the equivalent treatment — at the sending end, so the endpoint's validation stays strict.

## Change

`ChallengeUser` now sends `new Uri(navigation.Uri).PathAndQuery`:

- **Preserves the app path base** (`https://host/app/page?x=1` → `/app/page?x=1`) — which is why it uses `PathAndQuery` rather than `NavigationManager.ToBaseRelativePath`.
- **Drops the fragment**, matching the MVC coercion's documented behaviour.
- **Defensive re-check**: `PathAndQuery` of a same-origin URL can still begin with `//` or `/\` (e.g. a request path of `//evil.example/x`), which a downstream `Location` header would treat as protocol-relative. The coerced value is re-validated with `RedirectUriHelper.IsLocalUrl` and falls back to `/` — the same re-check `AccountController.Challenge` performs.

No public API change; no change to `LoginLogoutEndpointRouteBuilderExtensions`.

## Tests

`BlazorAuthenticationChallengeHandlerTests` gains a concrete `TestNavigationManager` (a subclass calling `Initialize()` and overriding `NavigateToCore` — the pattern the ASP.NET Core repo uses), which makes `NavigationManager.Uri`/`NavigateTo` unit-testable. With it:

- **New**: `ChallengeUser_SendsLocalReturnUrl_PreservingPathAndQuery` — returnUrl is the escaped local `/admin/reports?tab=2`, `forceLoad: true`.
- **New**: `ChallengeUser_LocalReturnUrl_PreservesPathBase` — an app under `/app/` keeps its base.
- **New**: `ChallengeUser_ProtocolRelativePathShape_CoercedToRoot` — a `//evil.example/x` path shape coerces to `/`.
- **Un-skipped**: both `HandleExceptionAsync_Detects…` tests previously skipped as "NavigationManager cannot be mocked" now run, asserting navigation occurred with `forceLoad` and the requested scope present.

The existing `GetAuthProperties_CoercesNonLocalReturnUrls` theory is untouched and still pins the endpoint's strict validation — the flow now composes: handler sends local, endpoint accepts local. All 37 tests in the Blazor test namespace pass on net10.0.

## Repro (before) / behaviour (after)

Blazor Server app without `Microsoft.Identity.Web.UI`, `MapLoginAndLogout()` mapped, incremental consent triggered from `/admin/reports?tab=2`:

- **Before**: `returnUrl=https%3A%2F%2Fapp…%2Fadmin%2Freports%3Ftab%3D2` → `IsLocalUrl` false → `RedirectUri = "/"` → user lands on the app root after consent.
- **After**: `returnUrl=%2Fadmin%2Freports%3Ftab%3D2` → `IsLocalUrl` true → user returns to `/admin/reports?tab=2`.
