### PR TITLE
Sidecar: validate Host header outside Development

### DIFF
--- a/src/Microsoft.Identity.Web.Sidecar/LocalCallerRestriction.cs
+++ b/src/Microsoft.Identity.Web.Sidecar/LocalCallerRestriction.cs
@@ -2,14 +2,17 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Identity.Web.Sidecar;
 
 /// <summary>
-/// Restricts the sidecar to callers connecting over the loopback interface
-/// (the co-located application), responding with 403 to other callers. The
-/// health endpoint is exempt so liveness/readiness probes, which target the
-/// pod's routable address, continue to work.
+/// Restricts the sidecar to its co-located application. Outside Development a
+/// request must originate from the loopback interface (otherwise
+/// <c>403 Forbidden</c>) and carry a local host name in its <c>Host</c> header
+/// (otherwise <c>400 Bad Request</c>). The health endpoint is exempt from both
+/// checks so liveness/readiness probes, which target the pod's routable
+/// address, continue to work.
 /// </summary>
 public static class LocalCallerRestriction
 {
@@ -20,27 +23,57 @@ public static class LocalCallerRestriction
     public const string HealthEndpointPath = "/healthz";
 
     private static readonly PathString s_healthEndpoint = new(HealthEndpointPath);
+    private static readonly PathString s_healthEndpointWithSlash = new(HealthEndpointPath + "/");
+
+    // Local host names accepted in the Host header. HostString.MatchesAny
+    // preserves the framework's port, casing, and IPv6 matching behavior.
+    private static readonly StringSegment[] s_allowedHosts =
+        new StringSegment[] { "localhost", "127.0.0.1", "[::1]" };
 
     /// <summary>
-    /// Adds middleware that rejects, with <c>403 Forbidden</c>, any request
-    /// whose connection does not originate from the loopback interface, except
-    /// requests to the health endpoint.
+    /// Adds middleware that, for every request except the health endpoint,
+    /// rejects callers that do not connect over the loopback interface with
+    /// <c>403 Forbidden</c>, and requests whose <c>Host</c> header is not a
+    /// local host name with <c>400 Bad Request</c>.
     /// </summary>
     /// <param name="app">The application to configure.</param>
     public static void UseLocalCallerRestriction(this WebApplication app)
     {
         app.Use(static (context, next) =>
         {
-            if (IsLocal(context.Connection.RemoteIpAddress) ||
-                context.Request.Path.Equals(s_healthEndpoint, StringComparison.OrdinalIgnoreCase))
+            if (IsHealthEndpoint(context.Request.Path))
             {
                 return next(context);
             }
 
-            context.Response.StatusCode = StatusCodes.Status403Forbidden;
-            return Task.CompletedTask;
+            if (!IsLocal(context.Connection.RemoteIpAddress))
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return Task.CompletedTask;
+            }
+
+            if (!HasLocalHost(context.Request.Host))
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return Task.CompletedTask;
+            }
+
+            return next(context);
         });
     }
+
+    // Exempts the health endpoint, including the trailing-slash form that
+    // routing also accepts, but not arbitrary subpaths beneath it.
+    private static bool IsHealthEndpoint(PathString path) =>
+        path.Equals(s_healthEndpoint, StringComparison.OrdinalIgnoreCase) ||
+        path.Equals(s_healthEndpointWithSlash, StringComparison.OrdinalIgnoreCase);
+
+    // An absent Host header is allowed (parity with the framework's
+    // HostFilteringOptions.AllowEmptyHosts default); the loopback check above
+    // already gates access.
+    private static bool HasLocalHost(HostString host) =>
+        string.IsNullOrEmpty(host.Value) ||
+        HostString.MatchesAny(host.Value, s_allowedHosts);
 
     /// <summary>
     /// Determines whether a connection originates from the local host.

--- a/src/Microsoft.Identity.Web.Sidecar/Program.cs
+++ b/src/Microsoft.Identity.Web.Sidecar/Program.cs
@@ -71,40 +71,12 @@ public class Program
             options.AddOperationTransformer(new OptionsOverrideOperationTransformer());
         });
 
-        if (!builder.Environment.IsDevelopment())
-        {
-            // Outside development, accept requests only for local host names.
-            builder.Services.AddHostFiltering(options =>
-            {
-                options.AllowedHosts = ["localhost", "127.0.0.1", "[::1]"];
-            });
-
-            // Remove the framework's global Host filtering so it can be applied in the
-            // pipeline below instead, scoped to exempt the health endpoint. The filter is
-            // matched by its framework-internal type name; if that changes, the health test fails.
-            ServiceDescriptor? hostFilteringStartupFilter = builder.Services.FirstOrDefault(
-                static descriptor =>
-                    descriptor.ServiceType == typeof(IStartupFilter) &&
-                    descriptor.ImplementationType?.Name == "HostFilteringStartupFilter");
-
-            if (hostFilteringStartupFilter is not null)
-            {
-                builder.Services.Remove(hostFilteringStartupFilter);
-            }
-        }
-
         var app = builder.Build();
 
         if (!app.Environment.IsDevelopment())
         {
-            // Validate the Host header outside development, but keep the health
-            // endpoint reachable for probes that target the pod's routable address.
-            app.UseWhen(
-                static context => !context.Request.Path.Equals(
-                    LocalCallerRestriction.HealthEndpointPath, StringComparison.OrdinalIgnoreCase),
-                static appBuilder => appBuilder.UseHostFiltering());
-
-            // Loopback-only outside development; health endpoint excepted for probes.
+            // Outside development, restrict to loopback callers that use a local
+            // Host header; the health endpoint is excepted for probes.
             app.UseLocalCallerRestriction();
         }
 

--- a/src/Microsoft.Identity.Web.Sidecar/Program.cs
+++ b/src/Microsoft.Identity.Web.Sidecar/Program.cs
@@ -71,10 +71,39 @@ public class Program
             options.AddOperationTransformer(new OptionsOverrideOperationTransformer());
         });
 
+        if (!builder.Environment.IsDevelopment())
+        {
+            // Outside development, accept requests only for local host names.
+            builder.Services.AddHostFiltering(options =>
+            {
+                options.AllowedHosts = ["localhost", "127.0.0.1", "[::1]"];
+            });
+
+            // Remove the framework's global Host filtering so it can be applied in the
+            // pipeline below instead, scoped to exempt the health endpoint. The filter is
+            // matched by its framework-internal type name; if that changes, the health test fails.
+            ServiceDescriptor? hostFilteringStartupFilter = builder.Services.FirstOrDefault(
+                static descriptor =>
+                    descriptor.ServiceType == typeof(IStartupFilter) &&
+                    descriptor.ImplementationType?.Name == "HostFilteringStartupFilter");
+
+            if (hostFilteringStartupFilter is not null)
+            {
+                builder.Services.Remove(hostFilteringStartupFilter);
+            }
+        }
+
         var app = builder.Build();
 
         if (!app.Environment.IsDevelopment())
         {
+            // Validate the Host header outside development, but keep the health
+            // endpoint reachable for probes that target the pod's routable address.
+            app.UseWhen(
+                static context => !context.Request.Path.Equals(
+                    LocalCallerRestriction.HealthEndpointPath, StringComparison.OrdinalIgnoreCase),
+                static appBuilder => appBuilder.UseHostFiltering());
+
             // Loopback-only outside development; health endpoint excepted for probes.
             app.UseLocalCallerRestriction();
         }

--- a/src/Microsoft.Identity.Web.Sidecar/README.md
+++ b/src/Microsoft.Identity.Web.Sidecar/README.md
@@ -42,7 +42,7 @@ Settings are supplied via `appsettings.json`, environment variables, or any stan
 
 `AllowWebApiToBeAuthorizedByACL` will be set to true by the application. No action is required from the user to configure this.
 
-`AllowedHosts` is not used by the sidecar. It will always be `localhost` outside of development environments.
+`AllowedHosts` does not need to be set. Outside of development environments, the sidecar validates the request `Host` header against local host names (`localhost`, `127.0.0.1`, `[::1]`).
 
 *Important sections*
 
@@ -202,6 +202,9 @@ Agent identity parameters are also subject to the per-route override flag:
 
 - This API is only for usage as a sidecar. This API should not be publicly callable as it
   allows the caller to acquire tokens on behalf of the applications identity.
+- Outside of development environments, the sidecar restricts requests to loopback callers and
+  validates the request `Host` header against local host names. The `/healthz` endpoint is exempt
+  from both checks so orchestrator liveness/readiness probes continue to work.
 - Inbound PoP binds to the `original-method`/`original-uri` headers supplied by the co-located
   calling application; the sidecar does not independently observe the downstream request. The
   `ts`-based freshness check (default five minutes) is not a replay cache, and server nonce is not

--- a/tests/E2E Tests/Sidecar.Tests/HostFilteringTests.cs
+++ b/tests/E2E Tests/Sidecar.Tests/HostFilteringTests.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Identity.Web.Sidecar;
 using Xunit;
 
 namespace Sidecar.Tests;
@@ -59,14 +60,17 @@ public class HostFilteringTests(SidecarApiFactory factory) : IClassFixture<Sidec
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
-    [Fact]
-    public async Task Production_UnexpectedHost_HealthEndpoint_Succeeds()
+    [Theory]
+    [InlineData(LocalCallerRestriction.HealthEndpointPath)]
+    [InlineData(LocalCallerRestriction.HealthEndpointPath + "/")]
+    public async Task Production_UnexpectedHost_HealthEndpoint_Succeeds(string path)
     {
         var client = CreateClient(Environments.Production);
 
-        // The health endpoint is exempt so orchestrator probes, which may target
-        // the routable address, continue to work.
-        var response = await client.SendAsync(Get(HealthEndpoint, UnexpectedHost));
+        // The health endpoint, including the trailing-slash form routing accepts,
+        // is exempt so orchestrator probes, which may target the routable address,
+        // continue to work.
+        var response = await client.SendAsync(Get(path, UnexpectedHost));
 
         var body = await response.Content.ReadAsStringAsync();
         Assert.True(
@@ -86,7 +90,4 @@ public class HostFilteringTests(SidecarApiFactory factory) : IClassFixture<Sidec
 
         Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
     }
-
-    static string HealthEndpoint =>
-        Microsoft.Identity.Web.Sidecar.LocalCallerRestriction.HealthEndpointPath;
 }

--- a/tests/E2E Tests/Sidecar.Tests/HostFilteringTests.cs
+++ b/tests/E2E Tests/Sidecar.Tests/HostFilteringTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Sidecar.Tests;
+
+public class HostFilteringTests(SidecarApiFactory factory) : IClassFixture<SidecarApiFactory>
+{
+    readonly SidecarApiFactory _factory = factory;
+
+    // A Host header value that is not one of the sidecar's local host names.
+    const string UnexpectedHost = "unexpected.example.com";
+
+    // A path with no matching endpoint. A request that clears Host validation
+    // falls through to a 404, which distinguishes it from a 400 rejection.
+    const string UnmappedPath = "/host-validation-probe";
+
+    HttpClient CreateClient(string environment)
+    {
+        var configured = _factory.WithWebHostBuilder(builder =>
+            builder.UseSetting(WebHostDefaults.EnvironmentKey, environment));
+
+        return configured.CreateClient();
+    }
+
+    static HttpRequestMessage Get(string path, string host)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.TryAddWithoutValidation("Host", host);
+        return request;
+    }
+
+    [Fact]
+    public async Task Production_UnexpectedHost_IsRejected()
+    {
+        var client = CreateClient(Environments.Production);
+
+        var response = await client.SendAsync(Get(UnmappedPath, UnexpectedHost));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    [InlineData("[::1]")]
+    public async Task Production_LocalHost_ClearsHostValidation(string host)
+    {
+        var client = CreateClient(Environments.Production);
+
+        var response = await client.SendAsync(Get(UnmappedPath, host));
+
+        // A local host name clears Host validation and falls through to routing,
+        // which has no endpoint for this path.
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Production_UnexpectedHost_HealthEndpoint_Succeeds()
+    {
+        var client = CreateClient(Environments.Production);
+
+        // The health endpoint is exempt so orchestrator probes, which may target
+        // the routable address, continue to work.
+        var response = await client.SendAsync(Get(HealthEndpoint, UnexpectedHost));
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.True(
+            response.IsSuccessStatusCode,
+            $"Expected the health endpoint to be exempt from Host validation; got {(int)response.StatusCode}.");
+        Assert.Contains("Healthy", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Development_UnexpectedHost_IsNotRejected()
+    {
+        // Host validation is not applied in development, so the inner-loop
+        // experience is unchanged.
+        var client = CreateClient(Environments.Development);
+
+        var response = await client.SendAsync(Get(UnmappedPath, UnexpectedHost));
+
+        Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    static string HealthEndpoint =>
+        Microsoft.Identity.Web.Sidecar.LocalCallerRestriction.HealthEndpointPath;
+}


### PR DESCRIPTION
# Sidecar: validate Host header outside Development
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Adds ASP.NET Core Host filtering for `Microsoft.Identity.Web.Sidecar` outside the
Development environment

## What

- Registers `AddHostFiltering` only when the environment is not Development.
- Applies Host filtering in the request pipeline (scoped with `UseWhen`) rather than globally, so the `/healthz` endpoint stays exempt.
- In Development, neither check is applied, so the inner-loop experience is unchanged.