### PR TITLE
Use MicrosoftIdentityClientVersion instead of explicit version number

### DIFF
--- a/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/src/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -59,7 +59,7 @@
   </Choose>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.88.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
     <Compile Remove="*.cs" />
     <Compile Remove="AppServicesAuth\**" />
     <Compile Remove="AzureSdkSupport\**" />
@@ -72,7 +72,7 @@
     <Compile Remove="TokenCacheProviders\Session\**" />
 
     <AdditionalFiles Remove="PublicAPI/**/*.*" />
-    
+
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="$(MicrosoftAspNetCoreDataProtectionVersion)" />


### PR DESCRIPTION
This Dependabot PR bumped the variables `‎Directory.Build.props` that ID Web uses to define the MSAL .NET version: https://github.com/AzureAD/microsoft-identity-web/pull/4003

However it also explicitly pinned version 4.88.0 as a new `PackageReference` entry in `Microsoft.Identity.Web.csproj‎` for some frameworks. 

This led to package downgrade errors in some of our pipelines that use locally built packages with junk version numbers, and introduced a risk of version drift in different frameworks.

This PR simply uses the existing `MicrosoftIdentityClientVersion` for that `PackageReference` instead of the hardcoded 4.88.0