### PR TITLE
Surface distributed token cache removal failures

### DIFF
--- a/src/Microsoft.Identity.Web.TokenAcquisition/IDWebErrorMessage.cs
+++ b/src/Microsoft.Identity.Web.TokenAcquisition/IDWebErrorMessage.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Identity.Web
      */
     internal static class IDWebErrorMessage
     {
+        public const string L2CacheRemovalFailedErrorCode = "idw_l2_cache_removal_failed";
+
         // General IDW10000 = "IDW10000:"
         public const string HttpContextIsNull = "IDW10001: HttpContext is null. ";
         public const string HttpContextAndHttpResponseAreNull = "IDW10002: Current HttpContext and HttpResponse arguments are null. Pass an HttpResponse argument. ";

--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapter.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.DataProtection;
@@ -9,6 +11,7 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 {
@@ -29,6 +32,8 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         private readonly string _distributedCacheType = "DistributedCache"; // for logging
         private readonly string _memoryCacheType = "MemoryCache"; // for logging
         private const string DefaultPurpose = "msal_cache";
+        private readonly ConcurrentDictionary<string, object> _failedL2CacheRemovals =
+            new ConcurrentDictionary<string, object>();
 
         /// <summary>
         /// MSAL distributed token cache options.
@@ -115,6 +120,9 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                 throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCacheMessage);
             }
 
+            object removalMarker = new object();
+            _failedL2CacheRemovals[cacheKey] = removalMarker;
+
             if (_memoryCache != null)
             {
                 _memoryCache.Remove(cacheKey);
@@ -122,10 +130,8 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                 Logger.MemoryCacheRemove(_logger, _memoryCacheType, remove, cacheKey, null);
             }
 
-            await L2OperationWithRetryOnFailureAsync(
-                remove,
-                (cacheKey) => _distributedCache.RemoveAsync(cacheKey, cacheSerializerHints.CancellationToken),
-                cacheKey).ConfigureAwait(false);
+            await RemoveFromL2CacheAsync(cacheKey, cacheSerializerHints.CancellationToken).ConfigureAwait(false);
+            RemoveFailedRemovalIfCurrent(cacheKey, removalMarker);
         }
 
         /// <summary>
@@ -157,6 +163,12 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             if (!string.IsNullOrEmpty(cacheSerializerHints.ShouldNotUseDistributedCacheMessage))
             {
                 throw new InvalidOperationException(TokenCacheErrorMessage.CannotUseDistributedCache + " " + cacheSerializerHints?.ShouldNotUseDistributedCacheMessage);
+            }
+
+            if (_failedL2CacheRemovals.TryGetValue(cacheKey, out _))
+            {
+                _memoryCache?.Remove(cacheKey);
+                return null;
             }
 
             if (_memoryCache != null)
@@ -192,6 +204,12 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                     // back propagate to memory cache
                     if (result != null)
                     {
+                        if (_failedL2CacheRemovals.TryGetValue(cacheKey, out _))
+                        {
+                            _memoryCache.Remove(cacheKey);
+                            return null;
+                        }
+
                         MemoryCacheEntryOptions memoryCacheEntryOptions = new MemoryCacheEntryOptions
                         {
                             AbsoluteExpirationRelativeToNow = _memoryCacheExpirationTime,
@@ -200,8 +218,20 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 
                         Logger.BackPropagateL2toL1(_logger, memoryCacheEntryOptions.Size ?? 0);
                         _memoryCache.Set(cacheKey, result, memoryCacheEntryOptions);
+                        if (_failedL2CacheRemovals.TryGetValue(cacheKey, out _))
+                        {
+                            _memoryCache.Remove(cacheKey);
+                            return null;
+                        }
+
                         Logger.MemoryCacheCount(_logger, _memoryCacheType, read, _memoryCache.Count);
                     }
+                }
+
+                if (_failedL2CacheRemovals.TryGetValue(cacheKey, out _))
+                {
+                    _memoryCache?.Remove(cacheKey);
+                    return null;
                 }
             }
             else
@@ -211,6 +241,12 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                        (cacheKey) => _distributedCache.RefreshAsync(cacheKey, cacheSerializerHints.CancellationToken),
                        cacheKey,
                        result!).ConfigureAwait(false);
+
+                if (_failedL2CacheRemovals.TryGetValue(cacheKey, out _))
+                {
+                    _memoryCache?.Remove(cacheKey);
+                    return null;
+                }
 
                 if (telemetryData != null)
                 {
@@ -247,6 +283,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
             CacheSerializerHints? cacheSerializerHints)
         {
             const string write = "Write";
+            _failedL2CacheRemovals.TryGetValue(cacheKey, out object? failedRemovalAtInvocation);
 
             DateTimeOffset? cacheExpiry = cacheSerializerHints?.SuggestedCacheExpiry;
 
@@ -285,7 +322,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
 
             if (_distributedCacheOptions.DisableL1Cache || !_distributedCacheOptions.EnableAsyncL2Write)
             {
-                await L2OperationWithRetryOnFailureAsync(
+                var writeMeasure = await L2OperationWithRetryOnFailureAsync(
                     write,
                     (cacheKey) => _distributedCache.SetAsync(
                         cacheKey,
@@ -295,23 +332,27 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                         cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
                     cacheKey,
                     bytes!).MeasureAsync().ConfigureAwait(false);
+                ClearFailedRemovalAfterConfirmedWrite(cacheKey, failedRemovalAtInvocation, writeMeasure.Result);
             }
             else
             {
-                _ = Task.Run(async () => await
-                 L2OperationWithRetryOnFailureAsync(
-                 write,
-                 (cacheKey) => _distributedCache.SetAsync(
-                     cacheKey,
-                     bytes!,
-                     distributedCacheEntryOptions,
-                     cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
-                 cacheKey,
-                 bytes!).MeasureAsync().ConfigureAwait(false));
+                _ = Task.Run(async () =>
+                {
+                    var writeMeasure = await L2OperationWithRetryOnFailureAsync(
+                        write,
+                        (cacheKey) => _distributedCache.SetAsync(
+                            cacheKey,
+                            bytes!,
+                            distributedCacheEntryOptions,
+                            cacheSerializerHints?.CancellationToken ?? CancellationToken.None),
+                        cacheKey,
+                        bytes!).MeasureAsync().ConfigureAwait(false);
+                    ClearFailedRemovalAfterConfirmedWrite(cacheKey, failedRemovalAtInvocation, writeMeasure.Result);
+                });
             }
         }
 
-        private async Task L2OperationWithRetryOnFailureAsync(
+        private async Task<bool> L2OperationWithRetryOnFailureAsync(
             string operation,
             Func<string, Task> cacheOperation,
             string cacheKey,
@@ -329,6 +370,7 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                     bytes?.Length ?? 0,
                     inRetry,
                     measure.MilliSeconds);
+                return true;
             }
             catch (Exception ex)
             {
@@ -343,14 +385,107 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
                 if (_distributedCacheOptions.OnL2CacheFailure != null && _distributedCacheOptions.OnL2CacheFailure(ex) && !inRetry)
                 {
                     Logger.DistributedCacheRetry(_logger, _distributedCacheType, operation, cacheKey, null);
-                    await L2OperationWithRetryOnFailureAsync(
+                    return await L2OperationWithRetryOnFailureAsync(
                         operation,
                         cacheOperation,
                         cacheKey,
                         bytes,
                         true).ConfigureAwait(false);
                 }
+
+                return false;
             }
+        }
+
+        private async Task RemoveFromL2CacheAsync(string cacheKey, CancellationToken cancellationToken)
+        {
+            const string remove = "Remove";
+
+            try
+            {
+                await RemoveFromL2CacheAsync(cacheKey, false, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception initialException)
+            {
+                Logger.DistributedCacheConnectionError(
+                    _logger,
+                    _distributedCacheType,
+                    remove,
+                    false,
+                    initialException.Message,
+                    initialException);
+
+                if (_distributedCacheOptions.OnL2CacheFailure?.Invoke(initialException) != true)
+                {
+                    throw CreateRemovalFailure(initialException);
+                }
+
+                Logger.DistributedCacheRetry(_logger, _distributedCacheType, remove, cacheKey, null);
+                try
+                {
+                    await RemoveFromL2CacheAsync(cacheKey, true, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception retryException)
+                {
+                    Logger.DistributedCacheConnectionError(
+                        _logger,
+                        _distributedCacheType,
+                        remove,
+                        true,
+                        retryException.Message,
+                        retryException);
+                    throw CreateRemovalFailure(retryException);
+                }
+            }
+        }
+
+        private async Task RemoveFromL2CacheAsync(
+            string cacheKey,
+            bool inRetry,
+            CancellationToken cancellationToken)
+        {
+            var measure = await _distributedCache.RemoveAsync(cacheKey, cancellationToken).MeasureAsync().ConfigureAwait(false);
+            Logger.DistributedCacheStateWithTime(
+                _logger,
+                _distributedCacheType,
+                "Remove",
+                cacheKey,
+                0,
+                inRetry,
+                measure.MilliSeconds);
+        }
+
+        private static MsalClientException CreateRemovalFailure(Exception innerException)
+        {
+            return new MsalClientException(
+                TokenCacheErrorMessage.L2CacheRemovalFailedErrorCode,
+                TokenCacheErrorMessage.L2CacheRemovalFailed,
+                innerException);
+        }
+
+        private void ClearFailedRemovalAfterConfirmedWrite(
+            string cacheKey,
+            object? failedRemovalAtInvocation,
+            bool writeConfirmed)
+        {
+            if (writeConfirmed && failedRemovalAtInvocation != null)
+            {
+                RemoveFailedRemovalIfCurrent(cacheKey, failedRemovalAtInvocation);
+            }
+        }
+
+        private void RemoveFailedRemovalIfCurrent(string cacheKey, object failedRemoval)
+        {
+            ((ICollection<KeyValuePair<string, object>>)_failedL2CacheRemovals)
+                .Remove(new KeyValuePair<string, object>(cacheKey, failedRemoval));
         }
 
         private async Task<byte[]?> L2OperationWithRetryOnFailureAsync(

--- a/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapterOptions.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/Distributed/MsalDistributedTokenCacheAdapterOptions.cs
@@ -30,8 +30,12 @@ namespace Microsoft.Identity.Web.TokenCacheProviders.Distributed
         /// for instance, in the case of Redis exception, to reconnect. This is left to the application as it's
         /// the only one that knows about the real implementation of the L2 cache.
         /// The handler should return <c>true</c> if the cache should try the operation again, and
-        /// <c>false</c> otherwise. When <c>true</c> is passed and the retry fails, an exception
-        /// will be thrown.
+        /// <c>false</c> otherwise. Read, refresh, and write failures remain fail-open. For removal,
+        /// caller cancellation bypasses this callback, other failures invoke it once, and
+        /// <c>true</c> requests one retry. Callback exceptions propagate. An unconfirmed removal
+        /// suppresses process-local reads for that key until a later removal, or a later write
+        /// that observed the failed removal, is confirmed. This does not order successful removals
+        /// against ordinary L2 reads already in progress.
         /// </summary>
         public Func<Exception, bool>? OnL2CacheFailure { get; set; }
 

--- a/src/Microsoft.Identity.Web.TokenCache/TokenCacheErrorMessage.cs
+++ b/src/Microsoft.Identity.Web.TokenCache/TokenCacheErrorMessage.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Identity.Web
         public const string InitializeAsyncIsObsolete = "IDW10801: Use Initialize instead. See https://aka.ms/ms-id-web/1.9.0. ";
         public const string ExceptionDeserializingCache = "IDW10802: Exception occurred while deserializing token cache. See https://aka.ms/msal-net-token-cache-serialization general guidance and https://aka.ms/ms-id-web/token-cache-troubleshooting for token cache troubleshooting information.";
         public const string CannotUseDistributedCache = "IDW10803: Cannot use distributed cache for the current configuration. Use an in memory cache instead.";
+        public const string L2CacheRemovalFailedErrorCode = "idw_l2_cache_removal_failed";
+        public const string L2CacheRemovalFailed = "IDW10805: Removal of the distributed token cache entry could not be confirmed.";
     }
 }

--- a/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
+++ b/src/Microsoft.Identity.Web/WebAppExtensions/MicrosoftIdentityWebAppAuthenticationBuilder.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Client;
@@ -217,7 +218,17 @@ namespace Microsoft.Identity.Web
                        {
                            // Remove the account from MSAL.NET token cache
                            var tokenAcquisition = context!.HttpContext.RequestServices.GetRequiredService<ITokenAcquisitionInternal>();
-                           await tokenAcquisition.RemoveAccountAsync(context!.HttpContext.User, openIdConnectScheme).ConfigureAwait(false);
+                           try
+                           {
+                               await tokenAcquisition.RemoveAccountAsync(context!.HttpContext.User, openIdConnectScheme).ConfigureAwait(false);
+                           }
+                           catch (MsalClientException ex) when (ex.ErrorCode == IDWebErrorMessage.L2CacheRemovalFailedErrorCode)
+                           {
+                               context.HttpContext.RequestServices
+                                   .GetService<ILogger<MicrosoftIdentityWebAppAuthenticationBuilder>>()?
+                                   .LogWarning(ex, "The distributed token cache entry could not be removed. OpenID Connect sign-out will continue.");
+                           }
+
                            await signOutHandler(context).ConfigureAwait(false);
                        };
                    });

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -780,6 +780,60 @@ namespace Microsoft.Identity.Web.Test
             Assert.Equal(0, GetFailedRemovalCount(adapter));
         }
 
+#pragma warning disable VSTHRD003 // The fire-and-forget L2 write is deliberately coordinated by the test.
+        [Fact]
+        public async Task AsyncL2Write_ConfirmedCompletionClearsFailedRemovalMarkerAsync()
+        {
+            // Arrange
+            var (adapter, cache, options) = CreateAdapter();
+            options.EnableAsyncL2Write = true;
+            cache.RemoveAsyncOverride = (_, _) => Task.FromException(new InvalidOperationException("remove failed"));
+            await Assert.ThrowsAsync<MsalClientException>(() => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+            Assert.Equal(1, GetFailedRemovalCount(adapter));
+
+            int getCalls = 0;
+            cache.GetAsyncOverride = (key, _) =>
+            {
+                Interlocked.Increment(ref getCalls);
+                return Task.FromResult(cache.Get(key));
+            };
+            TaskCompletionSource<object?> setStarted = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object?> releaseSet = new TaskCompletionSource<object?>();
+            TaskCompletionSource<object?> setCompleted = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            cache.SetAsyncOverride = async (key, value, entryOptions, _) =>
+            {
+                setStarted.SetResult(null);
+                await releaseSet.Task;
+                cache.Set(key, value, entryOptions);
+                setCompleted.SetResult(null);
+            };
+
+            // Act
+            Task writeCall = adapter.TestWriteCacheBytesAsync(DefaultCacheKey, new byte[] { 8 });
+            await writeCall;
+            await setStarted.Task;
+
+            // Assert while L2 write is blocked
+            Assert.False(setCompleted.Task.IsCompleted);
+            Assert.Null(await adapter.TestReadCacheBytesAsync(DefaultCacheKey));
+            Assert.Equal(0, getCalls);
+            Assert.Equal(1, GetFailedRemovalCount(adapter));
+
+            // Act after confirmed L2 completion
+            releaseSet.SetResult(null);
+            await setCompleted.Task;
+            await WaitForFailedRemovalCountAsync(adapter, 0);
+            byte[]? result = await adapter.TestReadCacheBytesAsync(DefaultCacheKey);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(8, result[0]);
+            Assert.Equal(1, getCalls);
+        }
+#pragma warning restore VSTHRD003
+
         [Fact]
         public async Task OrdinaryReadAndWrite_DoNotCreateFailedRemovalMarkersAsync()
         {
@@ -851,6 +905,23 @@ namespace Microsoft.Identity.Web.Test
                 "_failedL2CacheRemovals",
                 BindingFlags.Instance | BindingFlags.NonPublic)!;
             return ((ConcurrentDictionary<string, object>)field.GetValue(adapter)!).Count;
+        }
+
+        private static async Task WaitForFailedRemovalCountAsync(
+            TestMsalDistributedTokenCacheAdapter adapter,
+            int expectedCount)
+        {
+            for (int attempt = 0; attempt < 1000; attempt++)
+            {
+                if (GetFailedRemovalCount(adapter) == expectedCount)
+                {
+                    return;
+                }
+
+                await Task.Yield();
+            }
+
+            Assert.Equal(expectedCount, GetFailedRemovalCount(adapter));
         }
 
         private static (

--- a/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/L1L2CacheTests.cs
@@ -2,12 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.TelemetryCore.TelemetryClient;
 using Microsoft.Identity.Web.Test.Common.TestHelpers;
@@ -392,6 +396,404 @@ namespace Microsoft.Identity.Web.Test
             Assert.Empty(L2Cache._dict);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RemoveFailure_ThrowsAndBlocksReadsAsync(bool disableL1Cache)
+        {
+            // Arrange
+            InvalidOperationException removalException = new InvalidOperationException("remove failed");
+            var (adapter, cache, _) = CreateAdapter(disableL1Cache);
+            cache.Set(DefaultCacheKey, new byte[] { 1 });
+            cache.RemoveAsyncOverride = (_, _) => Task.FromException(removalException);
+
+            // Act
+            MsalClientException exception = await Assert.ThrowsAsync<MsalClientException>(
+                () => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+            cache.GetAsyncOverride = (_, _) => throw new Xunit.Sdk.XunitException("L2 read should be blocked.");
+            byte[]? result = await adapter.TestReadCacheBytesAsync(DefaultCacheKey);
+
+            // Assert
+            Assert.Equal(TokenCacheErrorMessage.L2CacheRemovalFailedErrorCode, exception.ErrorCode);
+            Assert.Same(removalException, exception.InnerException);
+            Assert.Null(result);
+            Assert.Null(adapter._memoryCache?.Get(DefaultCacheKey));
+        }
+
+        [Fact]
+        public async Task RemoveFailure_CallbackFalseIsCalledOnceWithoutRetryAsync()
+        {
+            // Arrange
+            int attempts = 0;
+            int callbackCalls = 0;
+            var (adapter, cache, options) = CreateAdapter();
+            options.OnL2CacheFailure = _ =>
+            {
+                callbackCalls++;
+                return false;
+            };
+            cache.RemoveAsyncOverride = (_, _) =>
+            {
+                attempts++;
+                return Task.FromException(new InvalidOperationException("remove failed"));
+            };
+
+            // Act
+            MsalClientException exception = await Assert.ThrowsAsync<MsalClientException>(
+                () => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+
+            // Assert
+            Assert.Equal(TokenCacheErrorMessage.L2CacheRemovalFailedErrorCode, exception.ErrorCode);
+            Assert.Equal(1, attempts);
+            Assert.Equal(1, callbackCalls);
+        }
+
+        [Fact]
+        public async Task RemoveFailure_CallbackTrueRetriesOnceAsync()
+        {
+            // Arrange
+            int attempts = 0;
+            int callbackCalls = 0;
+            var (adapter, cache, options) = CreateAdapter();
+            cache.Set(DefaultCacheKey, new byte[] { 1 });
+            options.OnL2CacheFailure = _ =>
+            {
+                callbackCalls++;
+                return true;
+            };
+            cache.RemoveAsyncOverride = (key, _) =>
+            {
+                attempts++;
+                if (attempts == 1)
+                {
+                    return Task.FromException(new InvalidOperationException("remove failed"));
+                }
+
+                cache.Remove(key);
+                return Task.CompletedTask;
+            };
+
+            // Act
+            await adapter.TestRemoveKeyAsync(DefaultCacheKey);
+
+            // Assert
+            Assert.Equal(2, attempts);
+            Assert.Equal(1, callbackCalls);
+            Assert.Null(await adapter.TestReadCacheBytesAsync(DefaultCacheKey));
+        }
+
+        [Fact]
+        public async Task RemoveRetryFailure_ThrowsFinalFailureAsync()
+        {
+            // Arrange
+            int attempts = 0;
+            int callbackCalls = 0;
+            InvalidOperationException retryException = new InvalidOperationException("retry failed");
+            var (adapter, cache, options) = CreateAdapter();
+            options.OnL2CacheFailure = _ =>
+            {
+                callbackCalls++;
+                return true;
+            };
+            cache.RemoveAsyncOverride = (_, _) =>
+            {
+                attempts++;
+                return Task.FromException(
+                    attempts == 1 ? new InvalidOperationException("remove failed") : retryException);
+            };
+
+            // Act
+            MsalClientException exception = await Assert.ThrowsAsync<MsalClientException>(
+                () => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+
+            // Assert
+            Assert.Equal(2, attempts);
+            Assert.Equal(1, callbackCalls);
+            Assert.Same(retryException, exception.InnerException);
+        }
+
+        [Fact]
+        public async Task RemoveFailure_CallbackExceptionPropagatesAsync()
+        {
+            // Arrange
+            ApplicationException callbackException = new ApplicationException("callback failed");
+            var (adapter, cache, options) = CreateAdapter();
+            options.OnL2CacheFailure = _ => throw callbackException;
+            cache.RemoveAsyncOverride = (_, _) => Task.FromException(new InvalidOperationException("remove failed"));
+
+            // Act
+            ApplicationException exception = await Assert.ThrowsAsync<ApplicationException>(
+                () => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+
+            // Assert
+            Assert.Same(callbackException, exception);
+            cache.GetAsyncOverride = (_, _) => throw new Xunit.Sdk.XunitException("L2 read should be blocked.");
+            Assert.Null(await adapter.TestReadCacheBytesAsync(DefaultCacheKey));
+        }
+
+        [Fact]
+        public async Task RemoveCancellation_PropagatesWithoutCallbackOrRetryAsync()
+        {
+            // Arrange
+            int attempts = 0;
+            int callbackCalls = 0;
+            var (adapter, cache, options) = CreateAdapter();
+            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            await cancellationTokenSource.CancelAsync();
+            OperationCanceledException expectedException = new OperationCanceledException(
+                "caller canceled",
+                innerException: null,
+                cancellationTokenSource.Token);
+            options.OnL2CacheFailure = _ =>
+            {
+                callbackCalls++;
+                return true;
+            };
+            cache.RemoveAsyncOverride = (_, _) =>
+            {
+                attempts++;
+                return Task.FromException(expectedException);
+            };
+            CacheSerializerHints hints = new CacheSerializerHints
+            {
+                CancellationToken = cancellationTokenSource.Token,
+            };
+
+            // Act
+            OperationCanceledException exception = await Assert.ThrowsAsync<OperationCanceledException>(
+                () => adapter.TestRemoveKeyAsync(DefaultCacheKey, hints));
+
+            // Assert
+            Assert.Same(expectedException, exception);
+            Assert.Equal(1, attempts);
+            Assert.Equal(0, callbackCalls);
+            cache.GetAsyncOverride = (_, _) => throw new Xunit.Sdk.XunitException("L2 read should be blocked.");
+            Assert.Null(await adapter.TestReadCacheBytesAsync(DefaultCacheKey));
+        }
+
+#pragma warning disable VSTHRD003 // The tasks are deliberately coordinated to exercise overlapping removals.
+        [Fact]
+        public async Task OlderSuccessfulRemoval_DoesNotClearNewerFailedRemovalMarkerAsync()
+        {
+            // Arrange
+            var (adapter, cache, _) = CreateAdapter();
+            int attempts = 0;
+            TaskCompletionSource<object?> firstAttemptStarted = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object?> releaseFirstAttempt = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            cache.RemoveAsyncOverride = async (key, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                {
+                    firstAttemptStarted.SetResult(null);
+                    await releaseFirstAttempt.Task;
+                    cache.Remove(key);
+                    return;
+                }
+
+                throw new InvalidOperationException("newer removal failed");
+            };
+
+            // Act
+            Task olderRemoval = adapter.TestRemoveKeyAsync(DefaultCacheKey);
+            await firstAttemptStarted.Task;
+            await Assert.ThrowsAsync<MsalClientException>(() => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+            releaseFirstAttempt.SetResult(null);
+            await olderRemoval;
+            cache.GetAsyncOverride = (_, _) => throw new Xunit.Sdk.XunitException("L2 read should be blocked.");
+            byte[]? result = await adapter.TestReadCacheBytesAsync(DefaultCacheKey);
+
+            // Assert
+            Assert.Equal(2, attempts);
+            Assert.Null(result);
+            Assert.Equal(1, GetFailedRemovalCount(adapter));
+        }
+
+        [Fact]
+        public async Task OlderFailedRemoval_DoesNotPublishAfterNewerSuccessfulRemovalAsync()
+        {
+            // Arrange
+            var (adapter, cache, _) = CreateAdapter();
+            int attempts = 0;
+            TaskCompletionSource<object?> firstAttemptStarted = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object?> releaseFirstAttempt = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            cache.RemoveAsyncOverride = async (key, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                {
+                    firstAttemptStarted.SetResult(null);
+                    await releaseFirstAttempt.Task;
+                    throw new InvalidOperationException("older removal failed");
+                }
+
+                cache.Remove(key);
+            };
+
+            // Act
+            Task olderRemoval = adapter.TestRemoveKeyAsync(DefaultCacheKey);
+            await firstAttemptStarted.Task;
+            await adapter.TestRemoveKeyAsync(DefaultCacheKey);
+            releaseFirstAttempt.SetResult(null);
+            await Assert.ThrowsAsync<MsalClientException>(() => olderRemoval);
+            cache.Set(DefaultCacheKey, new byte[] { 6 });
+            byte[]? result = await adapter.TestReadCacheBytesAsync(DefaultCacheKey);
+
+            // Assert
+            Assert.Equal(2, attempts);
+            Assert.NotNull(result);
+            Assert.Equal(6, result[0]);
+            Assert.Equal(0, GetFailedRemovalCount(adapter));
+        }
+#pragma warning restore VSTHRD003
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ReadStartedBeforeFailedRemoval_DoesNotReturnOrBackfillAsync(bool useL1)
+        {
+            // Arrange
+            var (adapter, cache, _) = CreateAdapter();
+            SemaphoreSlim readStarted = new SemaphoreSlim(0, 1);
+            SemaphoreSlim releaseRead = new SemaphoreSlim(0, 1);
+            if (useL1)
+            {
+                adapter._memoryCache!.Set(
+                    DefaultCacheKey,
+                    new byte[] { 1 },
+                    new MemoryCacheEntryOptions { Size = 1 });
+                cache.RefreshAsyncOverride = async (_, _) =>
+                {
+                    readStarted.Release();
+                    await releaseRead.WaitAsync();
+                };
+            }
+            else
+            {
+                cache.GetAsyncOverride = async (_, _) =>
+                {
+                    readStarted.Release();
+                    await releaseRead.WaitAsync();
+                    return new byte[] { 1 };
+                };
+            }
+
+            // Act
+            Task<byte[]?> read = adapter.TestReadCacheBytesAsync(DefaultCacheKey);
+            await readStarted.WaitAsync();
+            cache.RemoveAsyncOverride = (_, _) => Task.FromException(new InvalidOperationException("remove failed"));
+            await Assert.ThrowsAsync<MsalClientException>(() => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+            releaseRead.Release();
+            byte[]? result = await read;
+
+            // Assert
+            Assert.Null(result);
+            Assert.Null(adapter._memoryCache!.Get(DefaultCacheKey));
+        }
+
+        [Fact]
+        public async Task WriteStartedBeforeFailedRemoval_DoesNotClearNewerRemovalMarkerAsync()
+        {
+            // Arrange
+            var (adapter, cache, options) = CreateAdapter();
+            options.EnableAsyncL2Write = false;
+            SemaphoreSlim writeStarted = new SemaphoreSlim(0, 1);
+            SemaphoreSlim releaseWrite = new SemaphoreSlim(0, 1);
+            cache.SetAsyncOverride = async (key, value, entryOptions, _) =>
+            {
+                writeStarted.Release();
+                await releaseWrite.WaitAsync();
+                cache.Set(key, value, entryOptions);
+            };
+
+            // Act
+            Task write = adapter.TestWriteCacheBytesAsync(DefaultCacheKey, new byte[] { 2 });
+            await writeStarted.WaitAsync();
+            cache.RemoveAsyncOverride = (_, _) => Task.FromException(new InvalidOperationException("remove failed"));
+            await Assert.ThrowsAsync<MsalClientException>(() => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+            releaseWrite.Release();
+            await write;
+            cache.GetAsyncOverride = (_, _) => throw new Xunit.Sdk.XunitException("L2 read should be blocked.");
+            byte[]? result = await adapter.TestReadCacheBytesAsync(DefaultCacheKey);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task ConfirmedWrite_ClearsOnlyMarkerObservedAtInvocationAsync()
+        {
+            // Arrange
+            var (adapter, cache, options) = CreateAdapter();
+            options.EnableAsyncL2Write = false;
+            cache.RemoveAsyncOverride = (_, _) => Task.FromException(new InvalidOperationException("remove failed"));
+            await Assert.ThrowsAsync<MsalClientException>(() => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+            SemaphoreSlim writeStarted = new SemaphoreSlim(0, 1);
+            SemaphoreSlim releaseWrite = new SemaphoreSlim(0, 1);
+            cache.SetAsyncOverride = async (key, value, entryOptions, _) =>
+            {
+                writeStarted.Release();
+                await releaseWrite.WaitAsync();
+                cache.Set(key, value, entryOptions);
+            };
+
+            // Act
+            Task write = adapter.TestWriteCacheBytesAsync(DefaultCacheKey, new byte[] { 3 });
+            await writeStarted.WaitAsync();
+            await Assert.ThrowsAsync<MsalClientException>(() => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+            releaseWrite.Release();
+            await write;
+            cache.GetAsyncOverride = (_, _) => throw new Xunit.Sdk.XunitException("L2 read should be blocked.");
+            byte[]? result = await adapter.TestReadCacheBytesAsync(DefaultCacheKey);
+
+            // Assert
+            Assert.Null(result);
+            Assert.Equal(1, GetFailedRemovalCount(adapter));
+        }
+
+        [Fact]
+        public async Task ConfirmedWriteAndLaterRemoval_ClearFailedRemovalMarkerAsync()
+        {
+            // Arrange
+            var (adapter, cache, options) = CreateAdapter();
+            options.EnableAsyncL2Write = false;
+            cache.RemoveAsyncOverride = (_, _) => Task.FromException(new InvalidOperationException("remove failed"));
+            await Assert.ThrowsAsync<MsalClientException>(() => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+
+            // Act and assert confirmed write recovery
+            await adapter.TestWriteCacheBytesAsync(DefaultCacheKey, new byte[] { 4 });
+            Assert.Equal(4, (await adapter.TestReadCacheBytesAsync(DefaultCacheKey))![0]);
+            Assert.Equal(0, GetFailedRemovalCount(adapter));
+
+            // Act and assert confirmed later removal recovery
+            cache.RemoveAsyncOverride = (_, _) => Task.FromException(new InvalidOperationException("remove failed"));
+            await Assert.ThrowsAsync<MsalClientException>(() => adapter.TestRemoveKeyAsync(DefaultCacheKey));
+            Assert.Equal(1, GetFailedRemovalCount(adapter));
+            cache.RemoveAsyncOverride = null;
+            await adapter.TestRemoveKeyAsync(DefaultCacheKey);
+            cache.Set(DefaultCacheKey, new byte[] { 5 });
+
+            // Assert
+            Assert.Equal(5, (await adapter.TestReadCacheBytesAsync(DefaultCacheKey))![0]);
+            Assert.Equal(0, GetFailedRemovalCount(adapter));
+        }
+
+        [Fact]
+        public async Task OrdinaryReadAndWrite_DoNotCreateFailedRemovalMarkersAsync()
+        {
+            // Arrange
+            var (adapter, _, _) = CreateAdapter();
+
+            // Act
+            Assert.Null(await adapter.TestReadCacheBytesAsync(DefaultCacheKey));
+            await adapter.TestWriteCacheBytesAsync(AnotherCacheKey, new byte[] { 1 });
+
+            // Assert
+            Assert.Equal(0, GetFailedRemovalCount(adapter));
+        }
+
 
         [Fact]
         public async Task SetLCache_ThrowIf_ShouldNotUseDistributedCache_TestAsync()
@@ -441,6 +843,32 @@ namespace Microsoft.Identity.Web.Test
         private static IDistributedCache MakeMockDistributedCache()
         {
             return new TestDistributedCache();
+        }
+
+        private static int GetFailedRemovalCount(TestMsalDistributedTokenCacheAdapter adapter)
+        {
+            FieldInfo field = typeof(MsalDistributedTokenCacheAdapter).GetField(
+                "_failedL2CacheRemovals",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return ((ConcurrentDictionary<string, object>)field.GetValue(adapter)!).Count;
+        }
+
+        private static (
+            TestMsalDistributedTokenCacheAdapter Adapter,
+            TestDistributedCache Cache,
+            MsalDistributedTokenCacheAdapterOptions Options) CreateAdapter(bool disableL1Cache = false)
+        {
+            TestDistributedCache cache = new TestDistributedCache();
+            MsalDistributedTokenCacheAdapterOptions options = new MsalDistributedTokenCacheAdapterOptions
+            {
+                DisableL1Cache = disableL1Cache,
+            };
+            ServiceProvider provider = new ServiceCollection().AddLogging().BuildServiceProvider();
+            TestMsalDistributedTokenCacheAdapter adapter = new TestMsalDistributedTokenCacheAdapter(
+                cache,
+                Microsoft.Extensions.Options.Options.Create(options),
+                provider.GetRequiredService<ILogger<MsalDistributedTokenCacheAdapter>>());
+            return (adapter, cache, options);
         }
     }
 }

--- a/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
+++ b/tests/Microsoft.Identity.Web.Test/TestDistributedCache.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,10 @@ namespace Microsoft.Identity.Web.Test
     {
         internal readonly ConcurrentDictionary<string, Entry> _dict = new ConcurrentDictionary<string, Entry>();
         internal ManualResetEventSlim ResetEvent { get; set; } = new ManualResetEventSlim(initialState: false);
+        internal Func<string, CancellationToken, Task<byte[]?>>? GetAsyncOverride { get; set; }
+        internal Func<string, CancellationToken, Task>? RefreshAsyncOverride { get; set; }
+        internal Func<string, CancellationToken, Task>? RemoveAsyncOverride { get; set; }
+        internal Func<string, byte[], DistributedCacheEntryOptions, CancellationToken, Task>? SetAsyncOverride { get; set; }
 
         public byte[]? Get(string key)
         {
@@ -35,6 +40,11 @@ namespace Microsoft.Identity.Web.Test
 
         public Task<byte[]?> GetAsync(string key, CancellationToken token = default)
         {
+            if (GetAsyncOverride != null)
+            {
+                return GetAsyncOverride(key, token);
+            }
+
             return Task.FromResult(Get(key));
         }
 
@@ -45,6 +55,11 @@ namespace Microsoft.Identity.Web.Test
 
         public Task RefreshAsync(string key, CancellationToken token = default)
         {
+            if (RefreshAsyncOverride != null)
+            {
+                return RefreshAsyncOverride(key, token);
+            }
+
             Refresh(key);
             return Task.CompletedTask;
         }
@@ -56,6 +71,11 @@ namespace Microsoft.Identity.Web.Test
 
         public Task RemoveAsync(string key, CancellationToken token = default)
         {
+            if (RemoveAsyncOverride != null)
+            {
+                return RemoveAsyncOverride(key, token);
+            }
+
             Remove(key);
             return Task.CompletedTask;
         }
@@ -68,6 +88,11 @@ namespace Microsoft.Identity.Web.Test
 
         public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
         {
+            if (SetAsyncOverride != null)
+            {
+                return SetAsyncOverride(key, value, options, token);
+            }
+
             Set(key, value, options);
             return Task.CompletedTask;
         }

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -1163,6 +1163,82 @@ namespace Microsoft.Identity.Web.Test
             await tokenAcquisitionMock.ReceivedWithAnyArgs().RemoveAccountAsync(Arg.Any<ClaimsPrincipal>());
         }
 
+        [Fact]
+        public async Task SignOutCacheRemovalFailure_InvokesOriginalHandlerOnceAsync()
+        {
+            // Arrange
+            var tokenAcquisition = Substitute.For<ITokenAcquisitionInternal>();
+            var redirectHandler = Substitute.For<Func<RedirectContext, Task>>();
+            tokenAcquisition
+                .RemoveAccountAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<string?>())
+                .Returns(_ => throw new MsalClientException(
+                    IDWebErrorMessage.L2CacheRemovalFailedErrorCode,
+                    "cache removal failed"));
+            var (provider, options) = CreateSignOutServices(tokenAcquisition, redirectHandler);
+            var (httpContext, authScheme, authProperties) = CreateContextParameters(provider);
+
+            // Act
+            await options.Events.RedirectToIdentityProviderForSignOut(
+                new RedirectContext(httpContext, authScheme, options, authProperties));
+
+            // Assert
+            await tokenAcquisition.Received(1).RemoveAccountAsync(Arg.Any<ClaimsPrincipal>(), OidcScheme);
+            await redirectHandler.Received(1).Invoke(Arg.Any<RedirectContext>());
+        }
+
+        [Fact]
+        public async Task SignOutUnrelatedRemovalFailure_PropagatesWithoutInvokingOriginalHandlerAsync()
+        {
+            // Arrange
+            InvalidOperationException removalException = new InvalidOperationException("unrelated removal failure");
+            var tokenAcquisition = Substitute.For<ITokenAcquisitionInternal>();
+            var redirectHandler = Substitute.For<Func<RedirectContext, Task>>();
+            tokenAcquisition
+                .RemoveAccountAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<string?>())
+                .Returns(_ => throw removalException);
+            var (provider, options) = CreateSignOutServices(tokenAcquisition, redirectHandler);
+            var (httpContext, authScheme, authProperties) = CreateContextParameters(provider);
+
+            // Act
+            Exception? exception = await Record.ExceptionAsync(
+                () => options.Events.RedirectToIdentityProviderForSignOut(
+                    new RedirectContext(httpContext, authScheme, options, authProperties)));
+
+            // Assert
+            Assert.Same(removalException, exception);
+            await tokenAcquisition.Received(1).RemoveAccountAsync(Arg.Any<ClaimsPrincipal>(), OidcScheme);
+            await redirectHandler.DidNotReceive().Invoke(Arg.Any<RedirectContext>());
+        }
+
+        private (ServiceProvider Provider, OpenIdConnectOptions Options) CreateSignOutServices(
+            ITokenAcquisitionInternal tokenAcquisition,
+            Func<RedirectContext, Task> redirectHandler)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton((provider) => _env)
+                .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+            services.AddAuthentication()
+                .AddMicrosoftIdentityWebApp(
+                    options =>
+                    {
+                        _configureMsOptions(options);
+                        options.Events.OnRedirectToIdentityProviderForSignOut = redirectHandler;
+                    },
+                    null,
+                    OidcScheme)
+                .EnableTokenAcquisitionToCallDownstreamApi(new[] { "custom_scope" });
+            services.RemoveAll<ITokenAcquisition>();
+            services.RemoveAll<ITokenAcquisitionInternal>();
+            services.AddScoped<ITokenAcquisition>(_ => tokenAcquisition);
+            services.AddScoped<ITokenAcquisitionInternal>(_ => tokenAcquisition);
+
+            ServiceProvider provider = services.BuildServiceProvider();
+            OpenIdConnectOptions options = provider
+                .GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>()
+                .Get(OidcScheme);
+            return (provider, options);
+        }
+
         private (HttpContext, AuthenticationScheme, AuthenticationProperties) CreateContextParameters(IServiceProvider provider, IEnumerable<Claim>? claims = null)
         {
             var httpContext = claims != null ? HttpContextUtilities.CreateHttpContext(claims) : HttpContextUtilities.CreateHttpContext();

--- a/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
+++ b/tests/Microsoft.Identity.Web.Test/WebAppExtensionsTests.cs
@@ -27,6 +27,7 @@ using Microsoft.Identity.Web.Resource;
 using Microsoft.Identity.Web.Test.Common;
 using Microsoft.Identity.Web.Test.Common.TestHelpers;
 using Microsoft.Identity.Web.TokenCacheProviders;
+using Microsoft.Identity.Web.TokenCacheProviders.Distributed;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 using Microsoft.Identity.Web.Util;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -1169,12 +1170,21 @@ namespace Microsoft.Identity.Web.Test
             // Arrange
             var tokenAcquisition = Substitute.For<ITokenAcquisitionInternal>();
             var redirectHandler = Substitute.For<Func<RedirectContext, Task>>();
+            var (provider, options) = CreateSignOutServices(tokenAcquisition, redirectHandler);
+            TestDistributedCache cache = new TestDistributedCache();
+            int removalAttempts = 0;
+            cache.RemoveAsyncOverride = (_, _) =>
+            {
+                removalAttempts++;
+                return Task.FromException(new InvalidOperationException("cache removal failed"));
+            };
+            TestMsalDistributedTokenCacheAdapter adapter = new TestMsalDistributedTokenCacheAdapter(
+                cache,
+                Microsoft.Extensions.Options.Options.Create(new MsalDistributedTokenCacheAdapterOptions()),
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<MsalDistributedTokenCacheAdapter>.Instance);
             tokenAcquisition
                 .RemoveAccountAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<string?>())
-                .Returns(_ => throw new MsalClientException(
-                    IDWebErrorMessage.L2CacheRemovalFailedErrorCode,
-                    "cache removal failed"));
-            var (provider, options) = CreateSignOutServices(tokenAcquisition, redirectHandler);
+                .Returns(_ => adapter.TestRemoveKeyAsync("sign-out-cache-key"));
             var (httpContext, authScheme, authProperties) = CreateContextParameters(provider);
 
             // Act
@@ -1182,6 +1192,7 @@ namespace Microsoft.Identity.Web.Test
                 new RedirectContext(httpContext, authScheme, options, authProperties));
 
             // Assert
+            Assert.Equal(1, removalAttempts);
             await tokenAcquisition.Received(1).RemoveAccountAsync(Arg.Any<ClaimsPrincipal>(), OidcScheme);
             await redirectHandler.Received(1).Invoke(Arg.Any<RedirectContext>());
         }


### PR DESCRIPTION
## Summary

- Surface exhausted distributed token-cache removal failures to direct callers.
- Suppress same-adapter reads of an unresolved entry until a later removal or write succeeds.
- Allow the existing sign-out redirect handler to continue after the specific removal failure.

## Release notes

Direct distributed token-cache removal calls now surface an error after removal and
its configured retry fail. OpenID Connect sign-out logs this specific error and
continues the existing redirect handler.

## Testing

- 81 focused tests passed on each of .NET 8, .NET 9, and .NET 10.
