### PR TITLE
Mark projects as AOT compatible

### DIFF
--- a/src/Microsoft.Identity.Web.AgentIdentities/Microsoft.Identity.Web.AgentIdentities.csproj
+++ b/src/Microsoft.Identity.Web.AgentIdentities/Microsoft.Identity.Web.AgentIdentities.csproj
@@ -9,6 +9,10 @@
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\..\README.md">
       <Pack>True</Pack>

--- a/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
+++ b/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
@@ -11,6 +11,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\..\README.md">
       <Pack>True</Pack>

--- a/src/Microsoft.Identity.Web.OidcFIC/Microsoft.Identity.Web.OidcFIC.csproj
+++ b/src/Microsoft.Identity.Web.OidcFIC/Microsoft.Identity.Web.OidcFIC.csproj
@@ -11,6 +11,15 @@
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <IsAotCompatible>true</IsAotCompatible>
+    <!-- The configuration binding source generator emits these diagnostics for the certificate
+         object graph on MicrosoftIdentityApplicationOptions (X509Certificate2, PublicKey, PrivateKey,
+         etc.), which is never populated from configuration. Suppressed to match the AOT test app. -->
+    <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101;SYSLIB0026;SYSLIB0027;SYSLIB0028</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\..\README.md">
       <Pack>True</Pack>

--- a/tests/Microsoft.Identity.Web.AotCompatibility.TestApp/Microsoft.Identity.Web.AotCompatibility.TestApp.csproj
+++ b/tests/Microsoft.Identity.Web.AotCompatibility.TestApp/Microsoft.Identity.Web.AotCompatibility.TestApp.csproj
@@ -30,6 +30,9 @@
     <TrimmerRootAssembly Include="Microsoft.Identity.Web.GraphServiceClient"/>
     <TrimmerRootAssembly Include="Microsoft.Identity.Web.GraphServiceClientBeta"/>
 
+    <TrimmerRootAssembly Include="Microsoft.Identity.Web.OidcFIC"/>
+    <TrimmerRootAssembly Include="Microsoft.Identity.Web.AgentIdentities"/>
+
     <!--
     <TrimmerRootAssembly Include="Microsoft.Identity.Web.MicrosoftGraph"/>
     <TrimmerRootAssembly Include="Microsoft.Identity.Web.MicrosoftGraphBeta"/>


### PR DESCRIPTION
Referencing the `Microsoft.Identity.Web.OidcFIC` package (the FIC signed-assertion loader used for agentic / cross-cloud Federated Identity Credential scenarios) breaks a trimmed or Native AOT publish of the consuming application. The failure surfaces as an `IL2026` trim warning that is promoted to a build error, e.g.:

```
ILLink : IL2026: Microsoft.Identity.Web.OidcFic.OidcIdpSignedAssertionLoader...
  Using 'ConfigurationBinder.Bind(IConfiguration, Object)' which has
  'RequiresUnreferencedCodeAttribute' can break functionality when trimming...
error NETSDK1144: Optimizing assemblies for size failed.
```

## Root cause

`OidcIdpSignedAssertionLoader.LoadIfNeededAsync` binds a configuration section to
`MicrosoftIdentityApplicationOptions` using the reflection-based configuration binder:

```csharp
configuration.GetSection(sectionName).Bind(microsoftIdentityApplicationOptions);
```

`ConfigurationBinder.Bind(IConfiguration, object)` is annotated `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]`. When an application is published with trimming (`PublishTrimmed`) or Native AOT (`PublishAot`), ILLink/ILC analyze the
whole call graph, walk into `OidcFIC`, and report `IL2026` (and `IL3050` under AOT) for this unguarded reflection call.

Unlike the rest of Microsoft Identity Web, the `OidcFIC` project set no trim/AOT properties:
- It did not enable the compile-time trim/AOT analyzers (`IsAotCompatible`), so the issue was never caught in this repo's own build.
- It did not enable the configuration-binding source generator (`EnableConfigurationBindingGenerator`), so the reflection-based binder remained in the shipped IL.
- The AOT compatibility test app did not root the `OidcFIC` assembly, so the gap was not covered by AOT validation.

## Changes

All changes are build/packaging configuration and follow the exact pattern already used by `Microsoft.Identity.Web.DownstreamApi`, `Microsoft.Identity.Web.MicrosoftGraph`, and the AOT compatibility test app.

### 1. `src/Microsoft.Identity.Web.OidcFIC/Microsoft.Identity.Web.OidcFIC.csproj`

```xml
<PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
  <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
  <IsAotCompatible>true</IsAotCompatible>
  <!-- The configuration binding source generator emits these diagnostics for the certificate
       object graph on MicrosoftIdentityApplicationOptions (X509Certificate2, PublicKey, PrivateKey,
       etc.), which is never populated from configuration. Suppressed to match the AOT test app. -->
  <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101;SYSLIB0026;SYSLIB0027;SYSLIB0028</NoWarn>
</PropertyGroup>
```

### 2. Regression hardening for sibling packages

In addition to `OidcFIC` assembly which threw the original issue, two leaf libraries were verified to be trim/AOT-clean but were not yet marked as being compatible. They are now marked `IsAotCompatible` (net8.0+) to avoid them causing the same errors:
- `src/Microsoft.Identity.Web.AgentIdentities/Microsoft.Identity.Web.AgentIdentities.csproj` (the agentic-identity package, which references `OidcFIC`).
- `src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj`.

### 3. `tests/Microsoft.Identity.Web.AotCompatibility.TestApp`

An existing test app intended to cover AOT compatibility, but did not reference either `OidcFIC` or `AgentIdentities`. This PR adds them to the `TrimmerRootAssembly` list so the FIC / agentic path is actually exercised by an AOT publish and this class of regression is caught going forward:

```xml
<TrimmerRootAssembly Include="Microsoft.Identity.Web.OidcFIC"/>
<TrimmerRootAssembly Include="Microsoft.Identity.Web.AgentIdentities"/>
```

## Verification

- **Reproduced** the original `IL2026`/`IL3050` at `OidcIdpSignedAssertionLoader.cs` by building `OidcFIC` with the AOT analyzers enabled.
- **Multi-TFM build** of `OidcFIC` (net8.0/net9.0/net10.0 + net462/net472/netstandard2.0) with the repo default `TreatWarningsAsErrors=true`: 0 warnings, 0 errors.
- **Trimmed publish** of a consumer app that roots the `OidcFIC` assembly (net8.0): 0 `IL2026`/`IL3050`/`NETSDK1144`.
- **Native AOT** publish of the AOT test app (net10.0) with `OidcFIC` rooted: the entire managed IL scan / trim-and-AOT analysis phase completed with 0 warnings (only the final native link step fails in the local environment because the C++ linker is not on PATH — an environment limitation, not a code issue).
- **Existing unit tests**: all 9 `OidcIdpSignedAssertionLoader` tests pass — binding behavior is preserved.

## net8/9 gap follow-up

This PR is the **limited fix** for a customer-reported issue: it makes the `OidcFIC` package (and the verified sibling leaf libraries) trim-/AOT-clean on net8.0, net9.0, and net10.0.

It does **not** attempt to deliver end-to-end trim/AOT support for a full Microsoft Identity Web **web app / web API** on net8/9. Investigation showed that the AOT-safe web-API entry point — `AddMicrosoftIdentityWebApiAot` and its supporting
`MicrosoftIdentityJwtBearerOptionsPostConfigurator` — is gated behind `#if NET10_0_OR_GREATER`. On net8/9 the only configuration path is the reflection-based `AddMicrosoftIdentityWebApi(IConfiguration, ...)`, which is inherently not AOT-safe. This is the deliberate reason the AOT compatibility test app and `TokenAcquisition`'s `IsAotCompatible` marker are net10-focused.

The individual leaf libraries (`TokenAcquisition`, `OidcFIC`, `AgentIdentities`, `Certificateless`) were confirmed to be trim/AOT-clean on net8/9 in isolation. Closing the full net8/9 gap would require back-porting the reflection-free web-API configuration surface (`AddMicrosoftIdentityWebApiAot` et al.) to net8/9 — a separate, larger effort tracked independently.