### PR TITLE
Make managed identity key attestation optional

### DIFF
--- a/Microsoft.Identity.Web.linux.slnf
+++ b/Microsoft.Identity.Web.linux.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src/Microsoft.Identity.Web.Diagnostics/Microsoft.Identity.Web.Diagnostics.csproj",
       "src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj",
+      "src/Microsoft.Identity.Web.KeyAttestation/Microsoft.Identity.Web.KeyAttestation.csproj",
       "src/Microsoft.Identity.Web.Certificate/Microsoft.Identity.Web.Certificate.csproj",
       "src/Microsoft.Identity.Web.TokenCache/Microsoft.Identity.Web.TokenCache.csproj",
       "src/Microsoft.Identity.Web.TokenAcquisition/Microsoft.Identity.Web.TokenAcquisition.csproj",

--- a/Microsoft.Identity.Web.sln
+++ b/Microsoft.Identity.Web.sln
@@ -228,6 +228,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "daemon-app-msi-mtls", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "daemon-app-fic-mtls", "tests\DevApps\daemon-app\daemon-app-fic-mtls\daemon-app-fic-mtls.csproj", "{6CCB739E-EA5B-4F5C-AF7E-FC983D8171D9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Web.KeyAttestation", "src\Microsoft.Identity.Web.KeyAttestation\Microsoft.Identity.Web.KeyAttestation.csproj", "{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1075,6 +1077,18 @@ Global
 		{6CCB739E-EA5B-4F5C-AF7E-FC983D8171D9}.Release|x64.Build.0 = Release|Any CPU
 		{6CCB739E-EA5B-4F5C-AF7E-FC983D8171D9}.Release|x86.ActiveCfg = Release|Any CPU
 		{6CCB739E-EA5B-4F5C-AF7E-FC983D8171D9}.Release|x86.Build.0 = Release|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Debug|x86.Build.0 = Debug|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Release|x64.Build.0 = Release|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1168,6 +1182,7 @@ Global
 		{4CC70892-2376-E556-4B07-0A40D1BF6684} = {7786D2DD-9EE4-42E1-B587-740A2E15C41D}
 		{7EBF1482-E98B-4908-87FA-2270FC95F775} = {4CC70892-2376-E556-4B07-0A40D1BF6684}
 		{6CCB739E-EA5B-4F5C-AF7E-FC983D8171D9} = {4CC70892-2376-E556-4B07-0A40D1BF6684}
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D} = {1DDE1AAC-5AE6-4725-94B6-A26C58D3423F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {104367F1-CE75-4F40-B32F-F14853973187}

--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -133,6 +133,13 @@ steps:
     ProjectRootPath: '$(Build.SourcesDirectory)\$(IdWebSourceDir)src\Microsoft.Identity.Web.Azure'
     AssemblyName: 'Microsoft.Identity.Web.Azure*'
 
+# Pack Microsoft.Identity.Web.KeyAttestation
+- template: template-pack-nuget.yaml
+  parameters:
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
+    ProjectRootPath: '$(Build.SourcesDirectory)\$(IdWebSourceDir)src\Microsoft.Identity.Web.KeyAttestation'
+    AssemblyName: 'Microsoft.Identity.Web.KeyAttestation*'
+
 # Copy all packages out to staging
 - task: CopyFiles@2
   displayName: 'Copy Files from $(Build.SourcesDirectory) to: $(Build.ArtifactStagingDirectory)\packages'

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Bug fixes
+- Move Credential Guard key attestation into the optional `Microsoft.Identity.Web.KeyAttestation` package. Managed identity mTLS proof-of-possession uses the unattested flow unless the package is installed and `AddMicrosoftIdentityWebKeyAttestation()` is registered, preventing native key-attestation binaries and symbols from being published with unrelated applications.
+
 ## 4.14.2
 
 ### Dependencies updates

--- a/docfx_project/src/source.sln
+++ b/docfx_project/src/source.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Web.Toke
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Web.UI", "..\..\src\Microsoft.Identity.Web.UI\Microsoft.Identity.Web.UI.csproj", "{20535D28-C2F4-4975-9982-A18E7141DA53}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Web.KeyAttestation", "..\..\src\Microsoft.Identity.Web.KeyAttestation\Microsoft.Identity.Web.KeyAttestation.csproj", "{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,5 +74,9 @@ Global
 		{20535D28-C2F4-4975-9982-A18E7141DA53}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20535D28-C2F4-4975-9982-A18E7141DA53}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20535D28-C2F4-4975-9982-A18E7141DA53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/docs/calling-downstream-apis/token-binding.md
+++ b/docs/calling-downstream-apis/token-binding.md
@@ -521,6 +521,17 @@ Two binding-capable assertion sources are supported:
 - `CustomSignedAssertion` from the OIDC IdP provider
   (`Microsoft.Identity.Web.OidcFIC`, `AddOidcFic()`)
 
+Managed identity mTLS PoP uses the unattested flow by default. To enable
+Credential Guard key attestation on supported hosts, install the optional
+`Microsoft.Identity.Web.KeyAttestation` package and register it:
+
+```csharp
+builder.Services.AddMicrosoftIdentityWebKeyAttestation();
+```
+
+Only applications that reference this package receive the native key-attestation
+runtime assets.
+
 ### OIDC FIC producing a final `mtls_pop` token
 
 The caller requests `ProtocolScheme = "MTLS_POP"`. The inner OIDC exchange is

--- a/docs/calling-downstream-apis/token-binding.md
+++ b/docs/calling-downstream-apis/token-binding.md
@@ -521,13 +521,30 @@ Two binding-capable assertion sources are supported:
 - `CustomSignedAssertion` from the OIDC IdP provider
   (`Microsoft.Identity.Web.OidcFIC`, `AddOidcFic()`)
 
-Managed identity mTLS PoP uses the unattested flow by default. To enable
-Credential Guard key attestation on supported hosts, install the optional
-`Microsoft.Identity.Web.KeyAttestation` package and register it:
+Managed identity mTLS PoP uses `WithMtlsProofOfPossession()` without key
+attestation by default. To also apply `WithAttestationSupport()` on supported
+hosts, install the optional `Microsoft.Identity.Web.KeyAttestation` package and
+register it:
 
 ```csharp
 builder.Services.AddMicrosoftIdentityWebKeyAttestation();
 ```
+
+For applications using `TokenAcquirerFactory`, register it before building the
+service provider:
+
+```csharp
+var tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
+tokenAcquirerFactory.Services.AddMicrosoftIdentityWebKeyAttestation();
+
+var serviceProvider = tokenAcquirerFactory.Build();
+```
+
+The resulting behavior is:
+
+- Default: `WithMtlsProofOfPossession()`
+- Optional package and registration:
+  `WithMtlsProofOfPossession()` + `WithAttestationSupport()`
 
 Only applications that reference this package receive the native key-attestation
 runtime assets.

--- a/docs/design/bearer_tokens_with_bound_credentials_devex.md
+++ b/docs/design/bearer_tokens_with_bound_credentials_devex.md
@@ -326,8 +326,10 @@ the configuration example above.
   for this flow.
 * Platform support for the binding certificate today:
   * Certificate flow: any platform — uses the app's existing certificate.
-  * FIC flow: requires the V2 MI credential endpoint, currently Windows
-    Confidential VMs (Key Guard + attestation).
+  * FIC flow: requires the V2 MI credential endpoint. Managed identity mTLS PoP
+    uses `WithMtlsProofOfPossession()` by default; applications that require
+    key attestation install `Microsoft.Identity.Web.KeyAttestation` and call
+    `AddMicrosoftIdentityWebKeyAttestation()`.
 
 ## Open questions
 

--- a/docs/design/credential-architecture.md
+++ b/docs/design/credential-architecture.md
@@ -111,11 +111,14 @@ For MI, token binding works differently — no CCA is involved:
 var miBuilder = managedIdApp.AcquireTokenForManagedIdentity(scope);
 if (isTokenBinding)
 {
-    miBuilder = miBuilder
-        .WithMtlsProofOfPossession()
-        .WithAttestationSupport();
+    miBuilder = miBuilder.WithMtlsProofOfPossession();
 }
 ```
+
+This is the default, unattested flow. Installing
+`Microsoft.Identity.Web.KeyAttestation` and calling
+`AddMicrosoftIdentityWebKeyAttestation()` additionally applies
+`WithAttestationSupport()`.
 
 MSAL handles the mTLS handshake with IMDS v2 internally.
 
@@ -289,4 +292,4 @@ sequenceDiagram
 | Client Secret | ✅ `WithClientSecret` | ❌ Not supported (no private key for binding) |
 | FIC via MI (`SignedAssertionFromManagedIdentity`) | ✅ `WithClientAssertion` | ✅ if `SupportsTokenBinding` (via `GetSignedAssertionWithBindingAsync`) |
 | OIDC FIC (`CustomSignedAssertion`) | ✅ `WithClientAssertion` | ✅ via `GetSignedAssertionWithBindingAsync` (binding cert from the inner acquisition) |
-| Managed Identity (direct, not FIC) | ✅ `AcquireTokenForMI` | ✅ `WithMtlsProofOfPossession` + `WithAttestationSupport` |
+| Managed Identity (direct, not FIC) | ✅ `AcquireTokenForMI` | ✅ Default: `WithMtlsProofOfPossession`; optional key-attestation package: `WithMtlsProofOfPossession` + `WithAttestationSupport` |

--- a/docs/design/msi-fic-pure-mtls-pop-devex.md
+++ b/docs/design/msi-fic-pure-mtls-pop-devex.md
@@ -28,8 +28,9 @@ This spec closes that gap.
   Identity and FIC-with-MI.
 * **Transparent binding** – IdWeb forwards the request to MSAL, MSAL
   provisions the binding certificate via the V2 Managed Identity credential
-  API (Key Guard + attestation), and the downstream HTTP call uses that
-  certificate over mTLS.
+  API, and the downstream HTTP call uses that certificate over mTLS. Key
+  attestation is added only when the optional
+  `Microsoft.Identity.Web.KeyAttestation` package is registered.
 
 The goal is **zero-touch** for developers who already use Managed Identity or
 FIC for bearer tokens.
@@ -255,8 +256,11 @@ the configuration example above.
 
 ## Prerequisites
 
-* `Microsoft.Identity.Web` takes a dependency on
-  `Microsoft.Identity.Client.KeyAttestation` (GA in the next MSAL release).
+* Managed identity mTLS PoP uses `WithMtlsProofOfPossession()` by default.
+  Applications that require key attestation install
+  `Microsoft.Identity.Web.KeyAttestation` and call
+  `AddMicrosoftIdentityWebKeyAttestation()`, which additionally applies
+  `WithAttestationSupport()`.
 * The downstream resource (Microsoft Graph, Azure Key Vault, a custom API)
   must accept mTLS PoP tokens. This is configured per-resource in ESTS.
 * The application's tenant and client must be on the ESTS allow-list for

--- a/docs/getting-started/packages.md
+++ b/docs/getting-started/packages.md
@@ -52,6 +52,7 @@ These packages support specialized authentication scenarios.
 | Package | Description |
 |---------|-------------|
 | **Microsoft.Identity.Web.Diagnostics** | Provides diagnostic and logging support for troubleshooting authentication issues in Microsoft.Identity.Web. |
+| **Microsoft.Identity.Web.KeyAttestation** | Optional Credential Guard key attestation support for managed identity mTLS proof-of-possession flows. Install this package only when attested keys are required. |
 | **Microsoft.Identity.Web.OidcFIC** | Implementation for Cloud Federation Identity Credential (FIC) credential provider. Enables cross-cloud authentication scenarios. |
 | **Microsoft.Identity.Web.AgentIdentities** | Helper methods for Agent identity blueprint to act as agent identities. Enables building autonomous agents and copilot scenarios. |
 

--- a/src/Microsoft.Identity.Web.Certificateless/IKeyAttestationProvider.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/IKeyAttestationProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Identity.Web
     /// <summary>
     /// Enables optional key attestation on a managed identity mTLS proof-of-possession request.
     /// </summary>
-    public interface IManagedIdentityAttestationProvider
+    public interface IKeyAttestationProvider
     {
         /// <summary>
         /// Configures key attestation on the managed identity request.

--- a/src/Microsoft.Identity.Web.Certificateless/IManagedIdentityAttestationProvider.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/IManagedIdentityAttestationProvider.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Enables optional key attestation on a managed identity mTLS proof-of-possession request.
+    /// </summary>
+    public interface IManagedIdentityAttestationProvider
+    {
+        /// <summary>
+        /// Configures key attestation on the managed identity request.
+        /// </summary>
+        /// <param name="builder">The managed identity request builder.</param>
+        /// <returns>The configured request builder.</returns>
+        AcquireTokenForManagedIdentityParameterBuilder EnableAttestation(
+            AcquireTokenForManagedIdentityParameterBuilder builder);
+    }
+}

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -9,9 +9,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Client.Extensibility;
-#if NETCOREAPP
-using Microsoft.Identity.Client.KeyAttestation;
-#endif
 using Microsoft.Identity.Web.Certificateless;
 using Microsoft.Identity.Web.TestOnly;
 using Microsoft.IdentityModel.LoggingExtensions;
@@ -26,6 +23,8 @@ namespace Microsoft.Identity.Web
         private IManagedIdentityApplication _managedIdentityApplication;
         private readonly string _tokenExchangeUrl;
         private readonly ILogger? _logger;
+        private readonly IManagedIdentityAttestationProvider? _attestationProvider;
+        private int _unattestedFlowLogged;
 
         /// <summary>
         /// See https://aka.ms/ms-id-web/certificateless.
@@ -63,6 +62,28 @@ namespace Microsoft.Identity.Web
                 managedIdentityClientId,
                 tokenExchangeUrl,
                 logger,
+                attestationProvider: null,
+                ManagedIdentityClientAssertionTestHook.HttpClientFactoryForTests)
+        {
+        }
+
+        /// <summary>
+        /// Creates a managed identity client assertion provider with optional key attestation support.
+        /// </summary>
+        /// <param name="managedIdentityClientId">Optional client ID of the managed identity.</param>
+        /// <param name="tokenExchangeUrl">Optional audience of the managed identity token.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="attestationProvider">The provider that enables key attestation for bound token requests.</param>
+        public ManagedIdentityClientAssertion(
+            string? managedIdentityClientId,
+            string? tokenExchangeUrl,
+            ILogger? logger,
+            IManagedIdentityAttestationProvider? attestationProvider)
+            : this(
+                managedIdentityClientId,
+                tokenExchangeUrl,
+                logger,
+                attestationProvider,
                 ManagedIdentityClientAssertionTestHook.HttpClientFactoryForTests)
         {
         }
@@ -82,9 +103,25 @@ namespace Microsoft.Identity.Web
             string? tokenExchangeUrl,
             ILogger? logger,
             IMsalHttpClientFactory? testHttpClientFactory)
+            : this(
+                managedIdentityClientId,
+                tokenExchangeUrl,
+                logger,
+                attestationProvider: null,
+                testHttpClientFactory)
+        {
+        }
+
+        private ManagedIdentityClientAssertion(
+            string? managedIdentityClientId,
+            string? tokenExchangeUrl,
+            ILogger? logger,
+            IManagedIdentityAttestationProvider? attestationProvider,
+            IMsalHttpClientFactory? testHttpClientFactory)
         {
             _tokenExchangeUrl = tokenExchangeUrl ?? CertificatelessConstants.DefaultTokenExchangeUrl;
             _logger = logger;
+            _attestationProvider = attestationProvider;
 
             var id = ManagedIdentityId.SystemAssigned;
             if (!string.IsNullOrEmpty(managedIdentityClientId))
@@ -178,11 +215,17 @@ namespace Microsoft.Identity.Web
             if (bindToCertificate)
             {
                 miBuilder = miBuilder.WithMtlsProofOfPossession();
-#if NETCOREAPP
-                // Key attestation is only available on modern .NET; on .NET Framework/netstandard the
-                // KeyAttestation dependency is intentionally absent (issue #3894).
-                miBuilder = miBuilder.WithAttestationSupport();
-#endif
+                if (_attestationProvider is not null)
+                {
+                    miBuilder = _attestationProvider.EnableAttestation(miBuilder);
+                }
+                else if (Interlocked.Exchange(ref _unattestedFlowLogged, 1) == 0)
+                {
+                    _logger?.LogInformation(
+                        "Managed identity mTLS proof-of-possession is using an unattested binding. " +
+                        "Install Microsoft.Identity.Web.KeyAttestation and call " +
+                        "AddMicrosoftIdentityWebKeyAttestation() to enable Credential Guard attestation.");
+                }
             }
 
             // Propagate claims into the MI token request.

--- a/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
+++ b/src/Microsoft.Identity.Web.Certificateless/ManagedIdentityClientAssertion.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Web
         private IManagedIdentityApplication _managedIdentityApplication;
         private readonly string _tokenExchangeUrl;
         private readonly ILogger? _logger;
-        private readonly IManagedIdentityAttestationProvider? _attestationProvider;
+        private readonly IKeyAttestationProvider? _keyAttestationProvider;
         private int _unattestedFlowLogged;
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Web
                 managedIdentityClientId,
                 tokenExchangeUrl,
                 logger,
-                attestationProvider: null,
+                keyAttestationProvider: null,
                 ManagedIdentityClientAssertionTestHook.HttpClientFactoryForTests)
         {
         }
@@ -73,17 +73,17 @@ namespace Microsoft.Identity.Web
         /// <param name="managedIdentityClientId">Optional client ID of the managed identity.</param>
         /// <param name="tokenExchangeUrl">Optional audience of the managed identity token.</param>
         /// <param name="logger">A logger.</param>
-        /// <param name="attestationProvider">The provider that enables key attestation for bound token requests.</param>
+        /// <param name="keyAttestationProvider">The provider that enables key attestation for bound token requests.</param>
         public ManagedIdentityClientAssertion(
             string? managedIdentityClientId,
             string? tokenExchangeUrl,
             ILogger? logger,
-            IManagedIdentityAttestationProvider? attestationProvider)
+            IKeyAttestationProvider? keyAttestationProvider)
             : this(
                 managedIdentityClientId,
                 tokenExchangeUrl,
                 logger,
-                attestationProvider,
+                keyAttestationProvider,
                 ManagedIdentityClientAssertionTestHook.HttpClientFactoryForTests)
         {
         }
@@ -107,7 +107,7 @@ namespace Microsoft.Identity.Web
                 managedIdentityClientId,
                 tokenExchangeUrl,
                 logger,
-                attestationProvider: null,
+                keyAttestationProvider: null,
                 testHttpClientFactory)
         {
         }
@@ -116,12 +116,12 @@ namespace Microsoft.Identity.Web
             string? managedIdentityClientId,
             string? tokenExchangeUrl,
             ILogger? logger,
-            IManagedIdentityAttestationProvider? attestationProvider,
+            IKeyAttestationProvider? keyAttestationProvider,
             IMsalHttpClientFactory? testHttpClientFactory)
         {
             _tokenExchangeUrl = tokenExchangeUrl ?? CertificatelessConstants.DefaultTokenExchangeUrl;
             _logger = logger;
-            _attestationProvider = attestationProvider;
+            _keyAttestationProvider = keyAttestationProvider;
 
             var id = ManagedIdentityId.SystemAssigned;
             if (!string.IsNullOrEmpty(managedIdentityClientId))
@@ -215,9 +215,9 @@ namespace Microsoft.Identity.Web
             if (bindToCertificate)
             {
                 miBuilder = miBuilder.WithMtlsProofOfPossession();
-                if (_attestationProvider is not null)
+                if (_keyAttestationProvider is not null)
                 {
-                    miBuilder = _attestationProvider.EnableAttestation(miBuilder);
+                    miBuilder = _keyAttestationProvider.EnableAttestation(miBuilder);
                 }
                 else if (Interlocked.Exchange(ref _unattestedFlowLogged, 1) == 0)
                 {

--- a/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
+++ b/src/Microsoft.Identity.Web.Certificateless/Microsoft.Identity.Web.Certificateless.csproj
@@ -25,14 +25,6 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
   </ItemGroup>
 
-  <!-- Microsoft.Identity.Client.KeyAttestation transitively depends on the native-only
-       Microsoft.Azure.Security.KeyGuardAttestation package, which ships no .NET Framework/netstandard
-       compatible assets and breaks NuGet restore for .NET Framework (packages.config) consumers (issue #3894).
-       Key attestation is only used on modern .NET, so the dependency is restricted to .NETCoreApp targets. -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <PackageReference Include="Microsoft.Identity.Client.KeyAttestation" Version="$(MicrosoftIdentityClientKeyAttestationVersion)" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>

--- a/src/Microsoft.Identity.Web.Certificateless/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Certificateless/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
-Microsoft.Identity.Web.IManagedIdentityAttestationProvider
-Microsoft.Identity.Web.IManagedIdentityAttestationProvider.EnableAttestation(Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder! builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder!
-Microsoft.Identity.Web.ManagedIdentityClientAssertion.ManagedIdentityClientAssertion(string? managedIdentityClientId, string? tokenExchangeUrl, Microsoft.Extensions.Logging.ILogger? logger, Microsoft.Identity.Web.IManagedIdentityAttestationProvider? attestationProvider) -> void
+Microsoft.Identity.Web.IKeyAttestationProvider
+Microsoft.Identity.Web.IKeyAttestationProvider.EnableAttestation(Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder! builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder!
+Microsoft.Identity.Web.ManagedIdentityClientAssertion.ManagedIdentityClientAssertion(string? managedIdentityClientId, string? tokenExchangeUrl, Microsoft.Extensions.Logging.ILogger? logger, Microsoft.Identity.Web.IKeyAttestationProvider? keyAttestationProvider) -> void

--- a/src/Microsoft.Identity.Web.Certificateless/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.Certificateless/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Microsoft.Identity.Web.IManagedIdentityAttestationProvider
+Microsoft.Identity.Web.IManagedIdentityAttestationProvider.EnableAttestation(Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder! builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder!
+Microsoft.Identity.Web.ManagedIdentityClientAssertion.ManagedIdentityClientAssertion(string? managedIdentityClientId, string? tokenExchangeUrl, Microsoft.Extensions.Logging.ILogger? logger, Microsoft.Identity.Web.IManagedIdentityAttestationProvider? attestationProvider) -> void

--- a/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestationProvider.cs
+++ b/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestationProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Web
     /// <summary>
     /// Enables Credential Guard key attestation for managed identity mTLS proof-of-possession requests.
     /// </summary>
-    internal sealed class ManagedIdentityAttestationProvider : IManagedIdentityAttestationProvider
+    internal sealed class KeyAttestationProvider : IKeyAttestationProvider
     {
         /// <inheritdoc/>
         public AcquireTokenForManagedIdentityParameterBuilder EnableAttestation(

--- a/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestationServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestationServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Identity.Abstractions;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Extensions for adding optional key attestation support.
+    /// </summary>
+    public static class KeyAttestationServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds Credential Guard key attestation support for managed identity mTLS
+        /// proof-of-possession requests.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMicrosoftIdentityWebKeyAttestation(
+            this IServiceCollection services)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            services.TryAddSingleton<IManagedIdentityAttestationProvider, ManagedIdentityAttestationProvider>();
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<ICredentialSourceLoader, KeyAttestedManagedIdentityCredentialLoader>());
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestationServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestationServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Web
         {
             ArgumentNullException.ThrowIfNull(services);
 
-            services.TryAddSingleton<IManagedIdentityAttestationProvider, ManagedIdentityAttestationProvider>();
+            services.TryAddSingleton<IKeyAttestationProvider, KeyAttestationProvider>();
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<ICredentialSourceLoader, KeyAttestedManagedIdentityCredentialLoader>());
 

--- a/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestedManagedIdentityCredentialLoader.cs
+++ b/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestedManagedIdentityCredentialLoader.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Identity.Web
+{
+    internal sealed class KeyAttestedManagedIdentityCredentialLoader : ICredentialSourceLoader
+    {
+        private readonly IManagedIdentityAttestationProvider _attestationProvider;
+        private readonly ILogger<KeyAttestedManagedIdentityCredentialLoader> _logger;
+
+        public KeyAttestedManagedIdentityCredentialLoader(
+            IManagedIdentityAttestationProvider attestationProvider,
+            ILogger<KeyAttestedManagedIdentityCredentialLoader> logger)
+        {
+            _attestationProvider = attestationProvider;
+            _logger = logger;
+        }
+
+        public CredentialSource CredentialSource => CredentialSource.SignedAssertionFromManagedIdentity;
+
+        public async Task LoadIfNeededAsync(
+            CredentialDescription credentialDescription,
+            CredentialSourceLoaderParameters? credentialSourceLoaderParameters)
+        {
+            if (credentialDescription.SourceType != CredentialSource.SignedAssertionFromManagedIdentity)
+            {
+                return;
+            }
+
+            ManagedIdentityClientAssertion? managedIdentityClientAssertion =
+                credentialDescription.CachedValue as ManagedIdentityClientAssertion;
+
+            if (credentialDescription.CachedValue is null)
+            {
+                managedIdentityClientAssertion = new ManagedIdentityClientAssertion(
+                    credentialDescription.ManagedIdentityClientId,
+                    credentialDescription.TokenExchangeUrl,
+                    _logger,
+                    _attestationProvider);
+            }
+
+            try
+            {
+                _ = await managedIdentityClientAssertion!
+                    .GetSignedAssertionAsync(null)
+                    .ConfigureAwait(false);
+                credentialDescription.CachedValue = managedIdentityClientAssertion;
+            }
+            catch (MsalServiceException)
+            {
+                credentialDescription.Skip = true;
+                throw;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestedManagedIdentityCredentialLoader.cs
+++ b/src/Microsoft.Identity.Web.KeyAttestation/KeyAttestedManagedIdentityCredentialLoader.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Identity.Web
 {
     internal sealed class KeyAttestedManagedIdentityCredentialLoader : ICredentialSourceLoader
     {
-        private readonly IManagedIdentityAttestationProvider _attestationProvider;
+        private readonly IKeyAttestationProvider _keyAttestationProvider;
         private readonly ILogger<KeyAttestedManagedIdentityCredentialLoader> _logger;
 
         public KeyAttestedManagedIdentityCredentialLoader(
-            IManagedIdentityAttestationProvider attestationProvider,
+            IKeyAttestationProvider keyAttestationProvider,
             ILogger<KeyAttestedManagedIdentityCredentialLoader> logger)
         {
-            _attestationProvider = attestationProvider;
+            _keyAttestationProvider = keyAttestationProvider;
             _logger = logger;
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Web
                     credentialDescription.ManagedIdentityClientId,
                     credentialDescription.TokenExchangeUrl,
                     _logger,
-                    _attestationProvider);
+                    _keyAttestationProvider);
             }
 
             try

--- a/src/Microsoft.Identity.Web.KeyAttestation/ManagedIdentityAttestationProvider.cs
+++ b/src/Microsoft.Identity.Web.KeyAttestation/ManagedIdentityAttestationProvider.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.KeyAttestation;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Enables Credential Guard key attestation for managed identity mTLS proof-of-possession requests.
+    /// </summary>
+    internal sealed class ManagedIdentityAttestationProvider : IManagedIdentityAttestationProvider
+    {
+        /// <inheritdoc/>
+        public AcquireTokenForManagedIdentityParameterBuilder EnableAttestation(
+            AcquireTokenForManagedIdentityParameterBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            return builder.WithAttestationSupport();
+        }
+    }
+}

--- a/src/Microsoft.Identity.Web.KeyAttestation/Microsoft.Identity.Web.KeyAttestation.csproj
+++ b/src/Microsoft.Identity.Web.KeyAttestation/Microsoft.Identity.Web.KeyAttestation.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>Microsoft Identity Web Key Attestation</Title>
+    <Product>Microsoft Identity Web Key Attestation</Product>
+    <Description>Optional key attestation support for managed identity mTLS proof-of-possession flows.</Description>
+    <ProjectGuid>{4E6707E4-3B6E-4B12-9B76-D6978B4DAF3D}</ProjectGuid>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <EnablePackageValidation>false</EnablePackageValidation>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Identity.Web.Certificateless\Microsoft.Identity.Web.Certificateless.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Abstractions" Version="$(MicrosoftIdentityAbstractionsVersion)" />
+    <PackageReference Include="Microsoft.Identity.Client.KeyAttestation" Version="$(MicrosoftIdentityClientKeyAttestationVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI\PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.Identity.Web.KeyAttestation/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Web.KeyAttestation/PublicAPI/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Microsoft.Identity.Web.KeyAttestation/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Web.KeyAttestation/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+#nullable enable
+Microsoft.Identity.Web.KeyAttestationServiceCollectionExtensions
+static Microsoft.Identity.Web.KeyAttestationServiceCollectionExtensions.AddMicrosoftIdentityWebKeyAttestation(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -21,9 +21,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensibility;
-#if NETCOREAPP
-using Microsoft.Identity.Client.KeyAttestation;
-#endif
 using Microsoft.Identity.Web.Experimental;
 using Microsoft.Identity.Web.Extensibility;
 using Microsoft.Identity.Web.TestOnly;
@@ -97,6 +94,8 @@ namespace Microsoft.Identity.Web
         protected readonly IMsalHttpClientFactory _httpClientFactory;
         protected readonly ILogger _logger;
         protected readonly IServiceProvider _serviceProvider;
+        private readonly IManagedIdentityAttestationProvider? _managedIdentityAttestationProvider;
+        private int _unattestedManagedIdentityFlowLogged;
         protected readonly ITokenAcquisitionHost _tokenAcquisitionHost;
         protected readonly ICredentialsProvider _credentialsProvider;
         protected readonly IOptionsMonitor<TokenAcquisitionExtensionOptions>? tokenAcquisitionExtensionOptionsMonitor;
@@ -142,6 +141,8 @@ namespace Microsoft.Identity.Web
             _httpClientFactory = serviceProvider.GetService<IMsalHttpClientFactory>() ?? new MsalMtlsHttpClientFactory(httpClientFactory);
             _logger = logger;
             _serviceProvider = serviceProvider;
+            _managedIdentityAttestationProvider =
+                serviceProvider.GetService(typeof(IManagedIdentityAttestationProvider)) as IManagedIdentityAttestationProvider;
             _tokenAcquisitionHost = tokenAcquisitionHost;
             tokenAcquisitionExtensionOptionsMonitor = serviceProvider.GetService<IOptionsMonitor<TokenAcquisitionExtensionOptions>>();
             _miHttpFactory = serviceProvider.GetService<IManagedIdentityTestHttpClientFactory>();
@@ -923,10 +924,17 @@ namespace Microsoft.Identity.Web
                     if (isTokenBinding)
                     {
                         miBuilder = miBuilder.WithMtlsProofOfPossession();
-#if NETCOREAPP
-                        // Key attestation is only available on modern .NET (issue #3894).
-                        miBuilder = miBuilder.WithAttestationSupport();
-#endif
+                        if (_managedIdentityAttestationProvider is not null)
+                        {
+                            miBuilder = _managedIdentityAttestationProvider.EnableAttestation(miBuilder);
+                        }
+                        else if (Interlocked.Exchange(ref _unattestedManagedIdentityFlowLogged, 1) == 0)
+                        {
+                            _logger.LogInformation(
+                                "Managed identity mTLS proof-of-possession is using an unattested binding. " +
+                                "Install Microsoft.Identity.Web.KeyAttestation and call " +
+                                "AddMicrosoftIdentityWebKeyAttestation() to enable Credential Guard attestation.");
+                        }
                     }
 
                     if (!string.IsNullOrEmpty(tokenAcquisitionOptions.Claims))

--- a/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Web
         protected readonly IMsalHttpClientFactory _httpClientFactory;
         protected readonly ILogger _logger;
         protected readonly IServiceProvider _serviceProvider;
-        private readonly IManagedIdentityAttestationProvider? _managedIdentityAttestationProvider;
+        private readonly IKeyAttestationProvider? _keyAttestationProvider;
         private int _unattestedManagedIdentityFlowLogged;
         protected readonly ITokenAcquisitionHost _tokenAcquisitionHost;
         protected readonly ICredentialsProvider _credentialsProvider;
@@ -141,8 +141,8 @@ namespace Microsoft.Identity.Web
             _httpClientFactory = serviceProvider.GetService<IMsalHttpClientFactory>() ?? new MsalMtlsHttpClientFactory(httpClientFactory);
             _logger = logger;
             _serviceProvider = serviceProvider;
-            _managedIdentityAttestationProvider =
-                serviceProvider.GetService(typeof(IManagedIdentityAttestationProvider)) as IManagedIdentityAttestationProvider;
+            _keyAttestationProvider =
+                serviceProvider.GetService(typeof(IKeyAttestationProvider)) as IKeyAttestationProvider;
             _tokenAcquisitionHost = tokenAcquisitionHost;
             tokenAcquisitionExtensionOptionsMonitor = serviceProvider.GetService<IOptionsMonitor<TokenAcquisitionExtensionOptions>>();
             _miHttpFactory = serviceProvider.GetService<IManagedIdentityTestHttpClientFactory>();
@@ -924,9 +924,9 @@ namespace Microsoft.Identity.Web
                     if (isTokenBinding)
                     {
                         miBuilder = miBuilder.WithMtlsProofOfPossession();
-                        if (_managedIdentityAttestationProvider is not null)
+                        if (_keyAttestationProvider is not null)
                         {
-                            miBuilder = _managedIdentityAttestationProvider.EnableAttestation(miBuilder);
+                            miBuilder = _keyAttestationProvider.EnableAttestation(miBuilder);
                         }
                         else if (Interlocked.Exchange(ref _unattestedManagedIdentityFlowLogged, 1) == 0)
                         {

--- a/tests/E2E Tests/TokenAcquirerTests/ManagedIdentityFicTests.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/ManagedIdentityFicTests.cs
@@ -76,6 +76,7 @@ namespace TokenAcquirerTests
             // binding certificate flows from the inner MSI acquisition result.
             TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest();
             TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
+            tokenAcquirerFactory.Services.AddMicrosoftIdentityWebKeyAttestation();
 
             tokenAcquirerFactory.Services.Configure<MicrosoftIdentityApplicationOptions>(options =>
             {

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirerTests.csproj
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirerTests.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.AgentIdentities\Microsoft.Identity.Web.AgentIdentities.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.GraphServiceClient\Microsoft.Identity.Web.GraphServiceClient.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.KeyAttestation\Microsoft.Identity.Web.KeyAttestation.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Identity.Web.TokenAcquisition\Microsoft.Identity.Web.TokenAcquisition.csproj" />
     <ProjectReference Include="..\..\Microsoft.Identity.Web.Test.Common\Microsoft.Identity.Web.Test.Common.csproj" />
   </ItemGroup>

--- a/tests/Microsoft.Identity.Web.Test/KeyAttestationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/KeyAttestationTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Identity.Web.Test
             using ServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Assert
-            Assert.NotNull(serviceProvider.GetService<IManagedIdentityAttestationProvider>());
+            Assert.NotNull(serviceProvider.GetService<IKeyAttestationProvider>());
             Assert.Single(
                 serviceProvider.GetServices<ICredentialSourceLoader>(),
                 loader => loader.CredentialSource == CredentialSource.SignedAssertionFromManagedIdentity);
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Web.Test
                 managedIdentityClientId: null,
                 tokenExchangeUrl: null,
                 logger: null,
-                attestationProvider: provider);
+                keyAttestationProvider: provider);
 
             // Act
             InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(ThrowingAttestationProvider.ErrorMessage, exception.Message);
         }
 
-        private sealed class ThrowingAttestationProvider : IManagedIdentityAttestationProvider
+        private sealed class ThrowingAttestationProvider : IKeyAttestationProvider
         {
             internal const string ErrorMessage = "Attestation provider invoked.";
 

--- a/tests/Microsoft.Identity.Web.Test/KeyAttestationTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/KeyAttestationTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Abstractions;
+using Microsoft.Identity.Client;
+using Xunit;
+
+namespace Microsoft.Identity.Web.Test
+{
+    public class KeyAttestationTests
+    {
+        [Fact]
+        public void AddMicrosoftIdentityWebKeyAttestation_RegistersOptionalServices()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddTokenAcquisition();
+
+            // Act
+            services.AddMicrosoftIdentityWebKeyAttestation();
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            Assert.NotNull(serviceProvider.GetService<IManagedIdentityAttestationProvider>());
+            Assert.Single(
+                serviceProvider.GetServices<ICredentialSourceLoader>(),
+                loader => loader.CredentialSource == CredentialSource.SignedAssertionFromManagedIdentity);
+
+            var credentialsLoader = Assert.IsType<DefaultCertificateLoader>(
+                serviceProvider.GetRequiredService<ICredentialsLoader>());
+            Assert.Equal(
+                typeof(KeyAttestationServiceCollectionExtensions).Assembly,
+                credentialsLoader.CredentialSourceLoaders[CredentialSource.SignedAssertionFromManagedIdentity]
+                    .GetType()
+                    .Assembly);
+        }
+
+        [Fact]
+        public async Task GetSignedAssertionWithBindingAsync_WithAttestationProvider_UsesProvider()
+        {
+            // Arrange
+            var provider = new ThrowingAttestationProvider();
+            var assertion = new ManagedIdentityClientAssertion(
+                managedIdentityClientId: null,
+                tokenExchangeUrl: null,
+                logger: null,
+                attestationProvider: provider);
+
+            // Act
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => assertion.GetSignedAssertionWithBindingAsync(null));
+
+            // Assert
+            Assert.Equal(ThrowingAttestationProvider.ErrorMessage, exception.Message);
+        }
+
+        private sealed class ThrowingAttestationProvider : IManagedIdentityAttestationProvider
+        {
+            internal const string ErrorMessage = "Attestation provider invoked.";
+
+            public AcquireTokenForManagedIdentityParameterBuilder EnableAttestation(
+                AcquireTokenForManagedIdentityParameterBuilder builder)
+            {
+                throw new InvalidOperationException(ErrorMessage);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
+++ b/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" Include="..\..\src\Microsoft.Identity.Web.MicrosoftGraph\Microsoft.Identity.Web.MicrosoftGraph.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Identity.Web.Azure\Microsoft.Identity.Web.Azure.csproj" />
+    <ProjectReference Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" Include="..\..\src\Microsoft.Identity.Web.KeyAttestation\Microsoft.Identity.Web.KeyAttestation.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Identity.Web.OidcFIC\Microsoft.Identity.Web.OidcFIC.csproj" />
     <ProjectReference Include="..\Microsoft.Identity.Web.Test.Common\Microsoft.Identity.Web.Test.Common.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Problem

`Microsoft.Identity.Web.Certificateless` currently references `Microsoft.Identity.Client.KeyAttestation`. That dependency transitively brings the native-only `Microsoft.Azure.Security.KeyGuardAttestation` package into applications that never request key attestation, including consumers that arrive through `Microsoft.Identity.Web.TokenAcquisition` and `Microsoft.Identity.Web.Azure`.

NuGet dependencies cannot be conditioned on whether an API is used, so keeping the reference in `Certificateless` means every consumer receives the native DLL and PDB. It also creates compatibility problems for .NET Framework / `packages.config` consumers. See AzureAD/microsoft-authentication-library-for-dotnet#6133.

## Change

This PR separates managed identity mTLS PoP from optional Credential Guard key attestation:

- Keeps `Microsoft.Identity.Web.Certificateless` independent through the `IManagedIdentityAttestationProvider` extension point.
- Adds the optional `Microsoft.Identity.Web.KeyAttestation` package as the only IdWeb package that references `Microsoft.Identity.Client.KeyAttestation`.
- Adds `AddMicrosoftIdentityWebKeyAttestation()` for explicit opt-in.
- Uses the provider consistently for both managed identity mTLS PoP paths:
  - direct managed identity token acquisition;
  - `SignedAssertionFromManagedIdentity` / FIC token acquisition.
- Keeps the custom credential-loader override so the FIC path receives the provider without coupling `Certificateless` to the optional package.
- Updates the existing attested FIC E2E test to explicitly register the optional package.
- Updates packaging, API surface, changelog, and mTLS PoP documentation.

## Behavior

| Configuration | Managed identity mTLS PoP behavior |
| --- | --- |
| Default | `WithMtlsProofOfPossession()` |
| Install `Microsoft.Identity.Web.KeyAttestation` and call `AddMicrosoftIdentityWebKeyAttestation()` | `WithMtlsProofOfPossession()` + `WithAttestationSupport()` |

Only applications that opt in receive the native KeyGuard attestation assets. The unattested managed identity mTLS PoP flow remains supported by MSAL.

For `TokenAcquirerFactory` applications, opt-in is explicit before `Build()`:

```csharp
var tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
tokenAcquirerFactory.Services.AddMicrosoftIdentityWebKeyAttestation();

var serviceProvider = tokenAcquirerFactory.Build();
```

## Review focus

- `IManagedIdentityAttestationProvider` is the dependency-inversion seam; the core packages do not reference the optional implementation package.
- `KeyAttestedManagedIdentityCredentialLoader` intentionally overrides the built-in `SignedAssertionFromManagedIdentity` loader through the existing custom-loader mechanism.
- Absence of the provider intentionally selects the unattested flow and logs that choice once per component instance.
- No backward-compatibility shim, loader redesign, or broader API redesign is included.

## Validation

- Built the attested `TokenAcquirerTests` E2E project for `net8.0`: 0 warnings, 0 errors.
- Focused `KeyAttestationTests`: 2 passed.
- Previously validated the modified credential/attestation test set: 44 passed.
- Packed and inspected the affected NuGet dependency groups:
  - core `Certificateless`, `TokenAcquisition`, and `Azure` packages do not depend on KeyAttestation;
  - only `Microsoft.Identity.Web.KeyAttestation` depends on `Microsoft.Identity.Client.KeyAttestation`.