### PR TITLE
[3.x] Run PR validation on hosted agents

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,13 +6,80 @@ pr:
   branches:
     include:
       - master
+      - rel/3v
 
-jobs:
-- job: "PR_build"
-  pool:
-    name: MwWilson1EsHostedPool
-    demands:
-    - msbuild
-  steps:
-    - template: build/template-install-dependencies.yaml
-    - template: build/template-run-unit-tests.yaml
+stages:
+
+- stage: Build
+  displayName: 'Build & Unit Tests'
+  jobs:
+  - job: PR_build
+    variables:
+      UseLabAuthCertFromStore: true
+    pool:
+      vmImage: 'windows-2022'
+      demands:
+      - msbuild
+      - visualstudio
+    steps:
+      - template: build/template-install-dependencies.yaml
+      - template: build/template-build.yaml
+      - template: build/template-test-unit.yaml
+
+- stage: IntegrationTests
+  displayName: 'Integration Tests (.NET 8)'
+  dependsOn: []
+  jobs:
+  - job: IntegrationTests
+    variables:
+      UseLabAuthCertFromStore: true
+    pool:
+      vmImage: 'windows-2022'
+      demands:
+      - msbuild
+      - visualstudio
+    steps:
+      - template: build/template-install-dependencies.yaml
+      - template: build/template-build-test-project.yaml
+        parameters:
+          Project: 'tests/Microsoft.Identity.Web.Test.Integration/Microsoft.Identity.Web.Test.Integration.csproj'
+          TargetFramework: 'net8.0'
+      - template: build/template-test-integration.yaml
+
+- stage: E2ETests
+  displayName: 'E2E Tests (.NET 8)'
+  dependsOn: []
+  jobs:
+  - job: E2ETests
+    variables:
+      UseLabAuthCertFromStore: true
+    pool:
+      vmImage: 'windows-2022'
+      demands:
+      - msbuild
+      - visualstudio
+    steps:
+      - template: build/template-install-dependencies.yaml
+      - template: build/template-build-test-project.yaml
+        parameters:
+          Project: 'tests/E2E Tests/WebAppUiTests/WebAppUiTests.csproj'
+          TargetFramework: 'net8.0'
+      - template: build/template-build-test-project.yaml
+        parameters:
+          Project: 'tests/E2E Tests/TokenAcquirerTests/TokenAcquirerTests.csproj'
+          TargetFramework: 'net8.0'
+      - template: build/template-test-e2e.yaml
+        parameters:
+          e2eTestFilterCriteria: 'Category!=MI_E2E'
+
+- stage: ManagedIdentityE2E
+  displayName: 'Managed Identity E2E (MISEManagedIdentity)'
+  dependsOn: []
+  jobs:
+  - job: ManagedIdentityE2E
+    pool:
+      name: 'MISEManagedIdentity'
+    steps:
+      - template: build/template-run-managed-identity-e2e-tests.yaml
+        parameters:
+          TargetFramework: 'net8.0'

--- a/build/template-build-test-project.yaml
+++ b/build/template-build-test-project.yaml
@@ -1,0 +1,29 @@
+# template-build-test-project.yaml
+# Restore and build a single test project (and its project references) for one
+# target framework.
+
+parameters:
+- name: Project
+  type: string
+- name: BuildConfiguration
+  type: string
+  default: 'Release'
+- name: TargetFramework
+  type: string
+  default: 'net8.0'
+
+steps:
+
+- task: DotNetCoreCLI@2
+  displayName: 'Restore ${{ parameters.Project }}'
+  inputs:
+    command: 'restore'
+    projects: '${{ parameters.Project }}'
+    restoreArguments: '--property:NuGetAudit=false'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build ${{ parameters.Project }} (${{ parameters.TargetFramework }})'
+  inputs:
+    command: 'build'
+    projects: '${{ parameters.Project }}'
+    arguments: '--configuration ${{ parameters.BuildConfiguration }} --framework ${{ parameters.TargetFramework }} --no-restore'

--- a/build/template-build.yaml
+++ b/build/template-build.yaml
@@ -1,0 +1,18 @@
+# template-build.yaml
+# Restore and build the solution so test assemblies exist on a clean hosted agent.
+
+steps:
+
+- task: DotNetCoreCLI@2
+  displayName: 'Install wasm-tools workload'
+  inputs:
+    command: 'custom'
+    custom: 'workload'
+    arguments: 'install wasm-tools'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build solution (Release)'
+  inputs:
+    command: 'custom'
+    custom: 'msbuild'
+    arguments: 'Microsoft.Identity.Web.sln -r -t:build -verbosity:m -property:Configuration=Release -property:NuGetAudit=false'

--- a/build/template-run-managed-identity-e2e-tests.yaml
+++ b/build/template-run-managed-identity-e2e-tests.yaml
@@ -1,0 +1,45 @@
+# template-run-managed-identity-e2e-tests.yaml
+# Build and run managed-identity E2E tests on the MI-capable pool.
+
+parameters:
+- name: BuildConfiguration
+  type: string
+  default: 'Release'
+- name: TargetFramework
+  type: string
+  default: 'net8.0'
+
+steps:
+
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 8.0.x'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK from global.json'
+  inputs:
+    useGlobalJson: true
+
+- template: template-build-test-project.yaml
+  parameters:
+    Project: 'tests/E2E Tests/TokenAcquirerTests/TokenAcquirerTests.csproj'
+    BuildConfiguration: '${{ parameters.BuildConfiguration }}'
+    TargetFramework: '${{ parameters.TargetFramework }}'
+
+- task: VSTest@2
+  displayName: 'Run managed identity E2E tests'
+  env:
+    IDWEB_MI_UAMI_CLIENTID: '6325cd32-9911-41f3-819c-416cdf9104e7'
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: 'tests\E2E Tests\TokenAcquirerTests\bin\${{ parameters.BuildConfiguration }}\${{ parameters.TargetFramework }}\TokenAcquirerTests.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    testFiltercriteria: 'Category=MI_E2E'
+    runTestsInIsolation: true
+    rerunFailedTests: true
+    rerunMaxAttempts: '3'
+    runInParallel: false
+    failOnMinTestsNotRun: true
+    minimumExpectedTests: '1'

--- a/build/template-test-e2e.yaml
+++ b/build/template-test-e2e.yaml
@@ -1,0 +1,50 @@
+# template-test-e2e.yaml
+# Run the browser/host E2E tests (Playwright + multi-target).
+
+parameters:
+- name: e2eTestFilterCriteria
+  type: string
+  default: ''
+
+steps:
+
+- task: VSTest@2
+  displayName: 'Run E2E tests'
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: |
+        tests\E2E Tests\WebAppUiTests\bin\**\WebAppUiTests.dll
+        tests\E2E Tests\TokenAcquirerTests\bin\**\TokenAcquirerTests.dll
+        tests\E2E Tests\NET 7 tests\IntegrationTests\bin\**\IntegrationTests.dll
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    testFiltercriteria: '${{ parameters.e2eTestFilterCriteria }}'
+    rerunFailedTests: true
+    rerunMaxAttempts: '3'
+    runInParallel: false
+    codeCoverageEnabled: true
+    failOnMinTestsNotRun: false
+    minimumExpectedTests: '1'
+    runSettingsFile: 'build\CodeCoverage.runsettings'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish traces after test'
+  inputs:
+    PathtoPublish: '$(Build.SourcesDirectory)/tests/E2E Tests/PlaywrightTraces/'
+    ArtifactName: 'traces-after-tests-$(Build.BuildNumber)'
+  condition: failed()
+
+- task: CopyFiles@2
+  displayName: 'Copy screenshots to staging directory'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/tests/E2E Tests/'
+    Contents: '**/*screenshotFail.png'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\screenshots'
+    flattenFolders: true
+  condition: failed()
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Screenshot after test'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\screenshots'
+    ArtifactName: 'ScreenshotFail'
+  condition: failed()

--- a/build/template-test-integration.yaml
+++ b/build/template-test-integration.yaml
@@ -1,0 +1,18 @@
+# template-test-integration.yaml
+# Run the Microsoft.Identity.Web integration tests.
+
+steps:
+
+- task: VSTest@2
+  displayName: 'Run integration tests'
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: 'tests\Microsoft.Identity.Web.Test.Integration\bin\**\Microsoft.Identity.Web.Test.Integration.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    rerunFailedTests: true
+    rerunMaxAttempts: '3'
+    runInParallel: false
+    codeCoverageEnabled: true
+    failOnMinTestsNotRun: false
+    minimumExpectedTests: '1'
+    runSettingsFile: 'build\CodeCoverage.runsettings'

--- a/build/template-test-unit.yaml
+++ b/build/template-test-unit.yaml
@@ -1,0 +1,24 @@
+# template-test-unit.yaml
+# Run the Microsoft.Identity.Web unit tests.
+
+steps:
+
+- task: VSTest@2
+  displayName: 'Run unit tests'
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: 'tests\Microsoft.Identity.Web.Test\bin\**\Microsoft.Identity.Web.Test.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    runInParallel: true
+    codeCoverageEnabled: true
+    failOnMinTestsNotRun: true
+    minimumExpectedTests: '1'
+    runSettingsFile: 'build\CodeCoverage.runsettings'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run unit tests (.NET Framework 4.7.2)'
+  inputs:
+    command: 'test'
+    projects: 'tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj'
+    arguments: '--no-restore --no-build --configuration Release --framework net472'
+    testRunTitle: 'Unit tests (net472)'

--- a/tests/E2E Tests/IntegrationTestService/Program.cs
+++ b/tests/E2E Tests/IntegrationTestService/Program.cs
@@ -1,13 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace IntegrationTestService
 {
     public class Program
     {
+        internal const string UseCertFromStoreEnvVar = "UseLabAuthCertFromStore";
+
         public static void Main(string[] args)
         {
             CreateHostBuilder(args).Build().Run();
@@ -15,9 +20,36 @@ namespace IntegrationTestService
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((context, config) =>
+                {
+                    if (ShouldUseCertFromStore())
+                    {
+                        config.AddInMemoryCollection(LabAuthCertFromStoreOverrides());
+                    }
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+
+        private static bool ShouldUseCertFromStore()
+        {
+            string? value = Environment.GetEnvironmentVariable(UseCertFromStoreEnvVar);
+            return !string.IsNullOrEmpty(value) &&
+                   (value.Equals("true", StringComparison.OrdinalIgnoreCase) || value == "1");
+        }
+
+        private static IEnumerable<KeyValuePair<string, string?>> LabAuthCertFromStoreOverrides()
+        {
+            foreach (string section in new[] { "AzureAd", "AzureAd2" })
+            {
+                string prefix = $"{section}:ClientCertificates:0:";
+                yield return new(prefix + "SourceType", "StoreWithDistinguishedName");
+                yield return new(prefix + "CertificateStorePath", "LocalMachine/My");
+                yield return new(prefix + "CertificateDistinguishedName", "CN=LabAuth.MSIDLab.com");
+                yield return new(prefix + "KeyVaultUrl", null);
+                yield return new(prefix + "KeyVaultCertificateName", null);
+            }
+        }
     }
 }

--- a/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
+++ b/tests/E2E Tests/TokenAcquirerTests/TokenAcquirer.cs
@@ -481,6 +481,7 @@ namespace TokenAcquirerTests
     }
 
     [Collection(nameof(TokenAcquirerFactorySingletonProtection))]
+    [Trait("Category", "MI_E2E")]
     public class AcquireTokenManagedIdentity
     {
         [OnlyOnAzureDevopsFact]
@@ -490,7 +491,8 @@ namespace TokenAcquirerTests
             // Arrange
             const string scope = "https://vault.azure.net/.default";
             const string baseUrl = "https://vault.azure.net";
-            const string clientId = "5bcd1685-b002-4fd1-8ebd-1ec3e1e4ca4d";
+            string clientId = Environment.GetEnvironmentVariable("IDWEB_MI_UAMI_CLIENTID")
+                ?? "45344e7d-c562-4be6-868f-18dac789c021";
             TokenAcquirerFactoryTesting.ResetTokenAcquirerFactoryInTest();
             TokenAcquirerFactory tokenAcquirerFactory = TokenAcquirerFactory.GetDefaultInstance();
             IServiceProvider serviceProvider = tokenAcquirerFactory.Build();


### PR DESCRIPTION
## Summary
- align the `rel/3v` PR pipeline with the stage layout used on `master`
- run build, unit, integration, and non-managed-identity E2E tests on Microsoft-hosted `windows-2022` agents
- keep managed-identity E2E coverage on the dedicated `MISEManagedIdentity` pool
- use the imported LabAuth certificate from the hosted agent certificate store
- restore the complete project graph before framework-specific E2E builds

## Validation
- `WebAppUiTests` builds for `net8.0` after a clean full-graph restore
- `TokenAcquirerTests` builds for `net8.0` and discovers the `MI_E2E` test category
- build, unit, integration, hosted E2E, and managed-identity E2E stages pass