### PR TITLE
Fix warning caused by dependency and add validation gate to PR pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
       - template: build/template-install-dependencies.yaml
       - template: build/template-build.yaml
       - template: build/template-test-unit.yaml
-      - task: BuildQualityChecks@9
+      - task: BuildQualityChecks@10
         displayName: 'Check Warnings'
         inputs:
           checkWarnings: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,12 @@ stages:
       - template: build/template-install-dependencies.yaml
       - template: build/template-build.yaml
       - template: build/template-test-unit.yaml
+      - task: BuildQualityChecks@9
+        displayName: 'Check Warnings'
+        inputs:
+          checkWarnings: true
+          warningFailOption: 'build'
+          showStatistics: true
 
 # Integration tests only depend on .NET 8, so build just that project and run them
 # in parallel with the full Build stage (dependsOn: [] -> no dependency on Build).

--- a/build/template-publish-and-cleanup.yaml
+++ b/build/template-publish-and-cleanup.yaml
@@ -46,11 +46,11 @@ steps:
   displayName: 'TSA upload to Codebase: Microsoft Identity Web .NET Stamp: Azure'
   condition: and(succeeded(), eq(variables['PipelineType'], 'Legacy'))
   inputs:
-    GdnPublishTsaOnboard: false 
+    GdnPublishTsaOnboard: false
     GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/tsaConfig.json'
   continueOnError: true
 
-- task: BuildQualityChecks@9
+- task: BuildQualityChecks@10
   displayName: 'Check Warnings'
   inputs:
     checkWarnings: true

--- a/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj
+++ b/src/Microsoft.Identity.Web.OWIN/Microsoft.Identity.Web.OWIN.csproj
@@ -20,10 +20,6 @@
     <IdentityModelV5Version Condition="'$(IdentityModelV5Version)' == ''">5.7.1</IdentityModelV5Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IdentityModelV5Version)' == '5.7.1'">
-    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\..\README.md">
       <Pack>True</Pack>
@@ -44,7 +40,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="$(IdentityModelV5Version)" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="$(IdentityModelV5Version)" />
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Owin.Security.ActiveDirectory" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Owin.Security.Jwt" Version="4.2.2" />
     <PackageReference Include="Microsoft.Owin.Security.OpenIdConnect" Version="4.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>


### PR DESCRIPTION
This change fixes an unresolved assembly-version warning in the .NET Framework OWIN test build and adds warning-count enforcement to the PR pipeline.

The [scheduled build](https://identitydivision.visualstudio.com/IDDP/_build?definitionId=2513&_a=summary) started failing after the OWIN claims-validation tests were added to `Microsoft.Identity.Web.Test` for `net472` in PR https://github.com/AzureAD/microsoft-identity-web/pull/4006. The project reference to `Microsoft.Identity.Web.OWIN` exposed a pre-existing conflict between two versions of `Microsoft.IdentityModel.Protocols.WsFederation`:

- Version `0.0.1.0`, supplied by the direct `Microsoft.IdentityModel.Protocols.WsFederation` 5.7.1 dependency.
- Version `5.3.0.0`, referenced by `Microsoft.Owin.Security.ActiveDirectory` 4.2.2.

MSBuild reported this as `MSB3277`. The solution still compiled and the PR pipeline passed without issue, but the scheduled pipeline's `BuildQualityChecks` task detected that the warning count had increased from zero to one and failed the build.

## Why the PR pipeline did not catch it

The PR pipeline already builds `Microsoft.Identity.Web.Test` for `net472` and runs its .NET Framework tests. It therefore exercised the same dependency graph and emitted the same `MSB3277` warning.

However, the PR pipeline did not have the warning-quality gate used by the scheduled pipeline. `TreatWarningsAsErrors` in `Directory.Build.props` covers compiler and analyzer warnings, but this warning comes from MSBuild's assembly resolver and did not fail the build. The tests passed, so the PR pipeline completed successfully despite the warning in its build log.

## Changes

### Use the direct OWIN JWT dependency

`Microsoft.Identity.Web.OWIN` uses `Microsoft.Owin.Security.Jwt.JwtFormat` but does not use any APIs from `Microsoft.Owin.Security.ActiveDirectory`. Previously, the JWT assembly was obtained transitively through the broader ActiveDirectory package.

This change:

- Replaces `Microsoft.Owin.Security.ActiveDirectory` 4.2.2 with a direct reference to `Microsoft.Owin.Security.Jwt` 4.2.2.
- Removes the ActiveDirectory assembly that referenced the conflicting WsFederation 5.3.0 assembly.
- Removes the now-unnecessary conditional suppression of `MSB3277`.

The OWIN implementation continues using the same JWT package and version as before; the package graph now reflects the dependency that the source code actually uses.

### Add warning enforcement to the PR pipeline

The PR pipeline now runs `BuildQualityChecks@9` after its build and unit-test steps, using the same warning-count policy as the scheduled pipeline:

```yaml
- task: BuildQualityChecks@9
  displayName: 'Check Warnings'
  inputs:
    checkWarnings: true
    warningFailOption: 'build'
    showStatistics: true
```

This should prevent future increases in build warnings from reaching the scheduled pipeline only after a PR has merged.

## Compatibility and risk

No Microsoft Identity Web OWIN public APIs or implementation behavior are intentionally changed. The product code already used `Microsoft.Owin.Security.Jwt`, and it continues using version 4.2.2.

The observable package-level change is that `Microsoft.Owin.Security.ActiveDirectory` is no longer installed transitively with `Microsoft.Identity.Web.OWIN`. This may affect consumers that use ActiveDirectory middleware APIs, such as `UseWindowsAzureActiveDirectoryBearerAuthentication`, without declaring their own dependency.

Such consumers would need to add an explicit package reference:

```xml
<PackageReference Include="Microsoft.Owin.Security.ActiveDirectory" Version="4.2.2" />
```

Consumers that already reference `Microsoft.Owin.Security.ActiveDirectory` directly are unaffected. Overall risk is expected to be low because ActiveDirectory types are not used or exposed by Microsoft Identity Web OWIN, but the removed transitive dependency is a package-graph change and should be noted in the release notes.