### PR TITLE
Added a fix for failing id web pipeline

### DIFF
--- a/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
+++ b/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
     <DefineConstants>$(DefineConstants);DOTNET_472</DefineConstants>
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
     <DefineConstants>$(DefineConstants);DOTNET_462</DefineConstants>


### PR DESCRIPTION
# Added a fix for failing id web pipeline

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Id Web repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [*] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [*] You've included unit or integration tests for your change, where applicable.
- [*] You've included inline docs for your change, where applicable.
- [*] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

**What**

Treat  MSB3277  as a message when building the  net472  target of  Microsoft.Identity.Web.Test .

**Why**

The official build started failing because the warning count increased from 0 to 1. The new warning is  MSB3277 , reported while building  Microsoft.Identity.Web.Test  for  net472 .

**Root cause**

PR #4006 added  Microsoft.Identity.Web.OWIN  as a project reference for the  net472  test target. This brought two incompatible assembly versions into the test build:

•  Microsoft.IdentityModel.Protocols.WsFederation 5.7.1  exposes assembly version  0.0.1.0 .
•  Microsoft.Owin.Security.ActiveDirectory 4.2.2  expects assembly version  5.3.0.0 .

MSBuild reports this known conflict as  MSB3277 . The OWIN project already treats this warning as a message, but that setting does not propagate to the consuming test project. This change applies the same narrowly scoped handling to the  net472  test target, returning the official build warning count to zero without suppressing other warnings.

