### PR TITLE
Update Clone isolation test for Abstractions 12.6.1

### DIFF
--- a/tests/E2E Tests/Sidecar.Tests/SidecarOptionsIsolationTests.cs
+++ b/tests/E2E Tests/Sidecar.Tests/SidecarOptionsIsolationTests.cs
@@ -32,7 +32,7 @@ public class SidecarOptionsIsolationTests : IDisposable
     private const string AgentIdentityKey = "IDWEB_AGENT_IDENTITY";
 
     [Fact]
-    public void Clone_IsShallow_OnSharedMutableCollections()
+    public void Clone_IsolatesSharedMutableCollections()
     {
         var original = new DownstreamApiOptions
         {
@@ -44,13 +44,16 @@ public class SidecarOptionsIsolationTests : IDisposable
 
         var clone = original.Clone();
 
+        // As of Microsoft.Identity.Abstractions 12.6.1, Clone() allocates independent
+        // containers for the mutable collections, so the clone can be overridden per
+        // request without mutating the original (shared) configuration instance.
         Assert.NotSame(original.AcquireTokenOptions, clone.AcquireTokenOptions);
-        Assert.Same(original.AcquireTokenOptions.ExtraParameters, clone.AcquireTokenOptions.ExtraParameters);
-        Assert.Same(original.ExtraHeaderParameters, clone.ExtraHeaderParameters);
-        Assert.Same(original.ExtraQueryParameters, clone.ExtraQueryParameters);
+        Assert.NotSame(original.AcquireTokenOptions.ExtraParameters, clone.AcquireTokenOptions.ExtraParameters);
+        Assert.NotSame(original.ExtraHeaderParameters, clone.ExtraHeaderParameters);
+        Assert.NotSame(original.ExtraQueryParameters, clone.ExtraQueryParameters);
 
         clone.AcquireTokenOptions.ExtraParameters!["k2"] = "v2";
-        Assert.True(original.AcquireTokenOptions.ExtraParameters!.ContainsKey("k2"));
+        Assert.False(original.AcquireTokenOptions.ExtraParameters!.ContainsKey("k2"));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Targets #4020. That PR bumps `MicrosoftIdentityAbstractionsVersion` to 12.6.1,
which changes `Clone()` / the copy constructors on `AcquireTokenOptions` and
`DownstreamApiOptions` to allocate independent containers for their mutable
collections (`ExtraParameters`, `ExtraQueryParameters`, `ExtraHeadersParameters`)
instead of copying the references
(AzureAD/microsoft-identity-abstractions-for-dotnet#269).

`SidecarOptionsIsolationTests.Clone_IsShallow_OnSharedMutableCollections` was
written to document the previous shared-reference behavior (it asserts
`Assert.Same` on the collections and that a write to the clone appears on the
original). Under 12.6.1 those assertions invert, so the test fails the
Build & Unit Tests run on #4020.

## Change

Rename the test to `Clone_IsolatesSharedMutableCollections` and assert the new
behavior: after `Clone()`, the mutable collections are `NotSame` and a write to
the clone does not appear on the original. The sibling
`CloneForRequest_ReallocatesSharedMutableCollections` test is unaffected (it
still re-allocates and still passes).

## Notes

- Test-only change; no product code touched.
- `DownstreamApiOptionsMerger.CloneForRequest` is now effectively belt-and-
  suspenders (the underlying `Clone()` already isolates), but it remains correct
  and is left as-is; simplifying it can be a separate follow-up.

## Testing

`SidecarOptionsIsolationTests` passes against 12.6.1 (net10.0). Core
`Microsoft.Identity.Web.Test` unit tests pass against 12.6.1 as well.
