### PR TITLE
Remove internal credential example from API docs

### DIFF
--- a/src/Microsoft.Identity.Web.Certificate/DefaultCredentialsLoader.cs
+++ b/src/Microsoft.Identity.Web.Certificate/DefaultCredentialsLoader.cs
@@ -68,8 +68,8 @@ namespace Microsoft.Identity.Web
         }
 
         /// <summary>
-        /// Dictionary of credential loaders per credential source. The application can add more to 
-        /// process additional credential sources(like dSMS).
+        /// Dictionary of credential loaders per credential source. The application can add more to
+        /// process additional credential sources.
         /// </summary>
         public IDictionary<CredentialSource, ICredentialSourceLoader> CredentialSourceLoaders { get; }
 


### PR DESCRIPTION
## Summary
- remove an internal credential-source example from CredentialSourceLoaders documentation
- update the inherited documentation shown on the DefaultCertificateLoader API page

## Validation
- built Microsoft.Identity.Web.Certificate.csproj